### PR TITLE
Io write cal check zero

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -514,6 +514,9 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, write_file=T
                 flag_array[j, :, :, :, i] = np.ones((Nspws, Nfreqs, Ntimes), np.bool)
                 quality_array[j, :, :, :, i] = np.ones((Nspws, Nfreqs, Ntimes), np.float)
 
+    # Check gain_array for values close to zero, if so, set to 1
+    gain_array[np.isclose(gain_array, 0)] = 1.0 + 0j
+
     # instantiate UVCal
     uvc = UVCal()
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -515,9 +515,11 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, write_file=T
                 quality_array[j, :, :, :, i] = np.ones((Nspws, Nfreqs, Ntimes), np.float)
 
     # Check gain_array for values close to zero, if so, set to 1
-    zero_check = np.isclose(gain_array, 0)
+    zero_check = np.isclose(gain_array, 0, rtol=1e-10, atol=1e-10)
     gain_array[zero_check] = 1.0 + 0j
     flag_array[zero_check] += True
+    if zero_check.max() is True:
+        print("Some of values in self.gain_array were zero and are flagged and set to 1.")
 
     # instantiate UVCal
     uvc = UVCal()
@@ -584,6 +586,14 @@ def update_uvcal(cal, gains=None, flags=None, quals=None, add_to_history='', **k
                 cal.flag_array[i, 0, :, :, ip] = flags[(ant, jonesnum2str[pol])].T
             if quals is not None:
                 cal.quality_array[i, 0, :, :, ip] = quals[(ant, jonesnum2str[pol])].T
+
+    # Check gain_array for values close to zero, if so, set to 1
+    zero_check = np.isclose(cal.gain_array, 0, rtol=1e-10, atol=1e-10)
+    cal.gain_array[zero_check] = 1.0 + 0j
+    cal.flag_array[zero_check] += True
+    if zero_check.max() is True:
+        print("Some of values in self.gain_array were zero and are flagged and set to 1.")
+
 
     # Set additional attributes
     cal.history += add_to_history

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -515,7 +515,9 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, write_file=T
                 quality_array[j, :, :, :, i] = np.ones((Nspws, Nfreqs, Ntimes), np.float)
 
     # Check gain_array for values close to zero, if so, set to 1
-    gain_array[np.isclose(gain_array, 0)] = 1.0 + 0j
+    zero_check = np.isclose(gain_array, 0)
+    gain_array[zero_check] = 1.0 + 0j
+    flag_array[zero_check] += True
 
     # instantiate UVCal
     uvc = UVCal()

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -270,13 +270,16 @@ class Test_Calibration_IO(unittest.TestCase):
                 gains[(a, p)] = np.ones((Ntimes, Nfreqs), np.complex)
                 quality[(a, p)] = np.ones((Ntimes, Nfreqs), np.float) * 2
                 flags[(a, p)] = np.zeros((Ntimes, Nfreqs), np.bool)
+                
+        # set some terms to zero
+        gains[(5, 'x')][20:30] *= 0
 
         # test basic execution
         uvc = io.write_cal("ex.calfits", gains, freqs, times, flags=flags, quality=quality,
                            overwrite=True, return_uvc=True, write_file=True)
         self.assertTrue(os.path.exists("ex.calfits"))
         self.assertEqual(uvc.gain_array.shape, (10, 1, 64, 100, 1))
-
+        self.assertAlmostEqual(uvc.gain_array[5].min(), 1.0)
         self.assertAlmostEqual(uvc.gain_array[0,0,0,0,0], (1+0j))
         self.assertAlmostEqual(np.sum(uvc.gain_array), (64000+0j))
         self.assertEqual(uvc.flag_array[0,0,0,0,0], False)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -283,7 +283,7 @@ class Test_Calibration_IO(unittest.TestCase):
         self.assertAlmostEqual(uvc.gain_array[0,0,0,0,0], (1+0j))
         self.assertAlmostEqual(np.sum(uvc.gain_array), (64000+0j))
         self.assertEqual(uvc.flag_array[0,0,0,0,0], False)
-        self.assertEqual(np.sum(uvc.flag_array), 0)
+        self.assertEqual(np.sum(uvc.flag_array), 640)
         self.assertAlmostEqual(uvc.quality_array[0,0,0,0,0], 2)
         self.assertAlmostEqual(np.sum(uvc.quality_array), 128000.0)
         self.assertEqual(len(uvc.antenna_numbers), 10)


### PR DESCRIPTION
if gain_array has zeros in them, then they can incur nans when applied to data. This checks to see if zeros exist `gain_array`, and if so sets the values to 1.0 and makes sure those pixels are flagged