### PR TITLE
Update extract_hh.py to include outriggers

### DIFF
--- a/scripts/extract_hh.py
+++ b/scripts/extract_hh.py
@@ -37,7 +37,7 @@ for filename in args.files:
         raise ValueError('Unrecognized file type ' + str(args.filetype))
     st_type_str = uv.extra_keywords.pop('st_type').replace('\x00', '')
     st_type_list = st_type_str[1:-1].split(', ')
-    ind = [i for i, x in enumerate(st_type_list) if x == 'herahex']
+    ind = [i for i, x in enumerate(st_type_list) if x == 'herahex' or x == 'heraringa' or x == 'heraringb']
     uv.select(antenna_nums=uv.antenna_numbers[ind])
     st_type_list = list(np.array(st_type_list)[np.array(ind, dtype=int)])
     uv.extra_keywords['st_type'] = '[' + ', '.join(st_type_list) + ']'


### PR DESCRIPTION
This PR will extract HERA antennas whose designation is `heraringa` or `heraringb`, i.e., the outrigger antennas. This should future-proof ourselves, since there are only `heraringa` antennas for this season.