### PR TITLE
fixex io.write_cal when writing a calibration w/ a single integration

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -491,7 +491,10 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, total_qual=N
     time_array = np.array(times, np.float)
     Ntimes = len(time_array)
     time_range = np.array([time_array.min(), time_array.max()], np.float)
-    integration_time = np.median(np.diff(time_array)) * 24. * 3600.
+    if len(time_array) > 1:
+        integration_time = np.median(np.diff(time_array)) * 24. * 3600.
+    else:
+        integration_time = 0.0
 
     # get frequency info
     freq_array = np.array(freqs, np.float)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -299,9 +299,9 @@ class Test_Calibration_IO(unittest.TestCase):
         # test single integration write
         gains = odict(map(lambda k: (k, gains[k][:1]), gains.keys()))
         uvc = io.write_cal("ex.calfits", gains, freqs, times[:1], return_uvc=True, outdir='./')
-        nt.assert_almost_equal(uvc.integration_time, 0.0)
-        nt.assert_equal(uvc.Ntimes, 1)
-        nt.assert_true(os.path.exists('ex.calfits'))
+        self.assertAlmostEqual(uvc.integration_time, 0.0)
+        self.assertEqual(uvc.Ntimes, 1)
+        self.assertTrue(os.path.exists('ex.calfits'))
         os.remove('ex.calfits')
 
 

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -296,6 +296,14 @@ class Test_Calibration_IO(unittest.TestCase):
         uvc = io.write_cal("ex.calfits", gains, freqs, times, overwrite=True)
         if os.path.exists('ex.calfits'):
             os.remove('ex.calfits')
+        # test single integration write
+        gains = odict(map(lambda k: (k, gains[k][:1]), gains.keys()))
+        uvc = io.write_cal("ex.calfits", gains, freqs, times[:1], return_uvc=True, outdir='./')
+        nt.assert_almost_equal(uvc.integration_time, 0.0)
+        nt.assert_equal(uvc.Ntimes, 1)
+        nt.assert_true(os.path.exists('ex.calfits'))
+        os.remove('ex.calfits')
+
 
     def test_update_cal(self):
         # load in cal


### PR DESCRIPTION
when writing a calibration w/ a single integration (i.e. a single bandpass solution) `hera_cal.io.write_cal` failed at the calculation of `integration_time`, which is now fixed such that it is set to 0.0 when this happens. tests included