### PR TITLE
DO NOT MERGE: Add call to M&C database for array configuration

### DIFF
--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -834,6 +834,8 @@ class Test_omni_run(object):
             calfile, xx_fcal4real, omnipath, xx_vis4real)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
+        if os.path.exists(objective_file):
+            os.remove(objective_file)
         omni.omni_run(files, opts, history)
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
@@ -852,6 +854,8 @@ class Test_omni_run(object):
             calfile, xx_fcal4real, omnipath, xx_vis4real)
         opts, files = o.parse_args(cmd.split())
         history = 'history'
+        if os.path.exists(objective_file):
+            os.remove(objective_file)
         omni.omni_run(files, opts, history)
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
@@ -874,6 +878,8 @@ class Test_omni_run(object):
 
         opts, files = o.parse_args(cmd.split())
         history = 'history'
+        if os.path.exists(objective_file):
+            os.remove(objective_file)
         omni.omni_run(files, opts, history)
         nt.assert_true(os.path.exists(objective_file))
         # clean up

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1,4 +1,4 @@
-def get_HERA_aa(freqs,calfile='hera_cm',**kwargs):
+def get_HERA_aa(freqs, calfile='hera_cm', **kwargs):
     # create an aipy AntennaArray object using positions and hookup info in M&C.
     #
     # Inputs:
@@ -27,4 +27,4 @@ def get_HERA_aa(freqs,calfile='hera_cm',**kwargs):
         return get_aa(freqs)
     else:
         #use the time and position file aware get_aa
-        return get_aa(freqs,**kwargs)
+        return get_aa(freqs, **kwargs)


### PR DESCRIPTION
This PR adds functionality for making a live call to the CM database in the M&C system to get array information. If it is unavailable for any reason (`hera_mc` not installed, M&C system is down, etc.), it falls back on using the provided CSV file.

However, there are some loose ends that need tying off. This code is untested, since we need to install `hera_mc`, and spin up a sample CM database to test the rest of the function. I think we should set this up, but wanted to get other people's thoughts on doing this.

Also, this only queries the database "as-is" at the time the function is run, and does not support getting a past configuration state. I was envisioning running "post-processing" in that fashion by using the CSV file, so that we don't need to be plugged in to the live M&C database.