### PR TITLE
fixed cal_formts test w/ pyuvdata upgrade

### DIFF
--- a/hera_cal/cal_formats.py
+++ b/hera_cal/cal_formats.py
@@ -41,11 +41,11 @@ class HERACal(UVCal):
         # if we provided an ex_ants those antennas will not have a key in gains. Need to provide ex_ants list
         # to HERACal object.
         # create set to get unique antennas from both pol
-        ants = list(set([ant for pol in gains.keys() for ant in gains[pol].keys()]))
-        allants = np.sort(ants + ex_ants)  # total number of antennas
+        ants = np.array(list(set([ant for pol in gains.keys() for ant in gains[pol].keys()])))
+        allants = np.sort(np.concatenate([ants, np.array(ex_ants)])).astype(np.int)  # total number of antennas
         ants = np.sort(ants)
         # antenna names for all antennas
-        antnames = ['ant' + str(ant) for ant in allants]
+        antnames = np.array(['ant' + str(int(ant)) for ant in allants])
         time = meta['times']
         freq = meta['freqs']  # this is in Hz (should be anyways)
         pols = [str2pol[p] for p in gains.keys()]  # all of the polarizations
@@ -89,8 +89,8 @@ class HERACal(UVCal):
         
         pols = np.array(pols)
         freq = np.array(freq)
-        antarray = list(map(int, ants))
-        numarray = list(map(int, allants))
+        antarray = np.array(list(map(int, ants)))
+        numarray = np.array(list(map(int, allants)))
 
         # set UVCal attributes
         self.telescope_name = 'HERA'

--- a/hera_cal/tests/test_cal_formats.py
+++ b/hera_cal/tests/test_cal_formats.py
@@ -51,8 +51,8 @@ class Test_HERACal(UVCal):
         uv.read_calfits(os.path.join(
             DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.first.calfits'))
         for param in hc:
-           # print param
-           # print getattr(hc, param).value, getattr(uv, param).value
+            print param
+            print getattr(hc, param).value, getattr(uv, param).value
             if param == '_history':
                 continue
             elif param == '_git_hash_cal':
@@ -66,7 +66,8 @@ class Test_HERACal(UVCal):
                 continue
             else:
                 if "_antenna_" in param:
+                    # comparison between _antenna_numbers (and _antenna_names) fails but
+                    # comparison betwen antenna_numbers (and antenna_names) does not fail
                     param = param[1:]
-                print param
                 nt.assert_true(
                     np.all(getattr(hc, param) == getattr(uv, param)))

--- a/hera_cal/tests/test_cal_formats.py
+++ b/hera_cal/tests/test_cal_formats.py
@@ -25,6 +25,8 @@ class Test_HERACal(UVCal):
             elif param == '_extra_keywords':
                 continue
             else:
+                if "_antenna_" in param:
+                    param = param[1:]
                 nt.assert_true(np.all(getattr(hc, param) == getattr(uv, param)))
 
     def test_exception(self):
@@ -49,8 +51,8 @@ class Test_HERACal(UVCal):
         uv.read_calfits(os.path.join(
             DATA_PATH, 'test_input', 'zen.2457698.40355.xx.HH.uvc.first.calfits'))
         for param in hc:
-            print param
-            print getattr(hc, param).value, getattr(uv, param).value
+           # print param
+           # print getattr(hc, param).value, getattr(uv, param).value
             if param == '_history':
                 continue
             elif param == '_git_hash_cal':
@@ -63,5 +65,8 @@ class Test_HERACal(UVCal):
             elif param == '_extra_keywords':
                 continue
             else:
+                if "_antenna_" in param:
+                    param = param[1:]
+                print param
                 nt.assert_true(
                     np.all(getattr(hc, param) == getattr(uv, param)))


### PR DESCRIPTION
updated test in `test_cal_formats` to do a slightly different comparison when comparing `antenna_names` and `antenna_numbers`, which have apparently been allowed to float between lists and ndarrays in `pyuvdata` without an error. in the test, instead of comparing `_antenna_names` we compare `antenna_names` which passes when comparing a list to an ndarray so long as the elements are equal. 