### PR TITLE
Update flagging when skip_wgt is triggered

### DIFF
--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -83,6 +83,15 @@ class Test_Delay_Filter(unittest.TestCase):
             self.assertEqual(dfil.filtered_residuals[k].shape, (60,64))
             self.assertEqual(dfil.CLEAN_models[k].shape, (60,64))
             self.assertTrue(dfil.info.has_key(k))
+
+        # test skip_wgt imposition of flags
+        wgts={k: np.ones_like(dfil.flags[k])}
+        wgts[k][0,0:50] = 0
+        dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-3, window='blackman-harris', skip_wgt=0.5, maxiter=100)
+        self.assertTrue(dfil.info[k][0]['skipped'])
+        np.testing.assert_array_equal(dfil.flags[k][0,:], np.ones_like(dfil.flags[k][0,:]))
+        np.testing.assert_array_equal(dfil.CLEAN_models[k][0,:], np.zeros_like(dfil.CLEAN_models[k][0,:]))
+        np.testing.assert_array_equal(dfil.filtered_residuals[k][0,:], dfil.data[k][0,:])
         
     def test_write_filtered_data(self):
         dfil = df.Delay_Filter()


### PR DESCRIPTION
This updates hera_cal use the uvtools.dspec info objects to figure out which times got skipped due to too many flags and then to completely flag the time for all frequencies.

See https://github.com/HERA-Team/uvtools/pull/19

