### PR TITLE
Account for HERA-hex subarray sectors

### DIFF
--- a/scripts/extract_hh.py
+++ b/scripts/extract_hh.py
@@ -37,7 +37,7 @@ for filename in args.files:
         raise ValueError('Unrecognized file type ' + str(args.filetype))
     st_type_str = uv.extra_keywords.pop('st_type').replace('\x00', '')
     st_type_list = st_type_str[1:-1].split(', ')
-    ind = [i for i, x in enumerate(st_type_list) if x == 'herahex' or x == 'heraringa' or x == 'heraringb']
+    ind = [i for i, x in enumerate(st_type_list) if x[:7] == 'herahex' or x == 'heraringa' or x == 'heraringb']
     uv.select(antenna_nums=uv.antenna_numbers[ind])
     st_type_list = list(np.array(st_type_list)[np.array(ind, dtype=int)])
     uv.extra_keywords['st_type'] = '[' + ', '.join(st_type_list) + ']'


### PR DESCRIPTION
In M&C, the different fractured "triads" of the HERA core will be denoted `herahexe`, `herahexn`, and `herahexw`. Although all will still have the `HH` prefix for their short-form names, we need to update references to the long-form name. In particular, the `extract_hh.py` script only extracts antennas that match `herahex`, `heraringa`, and `heraringb`. The script has been updated to allow for the different suffices, but still remains backwards-compatible with the old format.