### PR TITLE
added ability to overwrite vis_units attribute

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -70,7 +70,7 @@ def recalibrate_in_place(data, data_flags, new_gains, cal_flags, old_gains=None,
 
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flags_npz=None, 
               flag_nchan_low=0, flag_nchan_high=0, filetype='miriad', gain_convention='divide',  
-              add_to_history='', clobber=False, **kwargs):
+              add_to_history='', clobber=False, vis_units=None, **kwargs):
     '''Update the calibration solution and flags on the data, writing to a new file. Takes out old calibration
     and puts in new calibration solution, including its flags. Also enables appending to history.
 
@@ -90,6 +90,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         add_to_history: appends a string to the history of the output file. This will preceed combined histories
             of flags_npz (if applicable), new_calibration and, old_calibration (if applicable).
         clobber: if True, overwrites existing file at outfilename
+        vis_units: str, change vis_units attribute to desired format if not None. See pyuvdata.UVData for options.
         kwargs: dictionary mapping updated attributes to their new values.
             See pyuvdata.UVData documentation for more info.
     '''
@@ -131,6 +132,10 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         add_to_history += ' OLD_CALFITS_HISTORY: ' + old_uvc.history + '\n'
         old_calibration, _ = io.load_cal(old_uvc)
 
+    # parse vis_units
+    if vis_units is not None:
+        kwargs['vis_units'] = vis_units
+
     recalibrate_in_place(data, data_flags, new_gains, new_flags, old_gains=old_calibration, gain_convention=gain_convention)
     io.update_vis(data_infilename, data_outfilename, filetype_in=filetype, filetype_out=filetype, data=data, 
                   flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs)
@@ -150,4 +155,5 @@ def apply_cal_argparser():
     a.add_argument("--gain_convention", type=str, default='divide', 
                   help="'divide' means V_obs = gi gj* V_true, 'multiply' means V_true = gi gj* V_obs.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
-    return a.parse_args()
+    a.add_argument("--vis_units", defualt=None, type=str, help="String to insert into vis_units attribute of output visibility file.")
+    return a

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -70,7 +70,7 @@ def recalibrate_in_place(data, data_flags, new_gains, cal_flags, old_gains=None,
 
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flags_npz=None, 
               flag_nchan_low=0, flag_nchan_high=0, filetype='miriad', gain_convention='divide',  
-              add_to_history='', clobber=False, vis_units=None, **kwargs):
+              add_to_history='', clobber=False, **kwargs):
     '''Update the calibration solution and flags on the data, writing to a new file. Takes out old calibration
     and puts in new calibration solution, including its flags. Also enables appending to history.
 
@@ -90,7 +90,6 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         add_to_history: appends a string to the history of the output file. This will preceed combined histories
             of flags_npz (if applicable), new_calibration and, old_calibration (if applicable).
         clobber: if True, overwrites existing file at outfilename
-        vis_units: str, change vis_units attribute to desired format if not None. See pyuvdata.UVData for options.
         kwargs: dictionary mapping updated attributes to their new values.
             See pyuvdata.UVData documentation for more info.
     '''
@@ -131,10 +130,6 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             old_uvc.read_calfits(old_calibration)
         add_to_history += ' OLD_CALFITS_HISTORY: ' + old_uvc.history + '\n'
         old_calibration, _ = io.load_cal(old_uvc)
