### PR TITLE
Fixed a bug in get_pos_reds

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -60,13 +60,13 @@ def get_pos_reds(antpos, precisionFactor=1e6):
     array_is_2D = np.all(np.all(np.array(antpos.values())[:,2]==0))
     for i,ant1 in enumerate(keys):
         for ant2 in keys[i+1:]:
-            delta = tuple((precisionFactor * (np.array(antpos[ant1]) - np.array(antpos[ant2]))).astype(int))
+            delta = tuple((precisionFactor*2.0 * (np.array(antpos[ant1]) - np.array(antpos[ant2]))).astype(int))
+            # Multiply by 2.0 because rounding errors can mimic changes below the grid spacing
             if delta[0] > 0 or (delta[0]==0 and delta[1] > 0) or (delta[0]==0 and delta[1]==0 and delta[2] > 0):
                 bl_pair = (ant1,ant2)
             else:
                 delta = tuple([-d for d in delta])
                 bl_pair = (ant2,ant1)
-            
             # Check to make sure reds doesn't have the key plus or minus rounding error
             p_or_m = (0,-1,1)
             if array_is_2D:

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -57,17 +57,30 @@ def get_pos_reds(antpos, precisionFactor=1e6):
 
     keys = antpos.keys()
     reds = {}
+    array_is_2D = np.all(np.all(np.array(antpos.values())[:,2]==0))
     for i,ant1 in enumerate(keys):
         for ant2 in keys[i+1:]:
             delta = tuple((precisionFactor * (np.array(antpos[ant1]) - np.array(antpos[ant2]))).astype(int))
-            if delta[1] > 0 or (delta[1]==0 and delta[0] > 0):
-                if reds.has_key(delta): reds[delta] += [(ant1,ant2)]
-                else: reds[delta] = [(ant1,ant2)]
+            if delta[0] > 0 or (delta[0]==0 and delta[1] > 0) or (delta[0]==0 and delta[1]==0 and delta[2] > 0):
+                bl_pair = (ant1,ant2)
             else:
                 delta = tuple([-d for d in delta])
-                if reds.has_key(delta): reds[delta] += [(ant2,ant1)]
-                else: reds[delta] = [(ant2,ant1)]
-    orderedDeltas = [delta for (delta,length) in sorted(zip(reds.keys(), [np.linalg.norm(delta) for delta in reds.keys()]))]
+                bl_pair = (ant2,ant1)
+            
+            # Check to make sure reds doesn't have the key plus or minus rounding error
+            p_or_m = (0,-1,1)
+            if array_is_2D:
+                epsilons = [[dx,dy,0] for dx in p_or_m for dy in p_or_m]
+            else:
+                epsilons = [[dx,dy,dz] for dx in p_or_m for dy in p_or_m for dz in p_or_m]
+            for epsilon in epsilons:
+                newKey = (delta[0]+epsilon[0], delta[1]+epsilon[1], delta[2]+epsilon[2])
+                if reds.has_key(newKey):
+                    reds[newKey].append(bl_pair)
+                    break
+            if not reds.has_key(newKey):
+                reds[delta] = [bl_pair]
+    orderedDeltas = [delta for (length,delta) in sorted(zip([np.linalg.norm(delta) for delta in reds.keys()],reds.keys()))]   
     return [reds[delta] for delta in orderedDeltas]
 
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -114,6 +114,26 @@ class TestMethods(unittest.TestCase):
         reds = [[(0,1,'xx')],[(0,1,'xy'), (0,1,'yy')],[(0,1,'yx')]]
         self.assertEqual(om.parse_pol_mode(reds), 'unrecognized_pol_mode')
 
+    def test_get_pos_red(self):
+        pos = build_hex_array(11,sep=1)
+        self.assertEqual(len(om.get_pos_reds(pos)),630)
+        pos = build_hex_array(11,sep=14.7)
+        self.assertEqual(len(om.get_pos_reds(pos)),630)
+        pos = build_hex_array(3,sep=14.7)
+        self.assertEqual(len(om.get_pos_reds(pos)),30)
+
+
+    def test_add_pol_reds(self):
+        reds = [[(1,2)]]
+        polReds = om.add_pol_reds(reds, pols=['xx'], pol_mode='1pol')
+        self.assertEqual(polReds, [[(1,2,'xx')]])
+        polReds = om.add_pol_reds(reds, pols=['xx','yy'], pol_mode='2pol')
+        self.assertEqual(polReds, [[(1,2,'xx')],[(1,2,'yy')]])
+        polReds = om.add_pol_reds(reds, pols=['xx','xy','yx','yy'], pol_mode='4pol')
+        self.assertEqual(polReds, [[(1,2,'xx')],[(1,2,'xy')],[(1,2,'yx')],[(1,2,'yy')]])
+        polReds = om.add_pol_reds(reds, pols=['xx','xy','yx','yy'], pol_mode='4pol_minV')
+        self.assertEqual(polReds, [[(1,2,'xx')],[(1,2,'xy'),(1,2,'yx')],[(1,2,'yy')]])
+
 
 class TestRedundantCalibrator(unittest.TestCase):
     


### PR DESCRIPTION
A bug in get_pos_reds caused baselines to appear non-redundant due to
rounding errors. Now I check for all possible rounding errors. I added
a unittest to expose this error. This does not affect hera_cal.omni.