### PR TITLE
Issue180/deprecate uv data to dict

### DIFF
--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -802,100 +802,6 @@ def array_axis_to_data_key(data, array_index, array_keys, key_index=-1, copy_dic
         return new_data
 
 
-def UVData2AbsCalDict(datanames, pol_select=None, pop_autos=True, return_meta=False, filetype='miriad',
-                      pick_data_ants=True, return_wgts=False):
-    """
-    turn a list of pyuvdata.UVData objects or a list of miriad or uvfits file paths
-    into the datacontainer dictionary form that AbsCal requires. This format is
-    keys as antennas-pair + polarization format, Ex. (1, 2, 'xx')
-    and values as 2D complex ndarrays with [0] axis indexing time and [1] axis frequency.
-
-    Parameters:
-    -----------
-    datanames : list of either strings of data file paths or list of UVData instances
-                to concatenate into a single dictionary
-
-    pol_select : list of polarization strings to keep
-
-    pop_autos : boolean, if True: remove autocorrelations
-
-    return_meta : boolean, if True: also return antenna and unique frequency and LST arrays
-
-    filetype : string, filetype of data if datanames is a string, options=['miriad', 'uvfits']
-                can be ingored if datanames contains UVData objects.
-
-    pick_data_ants : boolean, if True and return_meta=True, return only antennas in data
-
-    return_wgts : boolean, if True, return data flags as data weights [dtype=float]
-
-    Output:
-    -------
-    if return_meta is True:
-        (data, flags, antpos, ants, freqs, times, lsts, pols)
-    else:
-        (data, flags)
-
-    data : DataContainer containing baseline-pol complex visibility data
-    flags : DataContainer containing data flags, if return_wgts=True then this is a weight dict
-    antpos : dictionary containing antennas numbers as keys and position vectors
-    ants : ndarray containing unique antennas
-    freqs : ndarray containing frequency channels (Hz)
-    times : ndarray containing time stamps data in julian date
-    lst : ndarray containing time stamps in local sidereal time [radians]
-    pols : ndarray containing polarizations of data in string format ('xx', or 'yy')
-    """
-    # check datanames is not a list
-    if type(datanames) is not list and type(datanames) is not np.ndarray:
-        if type(datanames) is str:
-            # assume datanames is a file path
-            uvd = UVData()
-            suffix = os.path.splitext(datanames)[1]
-            if filetype == 'uvfits' or suffix == '.uvfits':
-                uvd.read_uvfits(datanames)
-                uvd.unphase_to_drift()
-            elif filetype == 'miriad':
-                uvd.read_miriad(datanames)
-        else:
-            # assume datanames is a UVData instance 
-            uvd = datanames
-    else:
-        # if datanames is a list, check data types of elements
-        if type(datanames[0]) is str:
-            # assume datanames contains file paths
-            uvd = UVData()
-            suffix = os.path.splitext(datanames[0])[1]
-            if filetype == 'uvfits' or suffix == '.uvfits':
-                uvd.read_uvfits(datanames)
-                uvd.unphase_to_drift()
-            elif filetype == 'miriad':
-                uvd.read_miriad(datanames)
-        else:
-            # assume datanames contains UVData instances
-            uvd = reduce(operator.add, datanames)
-
-    # load data
-    d, f = io.load_vis([uvd], nested_dict=True, pop_autos=pop_autos)
-
-    # turn into datacontainer
-    data, flags = DataContainer(d), DataContainer(f)
-
-    # turn into weights
-    if return_wgts:
-       flags = DataContainer(odict(map(lambda k: (k, (~flags[k]).astype(np.float)), flags.keys())))
-
-    # get meta
-    if return_meta:
-        freqs = np.unique(uvd.freq_array)
-        times = np.unique(uvd.time_array)
-        lsts = np.unique(uvd.lst_array)
-        antpos, ants = uvd.get_ENU_antpos(center=False, pick_data_ants=pick_data_ants)
-        antpos = odict(zip(ants, antpos))
-        pols = uvd.polarization_array
-        return data, flags, antpos, ants, freqs, times, lsts, pols
-    else:
-        return data, flags
-
-
 def fft_dly(vis, wgts=None, df=9.765625e4, medfilt=True, kernel=(1, 11), time_ax=0, freq_ax=1,
             solve_phase=True):
     """
@@ -1556,7 +1462,7 @@ def avg_file_across_red_bls(data_fname, outdir=None, output_fname=None,
         uvd.read_miriad(data_fname)
 
     # get data
-    data, flags = UVData2AbsCalDict(uvd)
+    data, flags = io.load_vis(uvd, pop_autos=True, return_meta=False, pick_data_ants=True)
 
     # get antpos and baselines
     antpos, ants = uvd.get_ENU_antpos()

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -874,7 +874,7 @@ def UVData2AbsCalDict(datanames, pol_select=None, pop_autos=True, return_meta=Fa
             uvd = reduce(operator.add, datanames)
 
     # load data
-    d, f = io.load_vis([uvd], nested_dict=True, pop_autos=True)
+    d, f = io.load_vis([uvd], nested_dict=True, pop_autos=pop_autos)
 
     # turn into datacontainer
     data, flags = DataContainer(d), DataContainer(f)

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -14,7 +14,7 @@ import functools
 import numpy as np
 from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
-from hera_cal import omni, utils, firstcal, cal_formats, redcal
+from hera_cal import omni, utils, firstcal, cal_formats, redcal, io
 from hera_cal.datacontainer import DataContainer
 from scipy import signal
 from scipy import interpolate
@@ -874,14 +874,7 @@ def UVData2AbsCalDict(datanames, pol_select=None, pop_autos=True, return_meta=Fa
             uvd = reduce(operator.add, datanames)
 
     # load data
-    d, f = firstcal.UVData_to_dict([uvd])
-
-    # pop autos
-    if pop_autos:
-        for i, k in enumerate(d.keys()):
-            if k[0] == k[1]:
-                d.pop(k)
-                f.pop(k)
+    d, f = io.load_vis([uvd], nested_dict=True, pop_autos=True)
 
     # turn into datacontainer
     data, flags = DataContainer(d), DataContainer(f)

--- a/hera_cal/firstcal.py
+++ b/hera_cal/firstcal.py
@@ -11,7 +11,7 @@ import scipy.sparse as sps
 import aipy
 from aipy.miriad import pol2str
 from hera_cal.omni import Antpol
-from hera_cal import omni, utils, cal_formats
+from hera_cal import omni, utils, cal_formats, io
 import omnical
 from pyuvdata import UVData
 
@@ -507,7 +507,7 @@ def firstcal_run(files, opts, history):
         niters = 0
 
         while niters == 0 or len(switched) > 0:
-            datapack, flagpack = UVData_to_dict([uv])
+            datapack, flagpack = io.load_vis([uv], nested_dict=True)
             datapack = _apply_pi_shift(datapack, switched)
             wgtpack = {k: {p: np.logical_not(flagpack[k][p]) for p in flagpack[k]} for k in flagpack} 
 

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -420,7 +420,7 @@ def lst_align_files(data_files, file_ext=".L.{:7.5f}", dlst=None,
     for i, f in enumerate(data_files):
         # load data
         (data, flgs, apos, ants, freqs, times, lsts,
-         pols) = abscal.UVData2AbsCalDict(f, return_meta=True, return_wgts=False)
+         pols) = io.load_vis(f, return_meta=True)
 
         # lst align
         interp_data, interp_flgs, interp_lsts = lst_align(data, lsts, flags=flgs, dlst=dlst, **align_kwargs)
@@ -458,7 +458,6 @@ def lst_bin_arg_parser():
     a.add_argument("--lst_hi", default=None, type=float, help="enact an upper bound on LST grid")
     a.add_argument("--ntimes_per_file", type=int, default=60, help="number of LST bins to write per output file")
     a.add_argument("--file_ext", type=str, default="{}.{}.{:7.5f}.uv", help="file extension for output files. See lstbin.lst_bin_files doc-string for format specs.")
-    a.add_argument("--pol_select", nargs='*', type=str, default=None, help="polarization strings to use in data_files")
     a.add_argument("--outdir", default=None, type=str, help="directory for writing output")
     a.add_argument("--overwrite", default=False, action='store_true', help="overwrite output files")
     a.add_argument("--history", default=' ', type=str, help="history to insert into output files")
@@ -472,7 +471,7 @@ def lst_bin_arg_parser():
 
 
 def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_ext="{}.{}.{:7.5f}.uv",
-                  pol_select=None, outdir=None, overwrite=False, history=' ', lst_start=0,
+                  outdir=None, overwrite=False, history=' ', lst_start=0,
                   align=False, align_kwargs={}, bin_kwargs={}, atol=1e-6, miriad_kwargs={}):
     """
     LST bin a series of miriad files with identical frequency bins, but varying
@@ -494,8 +493,6 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
     file_ext : type=str, extension to "zen." for output miriad files. This must have three
                formatting placeholders, first for polarization(s), second for type of file
                Ex. ["LST", "STD", "NUM"] and third for starting LST bin of file.
-
-    pol_select : type=list, list of polarization strings Ex. ['xx'] to select in data_files
 
     outdir : type=str, output directory
 
@@ -566,7 +563,7 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
     miriad_kwargs['overwrite'] = overwrite
  
     # get frequency, time and antennas position information from the zeroth data file
-    d, fl, ap, a, f, t, l, p = abscal.UVData2AbsCalDict(data_files[0][0], return_meta=True, pick_data_ants=False)
+    d, fl, ap, a, f, t, l, p = io.load_vis(data_files[0][0], return_meta=True, pick_data_ants=False)
     freq_array = copy.copy(f)
     antpos = copy.deepcopy(ap)
     start_jd = np.floor(t)[0]
@@ -600,7 +597,7 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
             for k in range(len(data_files[j])):
                 if f_select[j][k] == True and data_status[j][k] is None:
                     # open file
-                    d, fl, ap, a, f, t, l, p = abscal.UVData2AbsCalDict(data_files[j][k], return_meta=True, pol_select=pol_select)
+                    d, fl, ap, a, f, t, l, p = io.load_vis(data_files[j][k], return_meta=True)
 
                     # unwrap l
                     l[l < start_lst] += 2*np.pi

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -166,16 +166,23 @@ class Test_AbsCal_Funcs:
 
     def test_Baseline(self):
         # test basic execution
-        bls = map(lambda k: hc.abscal.Baseline(self.antpos[k[1]] - self.antpos[k[0]], tol=2.0), self.data.keys())
-        bls_conj = map(lambda k: hc.abscal.Baseline(self.antpos[k[0]] - self.antpos[k[1]], tol=2.0), self.data.keys())
-        nt.assert_equal(bls[0], bls[0])
-        nt.assert_false(bls[0] == bls[1])
-        nt.assert_equal(bls[0] == bls_conj[0], 'conjugated')
+        keys = self.data.keys()
+        k1 = (24, 25, 'xx')    # 14.6 m E-W
+        i1 = keys.index(k1)
+        k2 = (24, 37 ,'xx')    # different
+        i2 = keys.index(k2)
+        k3 = (52, 53, 'xx')   # 14.6 m E-W
+        i3 = keys.index(k3)
+        bls = map(lambda k: hc.abscal.Baseline(self.antpos[k[1]] - self.antpos[k[0]], tol=2.0), keys)
+        bls_conj = map(lambda k: hc.abscal.Baseline(self.antpos[k[0]] - self.antpos[k[1]], tol=2.0), keys)
+        nt.assert_equal(bls[i1], bls[i1])
+        nt.assert_false(bls[i1] == bls[i2])
+        nt.assert_equal(bls[i1] == bls_conj[i1], 'conjugated')
         # test different yet redundant baselines still agree
-        nt.assert_equal(bls[-1], bls[0])
+        nt.assert_equal(bls[i1], bls[i3])
         # test tolerance works as expected
-        bls = map(lambda k: hc.abscal.Baseline(self.antpos[k[1]] - self.antpos[k[0]], tol=1e-4), self.data.keys())
-        nt.assert_not_equal(bls[-3], bls[-1])
+        bls = map(lambda k: hc.abscal.Baseline(self.antpos[k[1]] - self.antpos[k[0]], tol=1e-4), keys)
+        nt.assert_not_equal(bls[i1], bls[i3])
 
     def test_match_red_baselines(self):
         model = copy.deepcopy(self.data)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -214,9 +214,9 @@ class Test_AbsCal:
         d, fl, ap, a, f, t, l, p = hc.io.load_vis(self.data_fname, return_meta=True, pick_data_ants=False)
         self.freq_array = f
         self.antpos = ap
-        p = map(lambda p: self.AC.pol2str[p][0], p)
+        gain_pols = map(lambda p: p[0], p)
         self.ap = ap
-        self.gk = hc.abscal.flatten(map(lambda p: map(lambda k: (k,p), a), p))
+        self.gk = hc.abscal.flatten(map(lambda p: map(lambda k: (k,p), a), gain_pols))
         self.freqs = f
 
     def test_init(self):

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -30,7 +30,11 @@ class Test_AbsCal_Funcs:
         self.time_array = np.unique(self.uvd.time_array)
 
         # configure data into dictionaries
-        data, wgts = hc.abscal.UVData2AbsCalDict(self.uvd, pop_autos=True, return_wgts=True)
+        data, flgs = hc.io.load_vis(self.uvd, pop_autos=True)
+        wgts = odict()
+        for k in flgs.keys():
+            wgts[k] = (~flgs[k]).astype(np.float)
+        wgts = hc.datacontainer.DataContainer(wgts)
 
         # configure baselines
         bls = odict([(x, self.antpos[x[0]] - self.antpos[x[1]]) for x in data.keys()])
@@ -47,54 +51,6 @@ class Test_AbsCal_Funcs:
         self.bls = bls
         self.model = model
         self.wgts = wgts
-
-    def test_UVData2AbsCalDict(self):
-        # test filename
-        fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        data, flags = hc.abscal.UVData2AbsCalDict(fname, pop_autos=False)
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (60, 64))
-        nt.assert_equal(flags[(24, 25, 'xx')].shape, (60, 64))
-        nt.assert_equal((24, 24, 'xx') in data, True)
-        data, flags = hc.abscal.UVData2AbsCalDict([fname])
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (60, 64))
-
-        # test pop autos
-        data, flags = hc.abscal.UVData2AbsCalDict(fname, pop_autos=True)
-        nt.assert_equal((24, 24, 'xx') in data, False)
-
-        # test pol select
-        data, flags = hc.abscal.UVData2AbsCalDict(fname, pop_autos=False, pol_select=['xx'])
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (60, 64))
-
-        # test uvd object
-        uvd = UVData()
-        uvd.read_miriad(fname)
-        data, flags = hc.abscal.UVData2AbsCalDict(uvd)
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (60, 64))
-        data, flags = hc.abscal.UVData2AbsCalDict([uvd])
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (60, 64))
-
-        # test multiple
-        fname2 = os.path.join(DATA_PATH, "zen.2458043.13298.xx.HH.uvORA")
-        data, flags = hc.abscal.UVData2AbsCalDict([fname, fname2])
-        nt.assert_equal(data[(24, 25, 'xx')].shape, (120, 64))
-        nt.assert_equal(flags[(24, 25, 'xx')].shape, (120, 64))
-
-        # test w/ meta
-        d, f, ap, a, f, t, l, p = hc.abscal.UVData2AbsCalDict([fname, fname2], return_meta=True)
-        nt.assert_equal(len(ap[24]), 3)
-        nt.assert_equal(len(f), len(self.freq_array))
-
-        # test uvfits
-        fname = os.path.join(DATA_PATH, 'zen.2458043.12552.xx.HH.uvA.vis.uvfits')
-        d, f = hc.abscal.UVData2AbsCalDict(fname, filetype='uvfits')
-        nt.assert_equal(d[(0,1,'xx')].shape, (60,64))
-
-        # test w/ meta pick_data_ants
-        d, f, ap, a, f, t, l, p = hc.abscal.UVData2AbsCalDict(fname, return_meta=True, pick_data_ants=False)
-        nt.assert_equal(len(ap[24]), 3)
-        nt.assert_equal(len(a), 47)
-        nt.assert_equal(len(f), len(self.freq_array))
 
     def test_data_key_to_array_axis(self):
         m, pk = hc.abscal.data_key_to_array_axis(self.model, 2)
