### PR TITLE
adds write_cal to hera_cal.io

### DIFF
--- a/hera_cal/cal_formats.py
+++ b/hera_cal/cal_formats.py
@@ -156,3 +156,6 @@ class HERACal(UVCal):
 
         # run a check
         self.check()
+
+
+        

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -100,9 +100,14 @@ def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, 
         return data, flags
 
 
-def write_vis(outfilename, data, flags, filetype='miriad', history='', clobber=False, **kwargs):
-    '''TODO: migrate in hera_cal.utils.data_to_miriad and generalize to also write uvfits.'''
-    raise NotImplementedError('This function has not been implemented yet.')
+def write_vis(fname, data, flags, filetype='miriad', history=' ', overwrite=False, **kwargs):
+    """
+
+    """
+    
+
+    
+
 
 
 def update_uvdata(uvd, data=None, flags=None, add_to_history='', **kwargs):
@@ -368,7 +373,7 @@ def write_cal(fname, gains, freqs, times, pols, flags=None, quality=None, write_
         return uvc
 
 
-def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', overwrite=False, **kwargs):
+def update_uvcal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', overwrite=False, **kwargs):
     '''Loads an existing calfits file with pyuvdata, modifies some subset of of its parameters, 
     and then writes a new calfits file to disk. Cannot modify the shape of gain arrays. 
     More than one spectral window is not supported.

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -101,12 +101,10 @@ def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, 
 
 
 def write_vis(fname, data, flags, filetype='miriad', history=' ', overwrite=False, **kwargs):
-    """
+    '''TODO: migrate in hera_cal.utils.data_to_miriad and generalize to also write uvfits.'''
+    raise NotImplementedError('This function has not been implemented yet.')
 
-    """
-    
 
-    
 
 
 
@@ -373,20 +371,17 @@ def write_cal(fname, gains, freqs, times, pols, flags=None, quality=None, write_
         return uvc
 
 
-def update_uvcal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', overwrite=False, **kwargs):
-    '''Loads an existing calfits file with pyuvdata, modifies some subset of of its parameters, 
-    and then writes a new calfits file to disk. Cannot modify the shape of gain arrays. 
-    More than one spectral window is not supported.
-
+def update_uvcal(cal, gains=None, flags=None, quals=None, add_to_history='', **kwargs):
+    '''Update UVCal object with gains, flags, quals, history, and/or other parameters
+    Cannot modify the shape of gain arrays. More than one spectral window is not supported.
     Arguments:
         cal: UVCal object to be updated
         gains: Dictionary of complex calibration gains with shape=(Ntimes,Nfreqs)
             with keys in the (1,'x') format. Default (None) leaves unchanged.
         flags: Dictionary like gains but of flags. Default (None) leaves unchanged.
         quals: Dictionary like gains but of per-antenna quality. Default (None) leaves unchanged.
-        add_to_history: appends a string to the history of the output file
-        overwrite: if True, overwrites existing file at outfilename
-        kwargs: dictionary mapping updated attributs to their new values. 
+        add_to_history: appends a string to the history of the UVCal object
+        kwargs: dictionary mapping updated attributs to their new values.
             See pyuvdata.UVCal documentation for more info.
     '''
     # Set gains, flags, and/or quals
@@ -406,11 +401,10 @@ def update_uvcal(infilename, outfilename, gains=None, flags=None, quals=None, ad
     cal.check()
 
 
-def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', overwrite=False, **kwargs):
+def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', clobber=False, **kwargs):
     '''Loads an existing calfits file with pyuvdata, modifies some subset of of its parameters,
     and then writes a new calfits file to disk. Cannot modify the shape of gain arrays.
     More than one spectral window is not supported.
-
     Arguments:
         infilename: filename of the base calfits file to be updated, or UVCal object
         outfilename: filename of the new calfits file
@@ -419,7 +413,7 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
         flags: Dictionary like gains but of flags. Default (None) leaves unchanged.
         quals: Dictionary like gains but of per-antenna quality. Default (None) leaves unchanged.
         add_to_history: appends a string to the history of the output file
-        overwrite: if True, overwrites existing file at outfilename
+        clobber: if True, overwrites existing file at outfilename
         kwargs: dictionary mapping updated attributs to their new values.
             See pyuvdata.UVCal documentation for more info.
     '''
@@ -435,6 +429,6 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
                  add_to_history=add_to_history, **kwargs)
 
     # Write to calfits file
-    cal.write_calfits(outfilename, clobber=overwrite) 
+    cal.write_calfits(outfilename, clobber=clobber)
 
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -401,7 +401,7 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
     cal.check()
 
 
-def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', clobber=False, **kwargs):
+def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_to_history='', overwrite=False, **kwargs):
     '''Loads an existing calfits file with pyuvdata, modifies some subset of of its parameters,
     and then writes a new calfits file to disk. Cannot modify the shape of gain arrays.
     More than one spectral window is not supported.
@@ -414,7 +414,7 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
         flags: Dictionary like gains but of flags. Default (None) leaves unchanged.
         quals: Dictionary like gains but of per-antenna quality. Default (None) leaves unchanged.
         add_to_history: appends a string to the history of the output file
-        clobber: if True, overwrites existing file at outfilename
+        overwrite: if True, overwrites existing file at outfilename
         kwargs: dictionary mapping updated attributs to their new values.
             See pyuvdata.UVCal documentation for more info.
     '''

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -295,7 +295,7 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, write_file=T
     ant_array = np.arange(Nants_data)
 
     # get polarization info
