### PR TITLE
Add optional `freqs` arg to `get_aa_from_uv`

### DIFF
--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -49,7 +49,7 @@ class AntennaArray(aipy.pol.AntennaArray):
         return changed
 
 
-def get_aa_from_uv(uvd, freqs=None):
+def get_aa_from_uv(uvd, freqs=[0.15]):
     '''
     Generate an AntennaArray object from a pyuvdata UVData object.
 
@@ -67,6 +67,8 @@ def get_aa_from_uv(uvd, freqs=None):
     Arguments
     ====================
     uvd: a pyuvdata UVData object containing the data.
+    freqs (optional): list of frequencies to pass to aa object. Defaults to single frequency
+        (150 MHz), suitable for computing redundancy and uvw info.
 
     Returns
     ====================
@@ -98,9 +100,7 @@ def get_aa_from_uv(uvd, freqs=None):
     # unpack from dict -> numpy array
     for k in antpos.keys():
         antpos_ideal[k, :] = np.array([antpos[k]['x'], antpos[k]['y'], antpos[k]['z']])
-    if freqs == None:
-        # Default to single frequency (150 MHz) for getting redundancy info
-        freqs = np.array([0.15])
+    freqs = np.asarray(freqs)
     # Make list of antennas.
     # These are values for a zenith-pointing antenna, with a dummy Gaussian beam.
     antennas = []

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -49,7 +49,7 @@ class AntennaArray(aipy.pol.AntennaArray):
         return changed
 
 
-def get_aa_from_uv(uvd):
+def get_aa_from_uv(uvd, freqs=None):
     '''
     Generate an AntennaArray object from a pyuvdata UVData object.
 
@@ -98,7 +98,9 @@ def get_aa_from_uv(uvd):
     # unpack from dict -> numpy array
     for k in antpos.keys():
         antpos_ideal[k, :] = np.array([antpos[k]['x'], antpos[k]['y'], antpos[k]['z']])
-    freqs = np.array([0.15])
+    if freqs == None:
+        # Default to single frequency (150 MHz) for getting redundancy info
+        freqs = np.array([0.15])
     # Make list of antennas.
     # These are values for a zenith-pointing antenna, with a dummy Gaussian beam.
     antennas = []


### PR DESCRIPTION
This PR adds an optional `freqs` argument to `get_aa_from_uv`, which passes the list in to the `aa` object. The default value is a single value at 150 MHz, which is backwards compatible with the previous method of calling the function. However, for applications besides computing redundancy information, it allows the user to specify a frequency list.