### PR TITLE
Save reds and update tolerance

### DIFF
--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -582,7 +582,7 @@ def firstcal_run(files, opts, history):
     if len(ubls) != None:
         print('Using Unique Baselines:', ubls)
     info = omni.aa_to_info(aa, pols=[opts.pol[0]],
-                           fcal=True, ubls=ubls, ex_ants=ex_ants)
+                           fcal=True, ubls=ubls, ex_ants=ex_ants, tol=opts.reds_tolerance)
     bls = [bl for bls in info.get_reds() for bl in bls]
     print('Number of redundant baselines:', len(bls))
 
@@ -683,4 +683,6 @@ def firstcal_option_parser():
                  help='optionally add the git origin of the cal repo')
     o.add_option('--metrics_json', default='',
                  help='metrics from hera_qm about array qualities')
+    o.add_option('--reds_tolerance', type='float', default=1.0,
+                 help='Tolerance level for calculating reds. Default is 1.0ns')
     return o

--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -587,7 +587,7 @@ def firstcal_run(files, opts, history):
     print('Number of redundant baselines:', len(bls))
 
     # append reds to history
-    history += '\n{0}'.format(info.get_reds) 
+    history += '\nredundant_baselines = {0}\n'.format(info.get_reds)
 
     # Firstcal loop per file.
     for filename in files:

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -1026,7 +1026,7 @@ def omni_run(files, opts, history):
     bls = [bl for red in reds for bl in red]
 
     # append reds to history
-    history += '\n{0}'.format(reds)
+    history += '\nredundant_baslines = {0}'.format(reds)
     ### Collect all firstcal files ###
     firstcal_files = {}
     if not opts.firstcal:

--- a/hera_cal/omni.py
+++ b/hera_cal/omni.py
@@ -953,6 +953,8 @@ def get_optionParser(methodName):
                      help='metrics from hera_qm about array qualities')
         o.add_option('--overwrite', action='store_true', default=False,
                      help="Overwrite output files even if they already exist.")
+        o.add_option('--reds_tolerance', type='float', default=1.0,
+                     help="Tolerance level for calculating reds. Default is 1.0ns")
 
     elif methodName == 'omni_apply':
         o.add_option('--firstcal', action='store_true',
@@ -1021,7 +1023,7 @@ def omni_run(files, opts, history):
     else:
         ex_ants = []
     info = aa_to_info(aa, pols=list(set(''.join(pols))),
-                      ex_ants=ex_ants, crosspols=pols, minV=opts.minV)
+                      ex_ants=ex_ants, crosspols=pols, minV=opts.minV, tol=opts.reds_tolerance)
     reds = info.get_reds()
     bls = [bl for red in reds for bl in red]
 


### PR DESCRIPTION
This addresses issue 105 and 106. Those changes were previously made, but this pr cleans up the code around them and adds the reds_tolerance as a command line option (with defaults that are equivalent in functionality to the current code) and makes it more explicit what is being saved in the history of the calibration files.