### PR TITLE
updated lstbin.lst_bin such that wrapped lst_arrays are handled better

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -196,7 +196,6 @@ def lst_bin(data_list, lst_list, flags_list=None, dlst=None, lst_start=None, lst
             if key in data:
                 pass
             elif switch_bl(key) in data:
-                print 'conjugating??'
                 # check to see if conj(key) exists in data
                 key = switch_bl(key)
                 d[key] = np.conj(d[switch_bl(key)])

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -147,6 +147,9 @@ def lst_bin(data_list, lst_list, flags_list=None, dlst=None, lst_start=None, lst
         # get lst array
         l = lst_list[i]
 
+        # ensure l isn't wrapped relative to lst_grid
+        l[l < lst_grid.min()] += 2*np.pi
+
         # digitize data lst array "l"
         grid_indices = np.digitize(l, lst_grid_left[1:], right=True)
 
@@ -735,9 +738,9 @@ def make_lst_grid(dlst, lst_start=None, verbose=True):
                 is also greater than the input dlst. There is a minimum allowed dlst of 6.283e-6 radians,
                 or .0864 seconds.
 
-    lst_start : type=float, starting point for lst_grid, extending out 2pi from lst_start.
-                            lst_start must fall exactly on an LST bin given a dlst. If not, it is
-                            replaced with the closest bin. Default is lst_start at zero radians.
+    lst_start : type=float, starting point for lst_grid, which extends out 2pi from lst_start.
+                lst_start must fall exactly on an LST bin given a dlst, within 0-2pi. If not, it is
+                replaced with the closest bin. Default is lst_start at zero radians.
 
     Output:
     -------
@@ -761,6 +764,10 @@ def make_lst_grid(dlst, lst_start=None, verbose=True):
 
     # shift grid by lst_start
     if lst_start is not None:
+        # enforce lst_start to be within 0-2pi, else replace with 0
+        if lst_start < 0 or lst_start > 2*np.pi:
+            abscal.echo("lst_start was < 0 or > 2pi, replacing with lst_start=0", verbose=verbose)
+            lst_start = 0.0
         lst_start = lst_grid[np.argmin(np.abs(lst_grid - lst_start))] - dlst/2
         lst_grid += lst_start
 

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -765,8 +765,8 @@ def make_lst_grid(dlst, lst_start=None, verbose=True):
     if lst_start is not None:
         # enforce lst_start to be within 0-2pi, else replace with 0
         if lst_start < 0 or lst_start > 2*np.pi:
-            abscal.echo("lst_start was < 0 or > 2pi, replacing with lst_start=0", verbose=verbose)
-            lst_start = 0.0
+            abscal.echo("lst_start was < 0 or > 2pi, taking modulus with (2pi)", verbose=verbose)
+            lst_start = lst_start % (2*np.pi)
         lst_start = lst_grid[np.argmin(np.abs(lst_grid - lst_start))] - dlst/2
         lst_grid += lst_start
 

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -37,6 +37,17 @@ class Test_lstbin:
         self.flgs_list = [self.flgs1, self.flgs2, self.flgs3]
         self.lst_list = [self.lsts1, self.lsts2, self.lsts3]
 
+    def test_make_lst_grid(self):
+        lst_grid = hc.lstbin.make_lst_grid(0.01, lst_start=None, verbose=False)
+        nt.assert_equal(len(lst_grid), 628)
+        nt.assert_almost_equal(lst_grid[0], 0.0050025360725952121)
+        lst_grid = hc.lstbin.make_lst_grid(0.01, lst_start=np.pi, verbose=False)
+        nt.assert_equal(len(lst_grid), 628)
+        nt.assert_almost_equal(lst_grid[0], 3.1365901175171982)
+        lst_grid = hc.lstbin.make_lst_grid(0.01, lst_start=-np.pi, verbose=False)
+        nt.assert_equal(len(lst_grid), 628)
+        nt.assert_almost_equal(lst_grid[0], 3.1365901175171982)
+
     def test_lstbin(self):
         dlst = 0.0007830490163484
         # test basic execution

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -81,6 +81,11 @@ class Test_lstbin:
         # test sigma clip
         output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
                                    verbose=False, sig_clip=True, min_N=5, sigma=2)
+        # test wrapping
+        lst_list = map(lambda l: (copy.deepcopy(l) + 6) % (2*np.pi), self.lst_list)
+        output = hc.lstbin.lst_bin(self.data_list, lst_list, dlst=0.001, lst_start=np.pi)
+        nt.assert_true(output[0][0] > output[0][-1])
+        nt.assert_equal(len(output[0][0]), 175)
 
     def test_lst_align(self):
         # test basic execution

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -85,7 +85,7 @@ class Test_lstbin:
         lst_list = map(lambda l: (copy.deepcopy(l) + 6) % (2*np.pi), self.lst_list)
         output = hc.lstbin.lst_bin(self.data_list, lst_list, dlst=0.001, lst_start=np.pi)
         nt.assert_true(output[0][0] > output[0][-1])
-        nt.assert_equal(len(output[0][0]), 175)
+        nt.assert_equal(len(output[0]), 175)
 
     def test_lst_align(self):
         # test basic execution


### PR DESCRIPTION
if the lst_array of a data_file was wrapped and lst_start was non-zero, the wrapped lsts were not being binned, so I included some checks and wrapping statements to catch this. a test is added to ensure its working properly.