### PR TITLE
updated delay_filter_run such that residual and/or model can be written

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -123,8 +123,9 @@ def delay_filter_argparser():
                    "Note that if outfile is not supplied, the parser defaults to None, but delay_filter_run.py "
                    "will override this default, and instead sets outfile to infile + 'D'.")
     a.add_argument("--filetype", type=str, default='miriad', help='filetype of input and output data files (default "miriad")')
-    a.add_argument("--write_model", default=False, action="store_true", help="write the low-pass filtered CLEAN model rather\
-                   than the high-pass filtered residual")
+    a.add_argument("--write_model", default=False, action="store_true", help="Write the low-pass filtered CLEAN model "\
+                   "in addition to the high-pass filtered residual. This file gets an 'M' extension on top of the specified outfile,"\
+                   " or if no outfile is provided, a 'DM' extension on top of the infile.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
 
     filt_options = a.add_argument_group(title='Options for the delay filter')

--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -123,9 +123,11 @@ def delay_filter_argparser():
                    "Note that if outfile is not supplied, the parser defaults to None, but delay_filter_run.py "
                    "will override this default, and instead sets outfile to infile + 'D'.")
     a.add_argument("--filetype", type=str, default='miriad', help='filetype of input and output data files (default "miriad")')
-    a.add_argument("--write_model", default=False, action="store_true", help="Write the low-pass filtered CLEAN model "\
-                   "in addition to the high-pass filtered residual. This file gets an 'M' extension on top of the specified outfile,"\
-                   " or if no outfile is provided, a 'DM' extension on top of the infile.")
+    a.add_argument("--write_model", default=False, action="store_true", help="Write the low-pass filtered CLEAN model rather"\
+                   "than the high-pass filtered residual.")
+    a.add_argument("--write_both", default=False, action='store_true', help="Write both the high-pass residual and the low-pass "\
+                    "CLEAN model. The residual gets the outfile name (or default 'D' extension), and the model gets an 'M' extension "\
+                    "on top of the residual filename.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
 
     filt_options = a.add_argument_group(title='Options for the delay filter')

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -15,5 +15,12 @@ df = Delay_Filter()
 df.load_data(a.infile, filetype = a.filetype)
 df.run_filter(standoff = a.standoff, horizon = a.horizon, tol = a.tol, window = a.window,
               skip_wgt = a.skip_wgt, maxiter = a.maxiter)
+
+# Write high-pass residual
 df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
-                       clobber = a.clobber, write_CLEAN_models = a.write_model)
+                       clobber = a.clobber, write_CLEAN_models = False)
+
+# Write low-pass model if desired
+a.outfile += 'M'
+df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
+                       clobber = a.clobber, write_CLEAN_models = True)

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -17,10 +17,12 @@ df.run_filter(standoff = a.standoff, horizon = a.horizon, tol = a.tol, window = 
               skip_wgt = a.skip_wgt, maxiter = a.maxiter)
 
 # Write high-pass residual
-df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
-                       clobber = a.clobber, write_CLEAN_models = False)
+if a.write_model == False or a.write_both == True:
+    df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
+                           clobber = a.clobber, write_CLEAN_models = False)
 
 # Write low-pass model if desired
-a.outfile += 'M'
-df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
-                       clobber = a.clobber, write_CLEAN_models = True)
+if a.write_model == True or a.write_both == True:
+    a.outfile += 'M'
+    df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
+                           clobber = a.clobber, write_CLEAN_models = True)

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -22,7 +22,8 @@ if a.write_model == False or a.write_both == True:
                            clobber = a.clobber, write_CLEAN_models = False)
 
 # Write low-pass model if desired
-if a.write_model == True or a.write_both == True:
-    a.outfile += 'M'
+if a.write_model or a.write_both:
+    if a.write_both:
+        a.outfile += 'M'
     df.write_filtered_data(a.outfile, filetype_out=a.filetype, add_to_history = ' '.join(sys.argv),
                            clobber = a.clobber, write_CLEAN_models = True)


### PR DESCRIPTION
by default residual is written. model can be alternatively written w/ `--write_model`, or both can be written with `--write_both`.

This enables us to write to file the model and residual without having to re-run the `delay_filter`, which is a slow process.

This will only affect the IDR2.1 pipeline if it ever uses `delay_filter_run.py` with the `--write_model` flag, otherwise it shouldn't change anything in the pipeline.
