### PR TITLE
Implemented delay rephasing in smooth_cal freq filter

### DIFF
--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -78,9 +78,18 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         gains[3,5] = 10.0
         wgts = np.ones((10,10),dtype=float)
         wgts[3,5] = 0
-        freqs = np.linspace(100.,200.,10)
+        freqs = np.linspace(100.,200.,10)*1e6
         ff = sc.freq_filter(gains, wgts, freqs)
         np.testing.assert_array_almost_equal(ff, np.ones((10,10),dtype=complex))
+
+        #test rephasing
+        gains = np.ones((2,1000),dtype=complex)
+        wgts = np.ones((2,1000),dtype=float)
+        freqs = np.linspace(100.,200.,1000)*1e6
+        gains *= np.exp(2.0j * np.pi * np.outer(100e-9 * np.ones(2), freqs))
+        ff = sc.freq_filter(gains, wgts, freqs)
+        np.testing.assert_array_almost_equal(ff, gains, 2)
+
 
 class Test_Calibration_Smoother(unittest.TestCase):
 

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -69,7 +69,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         gains[3,5] = 10.0
         wgts = np.ones((10,10),dtype=float)
         wgts[3,5] = 0
-        times = np.linspace(0,10*10/60./60./24.,10)
+        times = np.linspace(0,10*10/60./60./24.,10, endpoint=False)
         tf = sc.time_filter(gains, wgts, times, filter_scale = 120.0, nMirrors = 1)
         np.testing.assert_array_almost_equal(tf, np.ones((10,10),dtype=complex))
 
@@ -78,17 +78,17 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         gains[3,5] = 10.0
         wgts = np.ones((10,10),dtype=float)
         wgts[3,5] = 0
-        freqs = np.linspace(100.,200.,10)*1e6
+        freqs = np.linspace(100.,200.,10, endpoint=False)*1e6
         ff = sc.freq_filter(gains, wgts, freqs)
         np.testing.assert_array_almost_equal(ff, np.ones((10,10),dtype=complex))
 
         #test rephasing
         gains = np.ones((2,1000),dtype=complex)
         wgts = np.ones((2,1000),dtype=float)
-        freqs = np.linspace(100.,200.,1000)*1e6
-        gains *= np.exp(2.0j * np.pi * np.outer(100e-9 * np.ones(2), freqs))
+        freqs = np.linspace(100.,200.,1000, endpoint=False)*1e6
+        gains *= np.exp(2.0j * np.pi * np.outer(150e-9 * np.ones(2), freqs))
         ff = sc.freq_filter(gains, wgts, freqs)
-        np.testing.assert_array_almost_equal(ff, gains, 2)
+        np.testing.assert_array_almost_equal(ff, gains)
 
 
 class Test_Calibration_Smoother(unittest.TestCase):


### PR DESCRIPTION
This addresses #232 and fixes the problem of the two antennas that looked bad in the .OCRS files but fine in the .OCR files that @nkern found today.

The root of the problem that @AaronParsons and I figured out today was that the smoother was trying to filter the real and imaginary components of the calibration solutions, which can have a lot of spectral structure when the antenna has a large delay (beyond the 10 MHz scale) but isn't what we actually want to smooth out. My solution is to find a per-antenna, per-integration delay using abscal.fft_dly, remove it, smooth, and then put the delay back in.