### PR TITLE
fixed bug in abscal.apply_gains

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1030,7 +1030,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                     raise ValueError("can't run delay_cal when all_antenna_gains is True")
                 AC.delay_lincal(verbose=verbose, time_avg=True)
                 result_gains = merge_gains((AC.ant_dly_gain, AC.ant_dly_phi_gain))
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, result_gains, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(result_gains[k], np.bool)), result_gains.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, result_gains, cal_flags, gain_convention='divide')
                 gain_list.append(AC.ant_dly_gain)
                 gain_list.append(AC.ant_dly_phi_gain)
 
@@ -1040,12 +1041,14 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run avg_phs_cal when all_antenna_gains is True")
                 AC.phs_logcal(avg=True, verbose=verbose)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, cal_flags, gain_convention='divide')
                 gain_list.append(AC.ant_phi_gain)
 
             if delay_slope_cal:
                 AC.delay_slope_lincal(verbose=verbose, time_avg=True)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.dly_slope_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.dly_slope_gain[k], np.bool)), AC.dly_slope_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.dly_slope_gain, cal_flags, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
                 else:
@@ -1053,7 +1056,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
 
             if abs_amp_cal:
                 AC.abs_amp_logcal(verbose=verbose)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.abs_eta_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.abs_eta_gain[k], np.bool)), AC.abs_eta_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.abs_eta_gain, cal_flags, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_abs_eta_gain(total_gain_keys))
                 else:
@@ -1063,7 +1067,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if delay_slope_cal == False:
                     echo("it is recommended to run a delay_slope_cal before TT_phs_cal", verbose=verbose)
                 AC.TT_phs_logcal(verbose=verbose)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.TT_Phi_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.TT_Phi_gain[k], np.bool)), AC.TT_Phi_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.TT_Phi_gain, cal_flags, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_TT_Phi_gain(total_gain_keys, total_data_antpos))
                     gain_list.append(AC.custom_abs_psi_gain(total_gain_keys))
@@ -1075,7 +1080,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run gen_amp_cal when all_antenna_gains is True")
                 AC.amp_logcal(verbose=verbose)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_eta_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_eta_gain[k], np.bool)), AC.ant_eta_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_eta_gain, cal_flags, gain_convention='divide')
                 gain_list.append(AC.ant_eta_gain)
 
             if gen_phs_cal:
@@ -1084,7 +1090,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run gen_phs_cal when all_antenna_gains is True")
                 AC.phs_logcal(verbose=verbose)
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, gain_convention='divide')
+                cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, cal_flags, gain_convention='divide')
                 gain_list.append(AC.ant_phi_gain)
 
             # collate gains

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1029,7 +1029,8 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run delay_cal when all_antenna_gains is True")
                 AC.delay_lincal(verbose=verbose, time_avg=True)
-                AC.data = apply_gains(AC.data, (AC.ant_dly_gain, AC.ant_dly_phi_gain), gain_convention='divide')
+                result_gains = merge_gains((AC.ant_dly_gain, AC.ant_dly_phi_gain))
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, result_gains, gain_convention='divide')
                 gain_list.append(AC.ant_dly_gain)
                 gain_list.append(AC.ant_dly_phi_gain)
 
@@ -1039,12 +1040,12 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run avg_phs_cal when all_antenna_gains is True")
                 AC.phs_logcal(avg=True, verbose=verbose)
-                AC.data = apply_gains(AC.data, AC.ant_phi_gain, gain_convention='divide')
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, gain_convention='divide')
                 gain_list.append(AC.ant_phi_gain)
 
             if delay_slope_cal:
                 AC.delay_slope_lincal(verbose=verbose, time_avg=True)
-                AC.data = apply_gains(AC.data, AC.dly_slope_gain, gain_convention='divide')
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.dly_slope_gain, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
                 else:
@@ -1052,7 +1053,7 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
 
             if abs_amp_cal:
                 AC.abs_amp_logcal(verbose=verbose)
-                AC.data = apply_gains(AC.data, AC.abs_eta_gain, gain_convention='divide')
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.abs_eta_gain, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_abs_eta_gain(total_gain_keys))
                 else:
@@ -1062,7 +1063,7 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if delay_slope_cal == False:
                     echo("it is recommended to run a delay_slope_cal before TT_phs_cal", verbose=verbose)
                 AC.TT_phs_logcal(verbose=verbose)
-                AC.data = apply_gains(AC.data, AC.TT_Phi_gain)
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.TT_Phi_gain, gain_convention='divide')
                 if all_antenna_gains:
                     gain_list.append(AC.custom_TT_Phi_gain(total_gain_keys, total_data_antpos))
                     gain_list.append(AC.custom_abs_psi_gain(total_gain_keys))