@@ -219,7 +175,7 @@ class Test_AbsCal_Funcs:
 
     def test_avg_data_across_red_bls(self):
         # test basic execution 
-        data, flags, antpos, ants, freqs, times, lsts, pols = hc.abscal.UVData2AbsCalDict(self.data_file, return_meta=True)
+        data, flags, antpos, ants, freqs, times, lsts, pols = hc.io.load_vis(self.data_file, return_meta=True)
         rd, rf, rk = hc.abscal.avg_data_across_red_bls(data, antpos, flags=self.wgts, tol=2.0)
         # test various kwargs
         rd, rf, rk = hc.abscal.avg_data_across_red_bls(data, antpos, tol=2.0, median=True)
@@ -255,7 +211,7 @@ class Test_AbsCal:
         self.AC = hc.abscal.AbsCal(self.data_fname, self.model_fname)
 
         # make custom gain keys
-        d, fl, ap, a, f, t, l, p = hc.abscal.UVData2AbsCalDict(self.data_fname, return_meta=True, pick_data_ants=False)
+        d, fl, ap, a, f, t, l, p = hc.io.load_vis(self.data_fname, return_meta=True, pick_data_ants=False)
         self.freq_array = f
         self.antpos = ap
         p = map(lambda p: self.AC.pol2str[p][0], p)
