### PR TITLE
Fix Amplitude Renormalization in Remove_Degen

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -460,10 +460,11 @@ class RedundantCalibrator:
 
         #Amplitude renormalization: fixes the mean abs product of gains (as they appear in visibilities)
         for antpol in antpols:
+            bls_for_average = [bl for bls in self.reds for bl in bls if (bl[2] == 2*antpol) and (bls[0] in bl_pairs)]
             meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])])
-                for (ant1,ant2,pol) in bl_pairs if pol == 2*antpol], axis=0)
+                for (ant1,ant2,pol) in bls_for_average], axis=0)
             degenMeanSqAmplitude = np.mean([np.abs(degen_sol[(ant1,pol[0])] * degen_sol[(ant2,pol[1])])
-                for (ant1,ant2,pol) in bl_pairs if pol == 2*antpol], axis=0)
+                for (ant1,ant2,pol) in bls_for_average], axis=0)
             gainSols[gainPols == antpol] *= (degenMeanSqAmplitude / meanSqAmplitude)**.5
             visSols[visPols[:,0] == antpol] *= (meanSqAmplitude / degenMeanSqAmplitude)**.5
             visSols[visPols[:,1] == antpol] *= (meanSqAmplitude / degenMeanSqAmplitude)**.5

--- a/hera_cal/tests/test_omni.py
+++ b/hera_cal/tests/test_omni.py
@@ -470,6 +470,11 @@ class TestMethods(object):
         nt.assert_equal(xants, [0, 1, 81])
         return
 
+    def test_info_reds_to_redcal_reds(self):
+        reds_in = [[(0,1),(1,2)], [(3,4),(4,5)]]
+        reds_out_correct  = [[(0,1,'xx'), (1,2,'xx')], [(0,1,'yy'), (1,2,'yy')]]
+        reds_out = omni.info_reds_to_redcal_reds(reds_in, 3, pol_to_factor={'x':0, 'y':1})
+        nt.assert_equal(reds_out_correct, reds_out)
 
 class Test_Antpol(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -298,8 +298,9 @@ class TestRedundantCalibrator(unittest.TestCase):
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
         ants = [key for key in sol_rd.keys() if len(key)==2]
         gainSols = np.array([sol_rd[ant] for ant in ants])
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+                for (ant1,ant2,pol) in bls_for_average], axis=0)
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols), axis=0), 0, 10)
 
@@ -315,9 +316,9 @@ class TestRedundantCalibrator(unittest.TestCase):
         sol_rd = rc.remove_degen(antpos, sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols), axis=0), 0, 10)
@@ -373,11 +374,13 @@ class TestRedundantCalibrator(unittest.TestCase):
         bl_vecs = np.array([antpos[bl_pair[0]] - antpos[bl_pair[1]] for bl_pair in bl_pairs])
         gainSols = np.array([sol_rd[ant] for ant in ants])
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols=='x']), axis=0), 0, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols=='y']), axis=0), 0, 10)
@@ -394,15 +397,17 @@ class TestRedundantCalibrator(unittest.TestCase):
 
         sol_rd = rc.remove_degen(antpos, sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-            for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)
+            for (ant1,ant2,pol) in bls_for_average], axis=0)
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
 
         gainSols = np.array([sol_rd[ant] for ant in ants])
@@ -460,11 +465,13 @@ class TestRedundantCalibrator(unittest.TestCase):
         visPolsStr = np.array([bl[2] for bl in bl_pairs])
         bl_vecs = np.array([antpos[bl_pair[0]] - antpos[bl_pair[1]] for bl_pair in bl_pairs])
         gainSols = np.array([sol_rd[ant] for ant in ants])
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols), axis=0), 0, 10)
 
@@ -496,16 +503,18 @@ class TestRedundantCalibrator(unittest.TestCase):
         np.testing.assert_almost_equal(np.mean(np.angle(gainSols), axis=0), 
             np.mean(np.angle(degenGains), axis=0), 10)
         
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
         
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
 
         visSols = np.array([sol_rd[bl] for bl in bl_pairs])
@@ -561,11 +570,14 @@ class TestRedundantCalibrator(unittest.TestCase):
         bl_vecs = np.array([antpos[bl_pair[0]] - antpos[bl_pair[1]] for bl_pair in bl_pairs])
         gainSols = np.array([sol_rd[ant] for ant in ants])
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
+        
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, 1, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols=='x']), axis=0), 0, 10)
         #np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols=='y']), axis=0), 0, 10)
@@ -585,16 +597,18 @@ class TestRedundantCalibrator(unittest.TestCase):
         gainSols = np.array([sol_rd[ant] for ant in ants])
         degenGains = np.array([gains[ant] for ant in ants])
 
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'xx') and (bls[0] in v.keys())]
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'xx'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
         
+        bls_for_average = [bl for bls in reds for bl in bls if (bl[2] == 'yy') and (bls[0] in v.keys())]
         degenMeanSqAmplitude = np.mean([np.abs(gains[(ant1,pol[0])] * gains[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) 
-                for (ant1,ant2,pol) in v.keys() if pol == 'yy'], axis=0)        
+                for (ant1,ant2,pol) in bls_for_average], axis=0)        
         np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, 10)
 
         np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols=='x']), axis=0), 


### PR DESCRIPTION
At one point, we renormalized the amplitudes of the gains (and correspondingly, the visibilities) after omnical by forcing the average abs(gains) to be 1.0 (or whatever was put into the degen_sol).

Later, we decided that we wanted to normalize gains so that the mean gain product over the baseline pairs in the visibilities was taken to be 1 (or whatever was put into the degen_sol). This was originally accomplished with statements like

`meanSqAmplitude = np.mean([np.abs(g[(ant1,pol[0])] * g[(ant2,pol[1])]) for (ant1,ant2,pol) in v.keys() if pol == 2*antpol], axis=0)`

However, this is incorrect. `v.keys()` only gives the unique baselines, but we want to loop over all baselines.

We've implemented this fix, by introducing
`bls_for_average = [bl for bls in self.reds for bl in bls if (bl[2] == 2*antpol) and (bls[0] in bl_pairs)]` and looping over that. However, this means that remove_degen now needs to know about the `reds`. Redcal uses a polarization-aware format for reds than omni.py, so we had to edit omni.py to produce redcal's style of reds from `info.get_reds()`. Tests have also been updated.

This addresses #114. This may be of interest to you, @miguelfmorales