### PR TITLE
Refactor tests to eliminate warnings

### DIFF
--- a/hera_cal/tests/test_firstcal.py
+++ b/hera_cal/tests/test_firstcal.py
@@ -6,6 +6,7 @@ import aipy
 import optparse
 import sys
 from pyuvdata import UVCal, UVData
+import pyuvdata.tests as uvtest
 import hera_cal.firstcal as firstcal
 from hera_cal.omni import compute_reds
 from hera_cal.data import DATA_PATH
@@ -174,7 +175,8 @@ class Test_FirstCal(object):
         str2pol = {'xx': -5, 'yy': -6, 'xy': -7, 'yy': -8}
         filename = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA')
         uvd = UVData()
-        uvd.read_miriad(filename)
+        uvtest.checkWarnings(uvd.read_miriad, [filename], nwarnings=1,
+                             message='antenna_diameters is not set')
         if uvd.phase_type != 'drift':
             uvd.unphase_to_drift()
 
@@ -189,7 +191,9 @@ class Test_FirstCal(object):
                 np.testing.assert_equal(f[i, j][pol], np.resize(
                     uvd.flag_array[uvmask][:, 0, :, uvpol], f[i, j][pol].shape))
 
-        d, f = firstcal.UVData_to_dict([filename, filename])
+        d, f = uvtest.checkWarnings(firstcal.UVData_to_dict, [[filename, filename]], nwarnings=2,
+                                    message='antenna_diameters is not set',
+                                    category=[UserWarning, UserWarning])
         for i, j in d:
             for pol in d[i, j]:
                 uvpol = list(uvd.polarization_array).index(str2pol[pol])
@@ -294,7 +298,8 @@ class Test_firstcal_run(object):
         cmd = "-C {0} -p xx --ex_ants=81 {1}".format(calfile, xx_vis4real)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