@@ -271,7 +227,7 @@ class Test_AbsCal:
         AC = hc.abscal.AbsCal(self.AC.model, self.AC.data, antpos=self.AC.antpos, freqs=self.AC.freqs)
         nt.assert_almost_equal(AC.bls[(24,25,'xx')][0], -14.607842046642745)
         # init with meta
-        AC = hc.abscal.AbsCal(self.AC.model, self.AC.data, pol_select=['xx'])
+        AC = hc.abscal.AbsCal(self.AC.model, self.AC.data)
         # test feeding file
         AC = hc.abscal.AbsCal(self.model_fname, self.data_fname)
 
@@ -580,7 +536,11 @@ class Test_AbsCal:
     def test_mock_data(self):
         # load into pyuvdata object
         data_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        data, wgts, ap, a, f, t, l, p = hc.abscal.UVData2AbsCalDict(data_file, return_meta=True, return_wgts=True)
+        data, flgs, ap, a, f, t, l, p = hc.io.load_vis(data_file, return_meta=True)
+        wgts = odict()
+        for k in flgs.keys():
+            wgts[k] = (~flgs[k]).astype(np.float)
+        wgts = hc.datacontainer.DataContainer(wgts)
         # make mock data
         dly_slope = np.array([-1e-9, 2e-9, 0])
         model = odict()

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -172,7 +172,7 @@ class Test_AbsCal_Funcs:
         nt.assert_false(bls[0] == bls[1])
         nt.assert_equal(bls[0] == bls_conj[0], 'conjugated')
         # test different yet redundant baselines still agree
