### PR TITLE
enabled abscal_run to write blank and flagged calfits file if no model overlap

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -850,7 +850,7 @@ def abscal_run(data_files, model_files, verbose=True, overwrite=False, write_cal
                calfits_fname=None, return_gains=False, return_object=False, outdir=None,
                match_red_bls=False, tol=1.0, reweight=False, interp_model=True, all_antenna_gains=False,
                delay_cal=False, avg_phs_cal=False, delay_slope_cal=False, abs_amp_cal=False,
-               TT_phs_cal=False, gen_amp_cal=False, gen_phs_cal=False):
+               TT_phs_cal=False, gen_amp_cal=False, gen_phs_cal=False, history=''):
     """
     run AbsCal on a set of time-contiguous data files, using time-contiguous model files that cover
     the data_files across LST.
@@ -990,7 +990,8 @@ def abscal_run(data_files, model_files, verbose=True, overwrite=False, write_cal
             flag_dict = odict(map(lambda k: (k, np.ones(gain_dict[k].shape, np.bool)), gain_dict.keys()))
             # write to file
             if write_calfits:
-                io.write_cal(calfits_fname, gain_dict, data_freqs, data_times, flags=flag_dict, return_uvc=False, overwrite=overwrite)
+                io.write_cal(calfits_fname, gain_dict, data_freqs, data_times, flags=flag_dict, 
+                             return_uvc=False, overwrite=overwrite, history=history)
 
             # append gain dict to gains
             gains.append(gain_dict)
@@ -1086,7 +1087,8 @@ def abscal_run(data_files, model_files, verbose=True, overwrite=False, write_cal
 
         # write to file
         if write_calfits:
-            io.write_cal(calfits_fname, gain_dict, data_freqs, data_times, return_uvc=False, overwrite=overwrite)
+            io.write_cal(calfits_fname, gain_dict, data_freqs, data_times, return_uvc=False, 
+                         overwrite=overwrite, history=history)
 
         # append gain dict to gains
         gains.append(gain_dict)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -549,8 +549,6 @@ class Test_AbsCal:
         hc.abscal.abscal_run(data_files, model_files, TT_phs_cal=False, abs_amp_cal=False, gen_amp_cal=True, gen_phs_cal=True, write_calfits=False)
         # test exception
         nt.assert_raises(ValueError, hc.abscal.abscal_run, data_files, model_files, verbose=False, overwrite=True)
-        model_files = sorted(glob.glob(os.path.join(DATA_PATH, 'zen.2458045.*.xx.HH.uvXRAA')))
-        nt.assert_raises(ValueError, hc.abscal.abscal_run, data_files, model_files, verbose=False, overwrite=True)
         # check blank & flagged calfits file written if no LST overlap
         model_files = sorted(glob.glob(os.path.join(DATA_PATH, "zen.2458044.*.xx.HH.uvXRAA")))
         hc.abscal.abscal_run(data_files, model_files, write_calfits=True, overwrite=True, outdir='./', calfits_fname='ex.calfits')

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -551,6 +551,14 @@ class Test_AbsCal:
         nt.assert_raises(ValueError, hc.abscal.abscal_run, data_files, model_files, verbose=False, overwrite=True)
         model_files = sorted(glob.glob(os.path.join(DATA_PATH, 'zen.2458045.*.xx.HH.uvXRAA')))
         nt.assert_raises(ValueError, hc.abscal.abscal_run, data_files, model_files, verbose=False, overwrite=True)
+        # check blank & flagged calfits file written if no LST overlap
+        model_files = sorted(glob.glob(os.path.join(DATA_PATH, "zen.2458044.*.xx.HH.uvXRAA")))
+        hc.abscal.abscal_run(data_files, model_files, write_calfits=True, overwrite=True, outdir='./', calfits_fname='ex.calfits')
+        uvc = UVCal()
+        uvc.read_calfits('./ex.calfits')
+        nt.assert_true(uvc.flag_array.min())
+        nt.assert_almost_equal(uvc.gain_array.max(), 1.0)
+        os.remove('./ex.calfits')
 
 
     def test_mock_data(self):

--- a/scripts/abscal_run.py
+++ b/scripts/abscal_run.py
@@ -20,4 +20,4 @@ if args.data_is_omni_solution:
     kwargs['reweight'] = True
     kwargs['match_red_bls'] = True
 
-abscal.abscal_run(args.data_files, args.model_files, verbose=verbose, **kwargs)
+abscal.abscal_run(args.data_files, args.model_files, verbose=verbose, history=history, **kwargs)

--- a/scripts/omni_abscal_run.py
+++ b/scripts/omni_abscal_run.py
@@ -20,5 +20,5 @@ if args.data_is_omni_solution:
     kwargs['reweight'] = True
     kwargs['match_red_bls'] = True
 
-abscal.abscal_run(args.data_files, args.model_files, verbose=verbose, **kwargs)
+abscal.abscal_run(args.data_files, args.model_files, verbose=verbose, history=history, **kwargs)
 


### PR DESCRIPTION
this capability is for the makeflow pipeline which will break if there is no output calfits file.