-        firstcal.firstcal_run(files, opts, history)
+        uvtest.checkWarnings(firstcal.firstcal_run, [files, opts, history], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
         return

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 import aipy
 from omnical.calib import RedundantInfo
 from pyuvdata import UVCal, UVData
+import pyuvdata.tests as uvtest
 import hera_cal.omni as omni
 from hera_cal.data import DATA_PATH
 from hera_cal.calibrations import CAL_PATH
@@ -178,8 +179,11 @@ class TestMethods(object):
         Ntimes = 3 * 2  # need 2 here because reading two files
         Nchans = 1024  # hardcoded for this file
         # read in the same file twice to make sure file concatenation works
-        meta, gains, vis, xtalk = omni.from_fits(
-            [os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')] * 2)
+        meta, gains, vis, xtalk = uvtest.checkWarnings(omni.from_fits, [
+            [os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')] * 2],
+                                                       nwarnings=4,
+                                                       message='antenna_diameters is not set',
+                                                       category=([UserWarning]*4))
         for m in meta.keys():
             if m.startswith('chisq'):
                 nt.assert_equal(meta[m].shape, (Ntimes, Nchans))
@@ -224,8 +228,9 @@ class TestMethods(object):
 
         str2pol = {'xx': -5, 'yy': -6}
         uvd = UVData()
-        uvd.read_uvfits(os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.vis.uvfits'))
+        uvtest.checkWarnings(uvd.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.vis.uvfits')],
+                             nwarnings=1, message='antenna_diamteres is not set')
         # frim_fits turns data into drift
         uvd.unphase_to_drift()
         for pol in vis:
@@ -239,8 +244,9 @@ class TestMethods(object):
                     uvd.data_array[uvmask][:, 0, :, uvpol], vis[pol][i, j].shape))
 
         uvd = UVData()
-        uvd.read_uvfits(os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.xtalk.uvfits'))
+        uvtest.checkWarnings(uvd.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.xtalk.uvfits')],
+                             nwarnings=1, message='antenna_diameters is not set')
         # from_fits turns data into drift
         uvd.unphase_to_drift()
         for pol in xtalk:
@@ -317,8 +323,11 @@ class TestMethods(object):
         Ntimes = 3
         Nchans = 1024  # hardcoded for this file
         # read in the same file twice to make sure file concatenation works
-        meta, gains, vis, xtalk = omni.from_fits([os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')], antenna_nums=[9, 10, 112, 20, 22])
+        meta, gains, vis, xtalk = uvtest.checkWarnings(omni.from_fits, [[os.path.join(
+            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')]],
+                                                       {"antenna_nums": [9, 10, 112, 20, 22]},
+                                                       nwarnings=2, message='antenna_diameters is not set',
+                                                       category=([UserWarning]*2))
 
         pol2str = {-5: 'x', -6: 'y'}
         uvcal = UVCal()
@@ -382,8 +391,10 @@ class TestMethods(object):
         sys.path[:-1]  # remove last entry from path (DATA_PATH)
 
         # read in meta, gains, vis, xtalk from file.
-        meta, gains, vis, xtalk = omni.from_fits(
-            [os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')])
+        meta, gains, vis, xtalk = uvtest.checkWarnings(omni.from_fits, [
+            [os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')]],
+                                                       nwarnings=2, message='antenna_diameters is not set',
+                                                       category=([UserWarning]*2))
         _xtalk = {}
         # overide xtalk to have single visibility. from fits expands to size of
         # vis data.
@@ -400,31 +411,36 @@ class TestMethods(object):
 
         # read in old and newly written files and check equality.
         uv_vis_in = UVData()
-        uv_vis_in.read_uvfits(os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.vis.uvfits'))
+        uvtest.checkWarnings(uv_vis_in.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.vis.uvfits')],
+                             nwarnings=1, message='antenna_diameters is not set')
         uv_vis_in.unphase_to_drift()
         # overwrite history because uvdata writes git stuff whenever data is
         # written to a file.
         uv_vis_in.history = 'test_history'
 
         uv_xtalk_in = UVData()
-        uv_xtalk_in.read_uvfits(os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.xtalk.uvfits'))
+        uvtest.checkWarnings(uv_xtalk_in.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.xtalk.uvfits')],
+                             nwarnings=1, message='antenna_diameters is not set')
         uv_xtalk_in.unphase_to_drift()
         # overwrite history because uvdata writes git stuff whenever data is
         # written to a file.
         uv_xtalk_in.history = 'test_history'
 
         uv_vis_out = UVData()
-        uv_vis_out.read_uvfits(os.path.join(DATA_PATH, 'test_output', 'write_vis_test.fits'))
+        uvtest.checkWarnings(uv_vis_out.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_output', 'write_vis_test.fits')], nwarnings=1,
+                             message='antenna_diameters is not set')
         uv_vis_out.unphase_to_drift()
         # overwrite history because uvdata writes git stuff whenever data is
         # written to a file.
         uv_vis_out.history = 'test_history'
 
         uv_xtalk_out = UVData()
-        uv_xtalk_out.read_uvfits(os.path.join(
-            DATA_PATH, 'test_output', 'write_xtalk_test.fits'))
+        uvtest.checkWarnings(uv_xtalk_out.read_uvfits, [
+            os.path.join(DATA_PATH, 'test_output', 'write_xtalk_test.fits')], nwarnings=1,
+                             message='antenna_diameters is not set')
         uv_xtalk_out.unphase_to_drift()
         # overwrite history because uvdata writes git stuff whenever data is
         # written to a file.
@@ -651,8 +667,10 @@ class Test_Redcal_Basics(object):
 class Test_HERACal(UVCal):
 
     def test_gainHC(self):
-        meta, gains, vis, xtalk = omni.from_fits(os.path.join(
-            DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits'))
+        meta, gains, vis, xtalk = uvtest.checkWarnings(omni.from_fits, [
+            os.path.join(DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.omni.calfits')],
+                                                       nwarnings=2, message='antenna_diameters is not set',
+                                                       category=([UserWarning]*2))
         meta['inttime'] = np.diff(meta['times'])[0] * 60 * 60 * 24
         optional = {'observer': 'heracal'} #because it's easier than changing the fits header
         hc = omni.HERACal(meta, gains, optional=optional)
@@ -832,7 +850,9 @@ class Test_omni_run(object):
             calfile, xx_fcal4real, omnipath, xx_vis4real)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
-        omni.omni_run(files, opts, history)
+        uvtest.checkWarnings(omni.omni_run, [files, opts, history], nwarnings=2,
+                             message='antenna_diameters is not set',
+                             category=([UserWarning]*2))
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
 
@@ -850,7 +870,8 @@ class Test_omni_run(object):
             calfile, xx_fcal4real, omnipath, xx_vis4real)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
-        omni.omni_run(files, opts, history)
+        uvtest.checkWarnings(omni.omni_run, [files, opts, history], nwarnings=2,
+                             message='antenna_diameters is not set', category=([UserWarning]*2))
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
 
@@ -872,7 +893,8 @@ class Test_omni_run(object):
 
         opts, files = o.parse_args(cmd.split())
         history = 'history'
-        omni.omni_run(files, opts, history)
+        uvtest.checkWarnings(omni.omni_run, [files, opts, history], nwarnings=5,
+                             message='antenna_diameters is not set', category=([UserWarning]*5))
         nt.assert_true(os.path.exists(objective_file))
         # clean up
         os.remove(objective_file)
@@ -899,7 +921,8 @@ class Test_omni_run(object):
 
         opts, files = o.parse_args(cmd.split())
         history = 'history'
-        omni.omni_run(files, opts, history)
+        uvtest.checkWarnings(omni.omni_run, [files, opts, history], nwarnings=5,
+                             message='antenna_diameters is not set', category=([UserWarning]*5))
         nt.assert_true(os.path.exists(objective_file))
         # clean up
         os.remove(objective_file)
@@ -934,7 +957,8 @@ class Test_omni_apply(object):
         cmd = "-p xx --omnipath={0} --extension=O {1}".format(omni_file, vis_file)
 
         opts, files = o.parse_args(cmd.split())
-        omni.omni_apply(files, opts)
+        uvtest.checkWarnings(omni.omni_apply, [files, opts], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(objective_file))
         # clean up when we're done
         shutil.rmtree(objective_file)
@@ -949,7 +973,8 @@ class Test_omni_apply(object):
         cmd = "-p xx --omnipath={0} --median --firstcal {1}".format(fcal_file, vis_file)
 
         opts, files = o.parse_args(cmd.split())
-        omni.omni_apply(files, opts)
+        uvtest.checkWarnings(omni.omni_apply, [files, opts], nwarnings=1,
+                             message='antenna_diameters is not set')
         nt.assert_true(os.path.exists(objective_file))
         # clean up when we're done
         shutil.rmtree(objective_file)
@@ -969,7 +994,8 @@ class Test_omni_apply(object):
         o = omni.get_optionParser('omni_apply')
         cmd = "-p xx,xy,yx,yy --omnipath={0} --extension=O {1} {2} {3} {4}".format(fp_ocal,visxx,visyy,visyx,visxy)
         opts, files = o.parse_args(cmd.split())
-        omni.omni_apply(files, opts)
+        uvtest.checkWarnings(omni.omni_apply, [files, opts], nwarnings=4, message='antenna_diameters is not set',
+                             category=([UserWarning]*4))
     
         for f in objective_files:
             nt.assert_true(os.path.exists(f))


### PR DESCRIPTION
This PR changes many of the tests to prevent warnings from occurring during `nosetests`. This is done by wrapping many of the file reading calls (which trigger warnings about the antenna diameter not being set) with `pyuvdata.tests.checkWarnings` function.