### PR TITLE
Fix key error in abscal bl_cut

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1420,7 +1420,7 @@ def cut_bls(datacontainer, bls, bl_cut):
     """
     cut_datacontainer = odict()
     for k in datacontainer.keys():
-        if np.linalg.norm(bls[k]) <= bl_cut:
+        if bls.has_key(k) and np.linalg.norm(bls[k]) <= bl_cut:
             cut_datacontainer[k] = datacontainer[k]
 
     assert len(cut_datacontainer) > 0, "no baselines were kept after baseline cut..."


### PR DESCRIPTION
Right now in `/lustre/aoc/projects/hera/H1C_IDR2/IDR2_1/2458140/zen.2458140.53575.xx.HH.uv.ABSCAL.yy.log` we have:

```
Traceback (most recent call last):
  File "/users/heramgr/anaconda2/envs/hera/bin/omni_abscal_run.py", line 4, in <module>
    __import__('pkg_resources').run_script('hera-cal==1.0', 'omni_abscal_run.py')
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/pkg_resources/__init__.py", line 750, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1527, in run_script
    exec(code, namespace, namespace)
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/hera_cal-1.0-py2.7.egg/EGG-INFO/scripts/omni_abscal_run.py", line 24, in <
module>
    abscal.abscal_run(args.data_file, args.model_files, verbose=verbose, history=history, **kwargs)
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/hera_cal-1.0-py2.7.egg/hera_cal/abscal.py", line 1213, in abscal_run
    AC = AbsCal(new_model, data, wgts=wgts, refant=refant, antpos=antpos, freqs=data_freqs, bl_cut=bl_cut, bl_taper_fwhm=bl_taper_fwhm)
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/hera_cal-1.0-py2.7.egg/hera_cal/abscal.py", line 218, in __init__
    _data = cut_bls(self.data, self.bls, bl_cut)
  File "/users/heramgr/anaconda2/envs/hera/lib/python2.7/site-packages/hera_cal-1.0-py2.7.egg/hera_cal/abscal.py", line 1423, in cut_bls
    if np.linalg.norm(bls[k]) <= bl_cut:
KeyError: (0, 99, 'yy')
```
This is because the data has keys that are not in self.bls (i.e. that include flagged antennas). This fixes that problem.