### PR TITLE
Allow new_cal and old_cal in apply_cal script to be space-separated lists

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -58,7 +58,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             to be applied, along with its new flags (if any).
         old_calibration: filename of the calfits file (or a list of filenames) or UVCal object for the calibration 
             to be unapplied. Default None means that the input data is raw (i.e. uncalibrated).
-        flag_npz: optional path to npz file containing just flags to be ORed with flags in input data
+        flags_npz: optional path to npz file containing just flags to be ORed with flags in input data
         filetype: filename for the new file, either 'miriad' or 'uvfits'
         gain_convention: str, either 'divide' or 'multiply'. 'divide' means V_obs = gi gj* V_true,
             'multiply' means V_true = gi gj* V_obs. Assumed to be the same for new_gains and old_gains.
@@ -81,6 +81,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     data, data_flags = io.load_vis(uvd)
     
     # load new calibration solution
+    if new_calibration is None:
+        raise ValueError('Must provide a calibration solution to apply.')
     if isinstance(new_calibration, UVCal):
         uvc = new_calibration
     else:
@@ -109,9 +111,9 @@ def apply_cal_argparser():
     a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")
     a.add_argument("infile", type=str, help="path to visibility data file to calibrate")
     a.add_argument("outfile", type=str, help="path to new visibility results file")
-    a.add_argument("new_cal", type=str, nargs="+", help="path to new calibration calfits file (or files for cross-pol)")
-    a.add_argument("--old_cal", default=None, nargs="+", help="path to old calibration calfits file to unapply (or files for cross-pol)")
-    a.add_argument("--flags_npz", default=None, help="path to npz file of flags to OR with data flags")
+    a.add_argument("--new_cal", type=str, default=None, nargs="+", help="path to new calibration calfits file (or files for cross-pol)")
+    a.add_argument("--old_cal", type=str, default=None, nargs="+", help="path to old calibration calfits file to unapply (or files for cross-pol)")
+    a.add_argument("--flags_npz", type=str, default=None, help="path to npz file of flags to OR with data flags")
     a.add_argument("--filetype", type=str, default='miriad', help='filetype of input and output data files')
     a.add_argument("--gain_convention", type=str, default='divide', 
                   help="'divide' means V_obs = gi gj* V_true, 'multiply' means V_true = gi gj* V_obs.")

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -54,10 +54,10 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     Arguments:
         data_infilename: filename (or UVData object) of the data file to be updated.
         data_outfilename: filename of the resultant data file with the new calibration and flags.
-        new_calibration: filename of the calfits file (or UVCal object) for the calibration to be applied,
-            along with its new flags (if any)
-        old_calibration: filename of the calfits file (or UVCal object) for the calibration to be unapplied.
-            Default None means that the input data is raw (i.e. uncalibrated).
+        new_calibration: filename of the calfits file (or a list of filenames) or UVCal object for the calibration 
+            to be applied, along with its new flags (if any).
+        old_calibration: filename of the calfits file (or a list of filenames) or UVCal object for the calibration 
+            to be unapplied. Default None means that the input data is raw (i.e. uncalibrated).
         flag_npz: optional path to npz file containing just flags to be ORed with flags in input data
         filetype: filename for the new file, either 'miriad' or 'uvfits'
         gain_convention: str, either 'divide' or 'multiply'. 'divide' means V_obs = gi gj* V_true,
@@ -81,8 +81,11 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     data, data_flags = io.load_vis(uvd)
     
     # load new calibration solution
-    uvc = UVCal()
-    uvc.read_calfits(new_calibration)
+    if isinstance(new_calibration, UVCal):
+        uvc = new_calibration
+    else:
+        uvc = UVCal()   
+        uvc.read_calfits(new_calibration)
     add_to_history += ' NEW_CALFITS_HISTORY: ' + uvc.history + '\n'
     new_gains, new_flags = io.load_cal(uvc)
 
@@ -106,8 +109,8 @@ def apply_cal_argparser():
     a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")
     a.add_argument("infile", type=str, help="path to visibility data file to calibrate")
     a.add_argument("outfile", type=str, help="path to new visibility results file")
-    a.add_argument("new_cal", type=str, help="path to new calibration calfits file")
-    a.add_argument("--old_cal", default=None, help="path to old calibration calfits file (to unapply)")
+    a.add_argument("new_cal", type=str, nargs="+", help="path to new calibration calfits file (or files for cross-pol)")
+    a.add_argument("--old_cal", default=None, nargs="+", help="path to old calibration calfits file to unapply (or files for cross-pol)")
     a.add_argument("--flags_npz", default=None, help="path to npz file of flags to OR with data flags")
     a.add_argument("--filetype", type=str, default='miriad', help='filetype of input and output data files')
     a.add_argument("--gain_convention", type=str, default='divide', 

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -110,11 +110,11 @@ class Test_Update_Cal(unittest.TestCase):
         shutil.rmtree(outname)
 
     def test_apply_cal_argparser(self):
-        sys.argv = [sys.argv[0], 'a', 'b', 'c']
+        sys.argv = [sys.argv[0], 'a', 'b', 'c', 'd']
         args = ac.apply_cal_argparser()
         self.assertEqual(args.infile, 'a')
         self.assertEqual(args.outfile, 'b')
-        self.assertEqual(args.new_cal, 'c')
+        self.assertEqual(args.new_cal, ['c', 'd'])
 
 
 if __name__ == '__main__':

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -106,15 +106,16 @@ class Test_Update_Cal(unittest.TestCase):
                     if j < 300 or j > 923:
                         self.assertTrue(new_flags[k][i,j])
                     
-
+        with self.assertRaises(ValueError):
+            ac.apply_cal(fname, outname, None)
         shutil.rmtree(outname)
 
     def test_apply_cal_argparser(self):
-        sys.argv = [sys.argv[0], 'a', 'b', 'c', 'd']
+        sys.argv = [sys.argv[0], 'a', 'b', '--new_cal', 'd']
         args = ac.apply_cal_argparser()
         self.assertEqual(args.infile, 'a')
         self.assertEqual(args.outfile, 'b')
-        self.assertEqual(args.new_cal, ['c', 'd'])
+        self.assertEqual(args.new_cal, ['d'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is needed for xy and yx calibration, where the lists are loaded into a single UVCal object.