### PR TITLE
fixed bug in lstbin.lst_bin_files

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -40,7 +40,7 @@ def lst_bin(data_list, lst_list, flags_list=None, dlst=None, lst_start=None, lst
     -----------
     data_list : type=list, list of DataContainer dictionaries holding complex visibility data
 
-    lst_list : type=list, list of ndarrays holding LST stamps of each data dictionary in data_list.
+    lst_list : type=list, list of ndarrays holding LST bin centers of each data dictionary in data_list.
         These LST arrays must be monotonically increasing, except for a possible wrap at 2pi.
     
     flags_list : type=list, list of DataContainer dictionaries holding flags for each data dict
@@ -89,7 +89,7 @@ def lst_bin(data_list, lst_list, flags_list=None, dlst=None, lst_start=None, lst
 
     Output: (lst_bins, data_avg, flags_min, data_std, data_count)
     -------
-    lst_bins : ndarray containing final lst grid of data
+    lst_bins : ndarray containing final lst grid of data (marks bin centers)
 
     data_avg : dictionary of data having averaged in each LST bin
 
@@ -699,7 +699,15 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
                              lst_low=f_min, lst_hi=f_max, truncate_empty=False, sig_clip=sig_clip, 
                              sigma=sigma, min_N=min_N, rephase=rephase, freq_array=freq_array, antpos=antpos)
 
-        # make sure bin_lst is wrapped
+        # push lst_bins back to bin start rather than bin center
+        # b/c pyuvdata does not do this for us yet...
+        abscal.echo("pushing time and lst arrays backward by half an integration b/c pyuvdata "\
+                    "currently does not do this for us....", verbose=verbose)
+        # unwrap bin_lst
+        bin_lst[bin_lst < bin_lst[0] - atol] += 2*np.pi
+        # push back
+        bin_lst -= np.median(np.diff(bin_lst)) / 2.0
+        # re-wrap bin_lst
         bin_lst = bin_lst % (2*np.pi)
 
         # update history

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -603,7 +603,8 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
     # push time and lst arrays forward by half an integration
     abscal.echo("pushing time and lst arrays forward by half an integration b/c pyuvdata "\
                 "currently does not do this for us....", verbose=verbose)
-    t += np.median(np.diff(t)) / 2.0
+    if len(t) > 1:
+        t += np.median(np.diff(t)) / 2.0
 
     # get frequency, time and antenna position information
     freq_array = copy.copy(f)
@@ -647,8 +648,9 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
 
                     # push time and lst arrays forward by half an integration
                     # b/c pyuvdata does not currently do this for us....
-                    l += np.median(np.diff(l)) / 2.0
-                    t += np.median(np.diff(t)) / 2.0
+                    if len(l) > 1:
+                        l += np.median(np.diff(l)) / 2.0
+                        t += np.median(np.diff(t)) / 2.0
 
                     # unwrap l relative to start_lst
                     l[l < start_lst - atol] += 2*np.pi
@@ -706,7 +708,8 @@ def lst_bin_files(data_files, dlst=None, verbose=True, ntimes_per_file=60, file_
         # unwrap bin_lst
         bin_lst[bin_lst < bin_lst[0] - atol] += 2*np.pi
         # push back
-        bin_lst -= np.median(np.diff(bin_lst)) / 2.0
+        if len(bin_lst) > 1:
+            bin_lst -= np.median(np.diff(bin_lst)) / 2.0
         # re-wrap bin_lst
         bin_lst = bin_lst % (2*np.pi)
 

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -124,26 +124,31 @@ class Test_lstbin:
         # basic execution
         hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
                                 verbose=False)
-        nt.assert_true(os.path.exists('./zen.xx.LST.0.20164.uv'))
-        nt.assert_true(os.path.exists('./zen.xx.STD.0.20164.uv'))
-        shutil.rmtree('./zen.xx.LST.0.20164.uv')
-        shutil.rmtree('./zen.xx.STD.0.20164.uv')
+        output_lst_file = "./zen.xx.LST.0.20124.uv"
+        output_std_file = "./zen.xx.STD.0.20124.uv"
+        nt.assert_true(os.path.exists(output_lst_file))
+        nt.assert_true(os.path.exists(output_std_file))
+        shutil.rmtree(output_lst_file)
+        shutil.rmtree(output_std_file)
         # test rephase
         hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
                                 verbose=False, rephase=True)
