### PR TITLE
simple fix to enable minV mode.

### DIFF
--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1230,9 +1230,19 @@ def omni_run(files, opts, history):
 
         print('   Saving %s' % fitsname)
         hc = HERACal(m2, g3, ex_ants=ex_ants,  optional=optional)
+        
+        if opts.minV:
+            #XXX need to talk about whether or not these need conjugating!
+            if 'xy' in v3.keys() and not 'yx' in v3.keys():
+                v3['yx'] = v3['xy']
+            elif 'yx' in v3.keys() and not 'xy' in v3.keys():
+                v3['xy'] = v3['yx']
+            
         hc.write_calfits(fitsname)
         fsj = '.'.join(fitsname.split('.')[:-2])
+        
         uv_vis = make_uvdata_vis(aa, m2, v3)
+        
         uv_vis.reorder_pols()
         uv_vis.write_uvfits('%s.vis.uvfits' %
                             fsj, force_phase=True, spoof_nonessential=True)

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1232,7 +1232,6 @@ def omni_run(files, opts, history):
         hc = HERACal(m2, g3, ex_ants=ex_ants,  optional=optional)
         
         if opts.minV:
-            #XXX need to talk about whether or not these need conjugating!
             if 'xy' in v3.keys() and not 'yx' in v3.keys():
                 v3['yx'] = v3['xy']
             elif 'yx' in v3.keys() and not 'xy' in v3.keys():

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -820,6 +820,33 @@ class Test_omni_run(object):
         xtalkfile = re.sub('omni\.calfits', 'xtalk.uvfits', objective_file)
         os.remove(visfile)
         os.remove(xtalkfile)
+    
+    def test_execution_omni_run_4polminV(self):
+        objective_file = os.path.join(
+            DATA_PATH, 'zen.2457698.40355.HH.uvcA.omni.calfits')
+        if os.path.exists(objective_file):
+            os.remove(objective_file)
+        o = omni.get_optionParser('omni_run')
+        visxx = os.path.join(DATA_PATH, visXX)
+        visxy = os.path.join(DATA_PATH, visXY)
+        visyx = os.path.join(DATA_PATH, visYX)
+        visyy = os.path.join(DATA_PATH, visYY)
+        fcalxx = os.path.join(DATA_PATH, 'test_input', fcalXX)
+        fcalyy = os.path.join(DATA_PATH, 'test_input', fcalYY)
+
+        cmd = "-C %s -p xx,xy,yx,yy --minV --firstcal=%s,%s --ex_ants=81 --omnipath=%s %s %s %s %s" % (
+            calfile, fcalxx, fcalyy, DATA_PATH, visxx, visxy, visyx, visyy)
+
+        opts, files = o.parse_args(cmd.split())
+        history = 'history'
+        omni.omni_run(files, opts, history)
+        nt.assert_true(os.path.exists(objective_file))
+        # clean up
+        os.remove(objective_file)
+        visfile = re.sub('omni\.calfits', 'vis.uvfits', objective_file)
+        xtalkfile = re.sub('omni\.calfits', 'xtalk.uvfits', objective_file)
+        os.remove(visfile)
+        os.remove(xtalkfile)
 
 class Test_omni_apply(object):
 


### PR DESCRIPTION
The problem was that, because in the V-minimization mode we treat xy=yx, there are only xy _or_ yx visibility models, not both. This creates an uneven spacing of polarizations (xx=-5, yy=-6 but then we're either missing -7 or -8 for the xy or yx respectively). 

I replicated the crosspol part of the visibility model array (`v3`) to account for the other polarization. It's a little inelegant. Right now I am not conjugating the other crosspol visibility model, but this would be a simple addition if we want it.

In any case, we should talk about whether we want to implement this in general, as noted in Issue #32 . But now we can! 