### PR TITLE
Update omni_run to use hera_cm function

### DIFF
--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -10,6 +10,7 @@ import glob
 import re
 import optparse
 from hera_cal import redcal
+from hera_cal import utils
 from hera_qm import ant_metrics
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -1104,8 +1105,15 @@ def omni_run(files, opts, history):
             linear_pol_keys.append(pp)
 
     # Create info
-    # generate reds from calfile
-    aa = aipy.cal.get_aa(opts.cal, np.array([.15]))
+    # get frequencies from miriad file
+    uv = aipy.miriad.UV(files[0])
+    fqs = aipy.cal.get_freqs(uv['sdf'], uv['sfreq'], uv['nchan'])
+    (uvw, array_epoch_jd, ij), d = uv.read()
+    del (uv, uvw, d)
+
+    # get HERA info
+    aa = utils.get_HERA_aa(fqs, calfile=opts.cal, array_epoch_jd=array_epoch_jd)
+
     print('Getting reds from calfile')
     if opts.ex_ants or opts.metrics_json:
         ex_ants = process_ex_ants(opts.ex_ants, opts.metrics_json)

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -833,6 +833,9 @@ def make_uvdata_vis(aa, m, v, xtalk=False):
 
     uv.antenna_positions = np.array(antpos)
 
+    # do a consistency check
+    uv.check()
+
     return uv
 
 class HERACal(UVCal):
@@ -1112,7 +1115,7 @@ def omni_run(files, opts, history):
     del (uv, uvw, d)
 
     # get HERA info
-    aa = utils.get_HERA_aa(fqs, calfile=opts.cal, array_epoch_jd=array_epoch_jd)
+    aa = utils.get_HERA_aa(fqs[0], calfile=opts.cal, array_epoch_jd=array_epoch_jd)
 
     print('Getting reds from calfile')
     if opts.ex_ants or opts.metrics_json:

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -831,7 +831,8 @@ class Test_omni_run(object):
 
     def test_without_firstcal_file_omni_run(self):
         o = omni.get_optionParser('omni_run')
-        cmd = "-C %s -p xx %s" % (calfile, xx_vis)
+        xx_vis_path = os.path.join(DATA_PATH, xx_vis)
+        cmd = "-C %s -p xx %s" % (calfile, xx_vis_path)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
         nt.assert_raises(ValueError, omni.omni_run, files, opts, history)


### PR DESCRIPTION
This PR addresses Issue #66. It uses the hera_cm module to generate redundancy information based off of antenna locations in the HERA CM database.