-        nt.assert_true(os.path.exists('./zen.xx.LST.0.20164.uv'))
-        nt.assert_true(os.path.exists('./zen.xx.STD.0.20164.uv'))
-        shutil.rmtree('./zen.xx.LST.0.20164.uv')
-        shutil.rmtree('./zen.xx.STD.0.20164.uv')
+        output_lst_file = "./zen.xx.LST.0.20124.uv"
+        output_std_file = "./zen.xx.STD.0.20124.uv"
+        nt.assert_true(os.path.exists(output_lst_file))
+        nt.assert_true(os.path.exists(output_std_file))
+        shutil.rmtree(output_lst_file)
+        shutil.rmtree(output_std_file)
 
         data_files = [[sorted(glob.glob(DATA_PATH+'/zen.2458043.*uvXRAA'))[0]],
                       [sorted(glob.glob(DATA_PATH+'/zen.2458045.*uvXRAA'))[-1]]]
         # test data_list is empty
         hc.lstbin.lst_bin_files(data_files, ntimes_per_file=30, outdir="./", overwrite=True,
                                 verbose=False)
-        nt.assert_true(os.path.exists("./zen.xx.LST.0.20164.uv"))
-        nt.assert_true(os.path.exists("./zen.xx.LST.0.31909.uv"))
-        nt.assert_true(os.path.exists("./zen.xx.LST.0.36608.uv"))
+        output_lst_files = ['./zen.xx.LST.0.20124.uv', './zen.xx.LST.0.31870.uv', './zen.xx.LST.0.36568.uv']
+        nt.assert_true(os.path.exists(output_lst_files[0]))
+        nt.assert_true(os.path.exists(output_lst_files[1]))
+        nt.assert_true(os.path.exists(output_lst_files[2]))
         output_files = np.concatenate([glob.glob("./zen.xx.LST*"),
                                        glob.glob("./zen.xx.STD*")])
         for of in output_files:

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -147,12 +147,8 @@ def test_get_miriad_times():
     # test with integration buffer
     _starts, _stops, _ints = utils.get_miriad_times(filepaths, add_int_buffer=True)
     nt.assert_almost_equal(starts[0], _starts[0])
-    nt.assert_almost_equal(stops[-1], _stops[-1])
-    nt.assert_not_almost_equal(starts[1], _starts[1])
-    nt.assert_not_almost_equal(stops[0], _stops[0])
-    nt.assert_almost_equal(_starts[1] + _ints[1], starts[1])
     nt.assert_almost_equal(_stops[0] - _ints[0], stops[0])
-    # test if str
+    # test if fed as a str
     starts, stops, ints = utils.get_miriad_times(filepaths[0])
 
 def test_lst_rephase():

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -376,8 +376,7 @@ def get_miriad_times(filepaths, add_int_buffer=False):
     ------------
     filepaths : type=list, list of filepaths
 
-    add_int_buffer : type=bool, if True, extend stop times by a single integration duration
-        except for the list file in filepaths.
+    add_int_buffer : type=bool, if True, extend stop times by an integration duration.
 
     Output: (file_starts, file_stops, int_times)
     -------
@@ -411,8 +410,7 @@ def get_miriad_times(filepaths, add_int_buffer=False):
         stop = start + (uv['ntimes']-1) * int_time
         # add integration buffer to beginning and end if desired
         if add_int_buffer:
-            if i != (Nfiles-1):
-                stop += int_time
+            stop += int_time
         # add half an integration to get center of integration
         start += int_time / 2
         stop += int_time / 2

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -376,8 +376,8 @@ def get_miriad_times(filepaths, add_int_buffer=False):
     ------------
     filepaths : type=list, list of filepaths
 
-    add_int_buffer : type=bool, if True, extend start and stop times by a single integration duration
-        except for start of first file, and stop of last file.
+    add_int_buffer : type=bool, if True, extend stop times by a single integration duration
+        except for the list file in filepaths.
 
     Output: (file_starts, file_stops, int_times)
     -------
@@ -411,8 +411,6 @@ def get_miriad_times(filepaths, add_int_buffer=False):
         stop = start + (uv['ntimes']-1) * int_time
         # add integration buffer to beginning and end if desired
         if add_int_buffer:
-            if i != 0:
-                start -= int_time
             if i != (Nfiles-1):
                 stop += int_time
         # add half an integration to get center of integration

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -408,7 +408,7 @@ def get_miriad_times(filepaths, add_int_buffer=False):
         # get start and stop
         start = uv['lst']
         stop = start + (uv['ntimes']-1) * int_time
-        # add integration buffer to beginning and end if desired
+        # add integration buffer to end of file if desired
         if add_int_buffer:
             stop += int_time
         # add half an integration to get center of integration


### PR DESCRIPTION
There was a bug in the wrapping and unwrapping of LST arrays in `lstbin.lst_bin_files`, as well as the in the implementation of `lst_rephase` (nothing wrong with the `lst_rephase` code itself). Also made some updates to `utils.get_miriad_times` that helps fix these problems.