-
-    # parse vis_units
-    if vis_units is not None:
-        kwargs['vis_units'] = vis_units
 
     recalibrate_in_place(data, data_flags, new_gains, new_flags, old_gains=old_calibration, gain_convention=gain_convention)
     io.update_vis(data_infilename, data_outfilename, filetype_in=filetype, filetype_out=filetype, data=data, 

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -150,5 +150,5 @@ def apply_cal_argparser():
     a.add_argument("--gain_convention", type=str, default='divide', 
                   help="'divide' means V_obs = gi gj* V_true, 'multiply' means V_true = gi gj* V_obs.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
-    a.add_argument("--vis_units", defualt=None, type=str, help="String to insert into vis_units attribute of output visibility file.")
+    a.add_argument("--vis_units", default=None, type=str, help="String to insert into vis_units attribute of output visibility file.")
     return a

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -84,7 +84,7 @@ class Test_Update_Cal(unittest.TestCase):
         old_cal = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.HH.uvcA.omni.calfits")
         new_cal = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.HH.uvcA.omni.calfits")
         flags_npz = os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA.fake_flags.npz")
-        
+
         uvd = UVData()
         uvd.read_miriad(fname)
         uvd.flag_array = np.logical_or(uvd.flag_array, np.load(flags_npz)['flag_array'])
@@ -94,8 +94,11 @@ class Test_Update_Cal(unittest.TestCase):
         uvc_old.read_calfits(old_cal)
         uvc_old.gain_array *= (3.0 + 4.0j)
 
-        ac.apply_cal(fname, outname, new_cal, old_calibration=uvc_old, gain_convention = 'divide', 
-                     flags_npz = flags_npz, filetype = 'miriad', clobber = True)
+        ac.apply_cal(fname, outname, new_cal, old_calibration=uvc_old, gain_convention='divide', 
+                     flags_npz=flags_npz, filetype='miriad', clobber=True, vis_units='Jy')
+        u = UVData()
+        u.read_miriad(outname)
+        self.assertEqual(u.vis_units, 'Jy')
         new_data, new_flags = io.load_vis(outname)
         for k in new_data.keys():
             for i in range(new_data[k].shape[0]):
@@ -106,8 +109,8 @@ class Test_Update_Cal(unittest.TestCase):
                         self.assertTrue(new_flags[k][i,j])
 
         # test band edge flagging
-        ac.apply_cal(fname, outname, new_cal, old_calibration=uvc_old, gain_convention = 'divide', 
-             flag_nchan_low = 450, flag_nchan_high = 400, filetype = 'miriad', clobber = True)
+        ac.apply_cal(fname, outname, new_cal, old_calibration=uvc_old, gain_convention='divide', 
+             flag_nchan_low=450, flag_nchan_high=400, filetype='miriad', clobber=True)
         new_data, new_flags = io.load_vis(outname)
         for k in new_data.keys():
             for i in range(new_data[k].shape[0]):
@@ -116,18 +119,18 @@ class Test_Update_Cal(unittest.TestCase):
                         self.assertAlmostEqual(new_data[k][i,j] / 25.0, data[k][i,j],4)
                     if j < 450 or j > 623:
                         self.assertTrue(new_flags[k][i,j])
-                    
+
         with self.assertRaises(ValueError):
             ac.apply_cal(fname, outname, None)
         shutil.rmtree(outname)
 
     def test_apply_cal_argparser(self):
         sys.argv = [sys.argv[0], 'a', 'b', '--new_cal', 'd']
-        args = ac.apply_cal_argparser()
+        a = ac.apply_cal_argparser()
+        args = a.parse_args()
         self.assertEqual(args.infile, 'a')
         self.assertEqual(args.outfile, 'b')
         self.assertEqual(args.new_cal, ['d'])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -8,4 +8,5 @@ a = ac.apply_cal_argparser()
 args = a.parse_args()
 ac.apply_cal(args.infile, args.outfile, args.new_cal, old_calibration=args.old_cal, flags_npz=args.flags_npz, 
              flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, filetype=args.filetype, 
-             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber)
+             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber,
+             vis_units=args.vis_units)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -8,4 +8,4 @@ a = ac.apply_cal_argparser()
 args = a.parse_args()
 ac.apply_cal(args.infile, args.outfile, args.new_cal, old_calibration=args.old_cal, flags_npz=args.flags_npz, 
              flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, filetype=args.filetype, 
-             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber, **args.kwargs)
+             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -4,7 +4,8 @@ import argparse
 from hera_cal import apply_cal as ac
 import sys
 
-args = ac.apply_cal_argparser()
+a = ac.apply_cal_argparser()
+args = a.parse_args()
 ac.apply_cal(args.infile, args.outfile, args.new_cal, old_calibration=args.old_cal, flags_npz=args.flags_npz, 
              flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, filetype=args.filetype, 
-             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber)
+             gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber, **args.kwargs)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -6,7 +6,12 @@ import sys
 
 a = ac.apply_cal_argparser()
 args = a.parse_args()
+
+kwargs = {}
+if args.vis_units is not None:
+    kwargs['vis_units'] = args.vis_units
+
 ac.apply_cal(args.infile, args.outfile, args.new_cal, old_calibration=args.old_cal, flags_npz=args.flags_npz, 
              flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, filetype=args.filetype, 
              gain_convention=args.gain_convention, add_to_history = ' '.join(sys.argv), clobber=args.clobber,
-             vis_units=args.vis_units)
+             **kwargs)


### PR DESCRIPTION
 of output visibility file when using `apply_cal`. Also, the `apply_cal_argparser` shouldn't parse the arguments in the function, but should return the un-parsed object, which is parsed at the script level. This is necessary if one is using an argparser interactively, one can feed the object an empty list to instantiate the argument namespace with its default values (thanks to @adampbeardsley for that tip).