-        nt.assert_equal(bls[-1], bls[-3])
+        nt.assert_equal(bls[-1], bls[0])
         # test tolerance works as expected
         bls = map(lambda k: hc.abscal.Baseline(self.antpos[k[1]] - self.antpos[k[0]], tol=1e-4), self.data.keys())
         nt.assert_not_equal(bls[-3], bls[-1])

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -1,5 +1,5 @@
 import unittest
-from hera_cal import datacontainer
+from hera_cal import datacontainer, io
 import numpy as np
 from hera_cal.data import DATA_PATH
 import os
@@ -260,11 +260,11 @@ class TestDataContainer(unittest.TestCase):
 
     def test_adder(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        d, f = abscal.UVData2AbsCalDict(test_file)
+        d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d + d
         self.assertAlmostEqual(d2[(24,25,'xx')][30, 30], d[(24,25,'xx')][30, 30]*2)
         # test exception
-        d2, f2 = abscal.UVData2AbsCalDict(test_file)
+        d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[d2.keys()[0]] = d2[d2.keys()[0]][:, :10]
         self.assertRaises(ValueError, d.__add__, d2)
         d2[d2.keys()[0]] = d2[d2.keys()[0]][:10, :]
@@ -272,12 +272,12 @@ class TestDataContainer(unittest.TestCase):
 
     def test_mul(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        d, f = abscal.UVData2AbsCalDict(test_file)
+        d, f = io.load_vis(test_file, pop_autos=True)
         f[(24,25,'xx')][:,0] = False
         f2 = f * f
         self.assertFalse(f2[(24,25,'xx')][0,0])
         # test exception
-        d2, f2 = abscal.UVData2AbsCalDict(test_file)
+        d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[d2.keys()[0]] = d2[d2.keys()[0]][:, :10]
         self.assertRaises(ValueError, d.__mul__, d2)
         d2[d2.keys()[0]] = d2[d2.keys()[0]][:10, :]
@@ -285,7 +285,7 @@ class TestDataContainer(unittest.TestCase):
 
     def test_concatenate(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        d, f = abscal.UVData2AbsCalDict(test_file)
+        d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d.concatenate(d)
         self.assertEqual(d2[(24,25,'xx')].shape[0], d[(24,25,'xx')].shape[0]*2)
         d2 = d.concatenate(d, axis=1)
@@ -293,7 +293,7 @@ class TestDataContainer(unittest.TestCase):
         d2 = d.concatenate([d,d], axis=0)
         self.assertEqual(d2[(24,25,'xx')].shape[0], d[(24,25,'xx')].shape[0]*3)
         # test exceptions
-        d2, f2 = abscal.UVData2AbsCalDict(test_file)
+        d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[d2.keys()[0]] = d2[d2.keys()[0]][:10, :10]
         self.assertRaises(ValueError, d.concatenate, d2, axis=0)
         self.assertRaises(ValueError, d.concatenate, d2, axis=1)

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -28,11 +28,11 @@ class Test_lstbin:
                            sorted(glob.glob(DATA_PATH+'/zen.2458045.4*uvXRAA'))]
 
         (self.data1, self.flgs1, self.ap1, a, self.freqs1, t, self.lsts1,
-         p) = hc.abscal.UVData2AbsCalDict(self.data_files[0], return_meta=True)
+         p) = hc.io.load_vis(self.data_files[0], return_meta=True)
         (self.data2, self.flgs2, ap, a, self.freqs2, t, self.lsts2,
-         p) = hc.abscal.UVData2AbsCalDict(self.data_files[1], return_meta=True)
+         p) = hc.io.load_vis(self.data_files[1], return_meta=True)
         (self.data3, self.flgs3, ap, a, self.freqs3, t, self.lsts3,
-         p) = hc.abscal.UVData2AbsCalDict(self.data_files[2], return_meta=True)
+         p) = hc.io.load_vis(self.data_files[2], return_meta=True)
         self.data_list = [self.data1, self.data2, self.data3]
         self.flgs_list = [self.flgs1, self.flgs2, self.flgs3]
         self.lst_list = [self.lsts1, self.lsts2, self.lsts3]

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -7,6 +7,7 @@ from pyuvdata import UVData
 from hera_cal import utils, abscal, datacontainer
 from hera_cal.calibrations import CAL_PATH
 from hera_cal.data import DATA_PATH
+from hera_cal import io
 from pyuvdata import UVCal
 import glob
 from collections import OrderedDict as odict
@@ -151,7 +152,4 @@ def test_get_miriad_times():
     nt.assert_almost_equal(_stops[0] - _ints[0], stops[0])
     # test if str
     starts, stops, ints = utils.get_miriad_times(filepaths[0])
-
-
-
 


### PR DESCRIPTION
This PR changes the instances of the UVData_2_dict function in firstcal to use the io.load_vis function.

Also deprecates `abscal.UVData2AbscalDict` for `io.load_vis`