@@ -1074,7 +1075,7 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run gen_amp_cal when all_antenna_gains is True")
                 AC.amp_logcal(verbose=verbose)
-                AC.data = apply_gains(AC.data, AC.ant_eta_gain, gain_convention='divide')
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_eta_gain, gain_convention='divide')
                 gain_list.append(AC.ant_eta_gain)
 
             if gen_phs_cal:
@@ -1083,7 +1084,7 @@ def abscal_run(data_files, model_files, calfits_infiles=None, verbose=True, over
                 if all_antenna_gains:
                     raise ValueError("can't run gen_phs_cal when all_antenna_gains is True")
                 AC.phs_logcal(verbose=verbose)
-                AC.data = apply_gains(AC.data, AC.ant_phi_gain, gain_convention='divide')
+                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, gain_convention='divide')
                 gain_list.append(AC.ant_phi_gain)
 
             # collate gains

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -14,7 +14,7 @@ import functools
 import numpy as np
 from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
-from hera_cal import omni, utils, firstcal, cal_formats, redcal, io
+from hera_cal import omni, utils, firstcal, cal_formats, redcal, io, apply_cal
 from hera_cal.datacontainer import DataContainer
 from scipy import signal
 from scipy import interpolate

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -614,7 +614,8 @@ def merge_gains(gains):
 
 def apply_gains(data, gains, gain_convention='divide'):
     """
-    apply gain solutions to data
+    Apply gain solutions to data. If a requested antenna doesn't
+    exist in gains, eliminate associated visibilities from new_data.
 
     Parameters:
     -----------
@@ -659,6 +660,10 @@ def apply_gains(data, gains, gain_convention='divide'):
         # get gain keys
         g1 = (k[0], k[-1][0])
         g2 = (k[1], k[-1][1])
+
+        # ensure keys are in gains
+        if g1 not in gains or g2 not in gains:
+            continue
 
         # form visbility gain product
         vis_gain = gains[g1] * np.conj(gains[g2])

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -25,9 +25,9 @@ def recalibrate_in_place(data, data_flags, new_gains, cal_flags, old_gains=None,
             'multiply' means V_true = gi gj* V_obs. Assumed to be the same for new_gains and old_gains.
     '''
     # get datatype of data_flags to determine if flags or wgts
-    if np.all([(df.dtype == np.bool) for df in data.values()]):
+    if np.all([(df.dtype == np.bool) for df in data_flags.values()]):
         bool_flags = True
-    elif np.all([(df.dtype == np.float) for df in data.values()]):
+    elif np.all([(df.dtype == np.float) for df in data_flags.values()]):
         bool_flags = False
         wgts = data_flags
         data_flags = DataContainer(dict(map(lambda k: (k, ~wgts[k].astype(np.bool)), wgts.keys())))

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -472,7 +472,12 @@ class Test_AbsCal:
         nt.assert_almost_equal(corr_data[(24, 25, 'xx')][0,0], (self.AC.data[(24,25,'xx')]/\
             self.AC.abs_eta_gain[(24,'x')]/self.AC.abs_eta_gain[(25,'x')]/self.AC.ant_eta_gain[(24,'x')]/\
             self.AC.ant_eta_gain[(25,'x')])[0,0])
- 
+        # test for missing data
+        gains = copy.deepcopy(self.AC.abs_eta_gain)
+        del gains[(24, 'x')]
+        corr_data = hc.abscal.apply_gains(self.AC.data, gains)
+        nt.assert_true((24, 25, 'xx') not in corr_data)
+
     def test_fill_dict_nans(self):
         data = copy.deepcopy(self.AC.data)
         wgts = copy.deepcopy(self.AC.wgts)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -79,6 +79,14 @@ class Test_Update_Cal(unittest.TestCase):
         with self.assertRaises(KeyError):
             ac.recalibrate_in_place(dc, flags, g_new, cal_flags, old_gains=g_old, gain_convention='blah')
 
+        # test w/ data weights
+        dc = DataContainer({(0,1,'xx'): deepcopy(vis)})
+        flags = DataContainer({(0,1,'xx'): deepcopy(f)})
+        wgts = DataContainer(dict(map(lambda k: (k, (~flags[k]).astype(np.float)), flags.keys())))
+        del g_new[(0, 'x')]
+        ac.recalibrate_in_place(dc, wgts, g_new, cal_flags, gain_convention='divide')
+        self.assertAlmostEqual(wgts[(0,1,'xx')].max(), 0.0)
+
     def test_apply_cal(self):
         fname = os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA")
         outname = os.path.join(DATA_PATH, "test_output/zen.2457698.40355.xx.HH.applied.uvcA")


### PR DESCRIPTION
if an antenna existed in `data`, but was missing in gains it errored out. Now it just eliminates those visibilities from output `new_data`. Tests included to check for this.