### PR TITLE
add "--outpath" option to omni_apply.py

### DIFF
--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1452,7 +1452,7 @@ def omni_apply(files, opts):
             outpath = '/'.join(f.split('/')[:-1])
         else:
             outpath = opts.outpath
-        out_filename = "%s/%s" % (outpath, inp_filename)
+        out_filename = "{0}/{1}".format(outpath, inp_filename)
 
         # Write to file
         if opts.firstcal:

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1081,6 +1081,8 @@ def get_optionParser(methodName):
                      help='Applying firstcal solutions.')
         o.add_option('--extension', dest='extension', default='O', type='string',
                      help='Filename extension to be appended to the input filename')
+        o.add_option('--outpath', dest='outpath', default=None, type='string',
+                     help='Directory to write-out omnical-ibrated visibility data. Will use input file path by default.')
 
     return o
 
@@ -1444,11 +1446,20 @@ def omni_apply(files, opts):
                         np.logical_or(cal.flag_array[antenna_index[ai], nsp, :, :, p1].T,
                                       cal.flag_array[antenna_index[aj], nsp, :, :, p2].T))
 
-        if opts.firstcal:
-            print(" Writing {0}".format(f + 'F'))
-            mir.write_miriad(f + 'F')
+        # Define output path and filename
+        inp_filename = f.split('/')[-1]
+        if opts.outpath is None:
+            outpath = '/'.join(f.split('/')[:-1])
         else:
-            print(" Writing {0}".format(f + opts.extension))
-            mir.write_miriad(f + opts.extension)
+            outpath = opts.outpath
+        out_filename = "%s/%s" % (outpath, inp_filename)
+
+        # Write to file
+        if opts.firstcal:
+            print(" Writing {0}".format(out_filename + 'F'))
+            mir.write_miriad(out_filename + 'F')
+        else:
+            print(" Writing {0}".format(out_filename + opts.extension))
+            mir.write_miriad(out_filename + opts.extension)
 
     return

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -941,6 +941,21 @@ class Test_omni_apply(object):
         # clean up when we're done
         shutil.rmtree(objective_file)
 
+    def test_single_file_execution_omni_apply_custompath(self):
+        objective_file = os.path.join('./', 'zen.2457698.40355.xx.HH.uvcAAO')
+        if os.path.exists(objective_file):
+            shutil.rmtree(objective_file)
+        o = omni.get_optionParser('omni_apply')
+        omni_file = os.path.join(DATA_PATH, 'test_input', xx_ocal)
+        vis_file = os.path.join(DATA_PATH,  xx_vis)
+        cmd = "-p xx --omnipath={0} --extension=O --outpath={1} {2}".format(omni_file, ".", vis_file)
+
+        opts, files = o.parse_args(cmd.split())
+        omni.omni_apply(files, opts)
+        nt.assert_true(os.path.exists(objective_file))
+        # clean up when we're done
+        shutil.rmtree(objective_file)
+
     def test_single_file_firstcal_omni_apply(self):
         objective_file = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAAF')
         if os.path.exists(objective_file):


### PR DESCRIPTION
This PR adds the "--outpath" option to the omni_apply.py executable so that the user can write out omnical-ibrated visibility data to a directory **other than** the directory where the uncalibrated data is loaded. Follows the same convention as found in the firstcal_run.py executable.