### PR TITLE
Remove deprecated function

### DIFF
--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -770,63 +770,6 @@ def make_uvdata_vis(aa, m, v, xtalk=False):
 
     return uv
 
-# XXX Eventually this may belong in pyuvdata
-
-
-def concatenate_UVCal_on_pol(calfitsList):
-    '''
-    Joins UVCal files of different polarizations along 
-    the polarization axis of the delay_array, flag_array,
-    gain_array, and quality_array.
-    Args:
-        calfitsList: list of calfits filenames
-            type: list of strings
-    Returns:
-        a single cal file, with relevant arrays
-        concatenated along the polarization axis
-            type: pyuvdata.UVCal()
-    '''
-    # XXX these could be more flexible if we wanted to have it as optional
-    constProperties = ['antenna_names', 'antenna_numbers', 'cal_type', 'channel_width',  'freq_range', 'gain_convention',
-                       'integration_time', 'Nants_data', 'Nants_telescope', 'Nfreqs', 'Njones', 'Nspws', 'Ntimes',  'time_range', 'x_orientation']
-    constPropertiesArrays = ['ant_array', 'freq_array', 'time_array']
-
-    # check that constProperties match between files
-    calname0 = calfitsList[0]
-    cal0 = UVCal()
-    cal0.read_calfits(calname0)
-
-    if cal0.Njones != 1:
-        raise ValueError(
-            'Njones!=1; cannot concantenate > 1 polarization at a time')
-    for calname1 in calfitsList[1:]:
-        cal1 = UVCal()
-        cal1.read_calfits(calname1)
-        for prp in constProperties:
-            if not getattr(cal0, prp) == getattr(cal1, prp):
-                raise ValueError('%s of %s does not match %s' %
-                                 (prp, calname0, calname1))
-        for prp in constPropertiesArrays:
-            if not (getattr(cal0, prp) == getattr(cal1, prp)).all():
-                raise ValueError('%s of %s does not match %s' %
-                                 (prp, calname0, calname1))
-        if not cal1.Njones == 1:
-            raise ValueError(
-                'Njones!=1; cannot concantenate > 1 polarization at a time')
-        if cal1.jones_array[0] in cal0.jones_array:
-            raise ValueError(
-                'Cannot concatenate calfits files of identical polarization')
-
-        cal0.Njones += 1
-        cal0.jones_array = np.concatenate((cal0.jones_array, cal1.jones_array))
-        if cal0.delay_array is not None:
-            cal0.delay_array = np.concatenate((cal0.delay_array, cal1.delay_array), axis=4)
-        if cal0.gain_array is not None:
-            cal0.gain_array = np.concatenate((cal0.gain_array, cal1.gain_array), axis=4)
-        cal0.flag_array = np.concatenate((cal0.flag_array, cal1.flag_array), axis=4)
-        cal0.quality_array = np.concatenate((cal0.quality_array, cal1.quality_array), axis=4)
-    return cal0
-
 class HERACal(UVCal):
     '''
        Class that loads in hera omnical data into a pyuvdata calfits object.
@@ -1361,7 +1304,15 @@ def omni_apply(files, opts):
             if isLinPol(getPol(f)):
                 cal.read_calfits(filedict[f][0])
             else:
-                cal = concatenate_UVCal_on_pol(filedict[f])
+                # read each file in and add to base file
+                for i,fn in enumerate(filedict[f]):
+                    if i == 0:
+                        cal = UVCal()
+                        cal.read_calfits(fn)
+                    else:
+                        cal0 = UVCal()
+                        cal0.read_calfits(fn)
+                        cal += cal0
 
         print("  Calibrating...")
         antenna_index = dict(zip(*(cal.ant_array, range(cal.Nants_data))))

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -432,41 +432,6 @@ class TestMethods(object):
         nt.assert_equal(uv_vis_in, uv_vis_out)
         nt.assert_equal(uv_xtalk_in, uv_xtalk_in)
 
-    def test_concatenate_UVCal_on_pol(self):
-        calname0 = os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457705.41052.xx.HH.uvc.first.calfits')
-        calname1 = os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457705.41052.yy.HH.uvc.first.calfits')
-        calnameList = [calname0, calname1]
-        cal0 = UVCal()
-        cal0.read_calfits(calname0)
-        cal1 = UVCal()
-        cal1.read_calfits(calname1)
-
-        # Concatenate and test concatenation
-        newcal = omni.concatenate_UVCal_on_pol(calnameList)
-        testpath0 = os.path.join(
-            DATA_PATH, 'test_output', 'zen.2457705.41052.yy.HH.uvc.first.test0.calfits')
-        if os.path.exists(testpath0):
-            os.remove(testpath0)
-        newcal.write_calfits(testpath0)
-
-        nt.assert_equal(newcal.Njones, 2)
-        nt.assert_equal(sorted(newcal.jones_array), [-6, -5])
-        nt.assert_equal(newcal.flag_array.shape[-1], 2)
-        nt.assert_equal(newcal.delay_array.shape[-1], 2)
-        nt.assert_equal(newcal.quality_array.shape[-1], 2)
-
-        cal1.gain_convention = 'multiply'
-        testpath1 = os.path.join(
-            DATA_PATH, 'test_output', 'zen.2457705.41052.yy.HH.uvc.first.test1.calfits')
-        if os.path.exists(testpath1):
-            os.remove(testpath1)
-        cal1.write_calfits(testpath1)
-        nt.assert_raises(ValueError, omni.concatenate_UVCal_on_pol, [calname0, calname0])
-        nt.assert_raises(ValueError, omni.concatenate_UVCal_on_pol, [calname0, testpath0])
-        nt.assert_raises(ValueError, omni.concatenate_UVCal_on_pol, [calname0, testpath1])
-
     def test_getPol(self):
         filename = 'zen.2457698.40355.xx.HH.uvcA'
         nt.assert_equal(omni.getPol(filename), 'xx')


### PR DESCRIPTION
The `concatenate_UVCal_on_pol` functionality is now built in to `UVCal` objects in `pyuvdata`, and so the function is unnecessary. The function and tests for it have been removed, and references to it in the code have been replaced.