### PR TITLE
Omni apply fix

### DIFF
--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1454,9 +1454,11 @@ def omni_apply(files, opts):
                                       cal.flag_array[antenna_index[aj], nsp, :, :, p2].T))
 
         # Define output path and filename
-        inp_filename = f.split('/')[-1]
+        inp_filename = os.path.basename(f)
         if opts.outpath is None:
-            outpath = '/'.join(f.split('/')[:-1])
+            abspath = os.path.abspath(f)
+            dirname = os.path.dirname(abspath)
+            outpath = dirname
         else:
             outpath = opts.outpath
         out_filename = "{0}/{1}".format(outpath, inp_filename)

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1461,7 +1461,7 @@ def omni_apply(files, opts):
             outpath = dirname
         else:
             outpath = opts.outpath
-        out_filename = "{0}/{1}".format(outpath, inp_filename)
+        out_filename = os.path.join(outpath, inp_filename)
 
         # Write to file
         if opts.firstcal:

--- a/hera_cal/tests/test_firstcal.py
+++ b/hera_cal/tests/test_firstcal.py
@@ -311,5 +311,5 @@ class Test_firstcal_run(object):
         history = 'history'
         firstcal.firstcal_run(files, opts, history)
         nt.assert_true(os.path.exists(objective_file))
-        #os.remove(objective_file)
+        os.remove(objective_file)
         return


### PR DESCRIPTION
This PR updates the logic in `omni_apply` for placing output files in the same directory as the input files if none is specified. It uses `os.path`, and so is more flexible and robust to things such as trailing `/`s in directory names. There is also a fix to clean up a test file produced by `test_firstcal.py`.