### PR TITLE
explicitly search for and install all data files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,21 @@ from setuptools import setup
 import glob
 import os.path as path
 from os import listdir
+import sys,os
 
 __version__ = '0.0.0'
+
+def package_files(package_dir,subdirectory):
+    #walk the input package_dir/subdirectory
+    #return a package_data list
+    paths = []
+    directory = os.path.join(package_dir,subdirectory)
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            path = path.replace(package_dir+'/','')
+            paths.append(os.path.join(path, filename))
+    return paths
+data_files = package_files('hera_cal','data') + package_files('hera_cal','calibrations')
 
 setup_args = {
     'name': 'hera_cal',
@@ -15,7 +28,7 @@ setup_args = {
     'packages': ['hera_cal'],
     #    'scripts': glob.glob('scripts/*'),
     'version': __version__,
-    'package_data': {'hera_cal': ['data/*', 'data/*/*', 'calibrations/*']},
+    'package_data': {'hera_cal': data_files},
     #    'install_requires': ['numpy>=1.10', 'scipy', 'pyuvdata', 'astropy>1.2', 'aipy']
     #    'dependency_links': ['https://github.com/zakiali/omnical/tarball/master#egg=omnical-dev',]
     'zip_safe': False,


### PR DESCRIPTION
fixes data install issue:

copying hera_cal/data/heratest_calfile.py -> build/lib/hera_cal/data
error: can't copy 'hera_cal/data/test_input': doesn't exist or not a regular file