### PR TITLE
bug fix to firstcal.UVData_to_dict: now works w/ sorted baseline arrays

### DIFF
--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -405,12 +405,8 @@ def UVData_to_dict(uvdata_list, filetype='miriad'):
                 f[i, j] = {}
             for ip, pol in enumerate(uv_in.polarization_array):
                 pol = pol2str[pol]
-                try:
-                    new_data = copy.copy(uv_in.get_data((i, j))[:, :, ip])
-                    new_flags = copy.copy(uv_in.get_flags((i, j))[:, :, ip])
-                except:
-                    new_data = copy.copy(uv_in.get_data((i, j)))
-                    new_flags = copy.copy(uv_in.get_flags((i, j)))
+                new_data = copy.copy(uv_in.get_data((i, j, pol)))
+                new_flags = copy.copy(uv_in.get_flags((i, j, pol)))
 
                 if pol not in d[(i, j)]:
                     d[(i, j)][pol] = new_data

--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -403,7 +403,7 @@ def UVData_to_dict(uvdata_list, filetype='miriad'):
         flags = uv_in.flag_array.reshape(
             uv_in.Ntimes, uv_in.Nbls, uv_in.Nspws, uv_in.Nfreqs, uv_in.Npols)
 
-        for nbl, (i, j) in enumerate(map(uv_in.baseline_to_antnums, uv_in.baseline_array[:uv_in.Nbls])):
+        for nbl, (i, j) in enumerate(map(uv_in.baseline_to_antnums, np.unique(uv_in.baseline_array))):
             if (i, j) not in d:
                 d[i, j] = {}
                 f[i, j] = {}

--- a/hera_cal/tests/test_firstcal.py
+++ b/hera_cal/tests/test_firstcal.py
@@ -195,6 +195,14 @@ class Test_FirstCal(object):
                 np.testing.assert_equal(f[i, j][pol], np.resize(
                     uvd.flag_array[uvmask][:, 0, :, uvpol], f[i, j][pol].shape))
 
+    def test_UVData_to_dict_keys(self):
+        uvd = UVData()
+        uvd.read_miriad(os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcAA'))
+        nt.assert_equal(len(firstcal.UVData_to_dict([uvd])[0]), uvd.Nbls)
+        # reorder baseline array
+        uvd.baseline_array = uvd.baseline_array[np.argsort(uvd.baseline_array)]
+        nt.assert_equal(len(firstcal.UVData_to_dict([uvd])[0]), uvd.Nbls)
+
     def test_process_ubls(self):
         ubls = ''
         ubaselines = firstcal.process_ubls(ubls)


### PR DESCRIPTION
`firstcal.UVData_to_dict` assumed the `uvd.baseline_array` was not sorted. for some files (like omnical model visibility files) this sometimes isn't the case. It now works with any form of sorting for `uvd.baseline_array`. tests to ensure this works are included.