-    pol_array = np.array(sorted(map(lambda k: k[1].lower(), gains.keys())))
+    pol_array = np.array(sorted(set(map(lambda k: k[1].lower(), gains.keys()))))
     jones_array = np.array(map(lambda p: str2pol[p], pol_array), np.int)
     Njones = len(jones_array)
 

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -244,7 +244,7 @@ class Test_Calibration_IO(unittest.TestCase):
                 flags[(a, p)] = np.zeros((Ntimes, Nfreqs), np.bool)
 
         # test basic execution
-        uvc = io.write_cal("ex.calfits", gains, freqs, times, pols, flags=flags, quality=quality,
+        uvc = io.write_cal("ex.calfits", gains, freqs, times, flags=flags, quality=quality,
                            overwrite=True, return_uvc=True, write_file=True)
         self.assertTrue(os.path.exists("ex.calfits"))
         self.assertAlmostEqual(uvc.gain_array[0,0,0,0,0], (1+0j))
@@ -254,9 +254,9 @@ class Test_Calibration_IO(unittest.TestCase):
         if os.path.exists('ex.calfits'):
             os.remove('ex.calfits')
         # test execution with different parameters
-        uvc = io.write_cal("ex.calfits", gains, freqs, times, pols, overwrite=True)
+        uvc = io.write_cal("ex.calfits", gains, freqs, times, overwrite=True)
         # test exception
-        self.assertRaises(IOError, io.write_cal, "ex.calfits", gains, freqs, times, pols)
+        self.assertRaises(IOError, io.write_cal, "ex.calfits", gains, freqs, times)
         if os.path.exists('ex.calfits'):
             os.remove('ex.calfits')
 

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -247,9 +247,14 @@ class Test_Calibration_IO(unittest.TestCase):
         uvc = io.write_cal("ex.calfits", gains, freqs, times, flags=flags, quality=quality,
                            overwrite=True, return_uvc=True, write_file=True)
         self.assertTrue(os.path.exists("ex.calfits"))
+        self.assertEqual(uvc.gain_array.shape, (10, 1, 64, 100, 1))
+
         self.assertAlmostEqual(uvc.gain_array[0,0,0,0,0], (1+0j))
+        self.assertAlmostEqual(np.sum(uvc.gain_array), (64000+0j))
         self.assertEqual(uvc.flag_array[0,0,0,0,0], False)
+        self.assertEqual(np.sum(uvc.flag_array), 0)
         self.assertAlmostEqual(uvc.quality_array[0,0,0,0,0], 2)
+        self.assertAlmostEqual(np.sum(uvc.quality_array), 128000.0)
         self.assertEqual(len(uvc.antenna_numbers), 10)
         if os.path.exists('ex.calfits'):
             os.remove('ex.calfits')


### PR DESCRIPTION
`hera_cal.io.write_cal` is a method to format gain dictionaries into `pyuvdata.UVCal` structures, and to then write them out as `calfits` files. 