### PR TITLE
update firstcal.py and test_firstcal.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas sklearn
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas sklearn
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas scikit-learn
   - source activate test-environment
   - conda install -c conda-forge aipy
   - pip install coveralls

--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -493,7 +493,6 @@ def firstcal_run(files, opts, history):
 
             Iteratively run firstcal and look for rotated antennas.
             If rotated antennas found, fix the antenna and rerun firstcal.
-            Saves rotated antennas to a json file.
 
         Args:
             uv (pyuvdata.UVData): UVData object
@@ -606,14 +605,12 @@ def firstcal_run(files, opts, history):
             print("Setting phase type to drift")
             uv_in.unphase_to_drift()
         
-        sols, write_to_json = _search_and_iterate_firstcal(uv_in, info, opts)
-        write_to_json = [str(ai) for (ai, pol) in write_to_json]
-        dict_for_json = {'rotated_antennas': write_to_json,
-                         'delays': {str(ai.ant()): sols[ai].tolist() for ai in sols.keys()}}
+        sols, rotated_antennas = _search_and_iterate_firstcal(uv_in, info, opts)
+        rotated_antennas = [str(ai) for (ai, pol) in rotated_antennas]
         # convert delays to a gain solution
         gain_solutions = {ai: omni.get_phase(uv_in.freq_array[0, :], sols[ai]) for ai in sols.keys()}
         # fix 180 phase offset in gain solutions
-        for antpol in write_to_json:
+        for antpol in rotated_antennas:
             gain_solutions[int(antpol)] *= -1
              
 
@@ -648,10 +645,6 @@ def firstcal_run(files, opts, history):
                                  appendhist=history, optional=optional)
         print('     Saving {0}'.format(outname))
         hc.write_calfits(outname, clobber=opts.overwrite)
-        json_name = '{0}.{1}'.format(outname, 'rotated_metric.json')
-        print ('     Writing {0}'.format(json_name))
-        with open(json_name, 'w') as f:
-            json.dump(dict_for_json, f, indent=4)
 
     return
 

--- a/hera_cal/tests/test_firstcal.py
+++ b/hera_cal/tests/test_firstcal.py
@@ -333,8 +333,6 @@ class Test_firstcal_run(object):
     def test_rotated_antennas(self):
         objective_file = os.path.join(
             DATA_PATH, 'zen.2457555.42443.xx.HH.uvcA.first.calfits')
-        objective_file_2 = os.path.join(
-            DATA_PATH, 'zen.2457555.42443.xx.HH.uvcA.first.calfits.rotated_metric.json')
         xx_vis = os.path.join(
             DATA_PATH, 'zen.2457555.42443.xx.HH.uvcA')
         o = firstcal.firstcal_option_parser()
@@ -344,9 +342,4 @@ class Test_firstcal_run(object):
         firstcal.firstcal_run(files, opts, history)
         nt.assert_true(os.path.exists(objective_file))
         os.remove(objective_file)
-        with open(objective_file_2, 'r') as rotation_file:
-            rot_dict = json.load(rotation_file)
-        nt.assert_equal(rot_dict['rotated_antennas'], ['43']) 
-        nt.assert_equal(len(rot_dict['delays'].keys()), 17)
-        os.remove(objective_file_2)
         return


### PR DESCRIPTION
Since we don't need to write out the json anymore for rotated antennas and delay solutions, this PR gets rid of the writing of that file. The rotated antennas and gains are now being calculated in hera_qm firstcal_metrics. 