### PR TITLE
Fix fft_dly

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -299,7 +299,7 @@ class AbsCal(object):
             self._ant_phi = odict(map(lambda k: (k, np.ones_like(self._ant_phi[k]) * np.angle(np.median(np.real(np.exp(1j * self._ant_phi[k]))) + 1j * np.median(np.imag(np.exp(1j * self._ant_phi[k]))))), flatten(self._gain_keys)))
             self._ant_phi_arr = np.moveaxis(map(lambda pk: map(lambda k: self._ant_phi[k], pk), self._gain_keys), 0, -1)
 
-    def delay_lincal(self, medfilt=True, kernel=(1, 11), time_ax=0, freq_ax=1, verbose=True, time_avg=False,
+    def delay_lincal(self, medfilt=True, kernel=(1, 11), verbose=True, time_avg=False,
                      solve_offsets=True, window=None, edge_cut=0):
         """
         Solve for per-antenna delay according to the equation
@@ -346,24 +346,24 @@ class AbsCal(object):
 
         # run delay_lincal
         fit = delay_lincal(model, data, wgts=wgts, refant=self.refant, solve_offsets=solve_offsets,
-                           medfilt=medfilt, df=df, kernel=kernel, verbose=verbose, time_ax=time_ax, freq_ax=freq_ax,
+                           medfilt=medfilt, df=df, kernel=kernel, verbose=verbose, 
                            window=window, edge_cut=edge_cut)
 
         # time average
         if time_avg:
             k = flatten(self._gain_keys)[0]
-            Ntimes = fit["tau_{}_{}".format(k[0], k[1])].shape[time_ax]
+            Ntimes = fit["tau_{}_{}".format(k[0], k[1])].shape[0]
             for i, k in enumerate(flatten(self._gain_keys)):
                 tau_key = "tau_{}_{}".format(k[0], k[1])
-                tau_avg = np.moveaxis(np.median(fit[tau_key], axis=time_ax)[np.newaxis], 0, time_ax)
-                fit[tau_key] = np.repeat(tau_avg, Ntimes, axis=time_ax)
+                tau_avg = np.moveaxis(np.median(fit[tau_key], axis=0)[np.newaxis], 0, 0)
+                fit[tau_key] = np.repeat(tau_avg, Ntimes, axis=0)
                 if solve_offsets:
                     phi_key = "phi_{}_{}".format(k[0], k[1])
                     gain = np.exp(1j * fit[phi_key])
-                    real_avg = np.median(np.real(gain), axis=time_ax)
-                    imag_avg = np.median(np.imag(gain), axis=time_ax)
-                    phi_avg = np.moveaxis(np.angle(real_avg + 1j * imag_avg)[np.newaxis], 0, time_ax)
-                    fit[phi_key] = np.repeat(phi_avg, Ntimes, axis=time_ax)
+                    real_avg = np.median(np.real(gain), axis=0)
+                    imag_avg = np.median(np.imag(gain), axis=0)
+                    phi_avg = np.moveaxis(np.angle(real_avg + 1j * imag_avg)[np.newaxis], 0, 0)
+                    fit[phi_key] = np.repeat(phi_avg, Ntimes, axis=0)
 
         # form result
         self._ant_dly = odict(map(lambda k: (k, copy.copy(fit["tau_{}_{}".format(k[0], k[1])])), flatten(self._gain_keys)))
@@ -373,7 +373,7 @@ class AbsCal(object):
             self._ant_dly_phi = odict(map(lambda k: (k, copy.copy(fit["phi_{}_{}".format(k[0], k[1])])), flatten(self._gain_keys)))
             self._ant_dly_phi_arr = np.moveaxis(map(lambda pk: map(lambda k: self._ant_dly_phi[k], pk), self._gain_keys), 0, -1)
 
-    def delay_slope_lincal(self, medfilt=True, kernel=(1, 15), time_ax=0, freq_ax=1, verbose=True, time_avg=False,
+    def delay_slope_lincal(self, medfilt=True, kernel=(1, 15), verbose=True, time_avg=False,
                            four_pol=False, window=None, edge_cut=0):
         """
         Solve for an array-wide delay slope (a subset of the omnical degeneracies) by calling
@@ -384,10 +384,6 @@ class AbsCal(object):
         medfilt : boolean, if True median filter data before fft
 
         kernel : size of median filter across (time, freq) axes, type=(int, int)
-
-        time_ax : the time axis index of the data
-
-        freq_ax : the freq axis index of the data
 
         verbose : type=boolean, if True print feedback to stdout
 
@@ -424,7 +420,7 @@ class AbsCal(object):
 
         # run delay_slope_lincal
         fit = delay_slope_lincal(model, data, antpos, wgts=wgts, refant=self.refant, medfilt=medfilt, df=df,
-                                 kernel=kernel, verbose=verbose, time_ax=time_ax, freq_ax=freq_ax, four_pol=four_pol,
+                                 kernel=kernel, verbose=verbose, four_pol=four_pol,
                                  window=window, edge_cut=edge_cut)
 
         # separate pols if four_pol
@@ -438,14 +434,14 @@ class AbsCal(object):
         # time average
         if time_avg:
             k = flatten(self._gain_keys)[0]
-            Ntimes = fit["T_ew_{}".format(k[1])].shape[time_ax]
+            Ntimes = fit["T_ew_{}".format(k[1])].shape[0]
             for i, k in enumerate(flatten(self._gain_keys)):
                 ew_key = "T_ew_{}".format(k[1])
                 ns_key = "T_ns_{}".format(k[1])
-                ew_avg = np.moveaxis(np.median(fit[ew_key], axis=time_ax)[np.newaxis], 0, time_ax)
-                ns_avg = np.moveaxis(np.median(fit[ns_key], axis=time_ax)[np.newaxis], 0, time_ax)
-                fit[ew_key] = np.repeat(ew_avg, Ntimes, axis=time_ax)
-                fit[ns_key] = np.repeat(ns_avg, Ntimes, axis=time_ax)
+                ew_avg = np.moveaxis(np.median(fit[ew_key], axis=0)[np.newaxis], 0, 0)
+                ns_avg = np.moveaxis(np.median(fit[ns_key], axis=0)[np.newaxis], 0, 0)
+                fit[ew_key] = np.repeat(ew_avg, Ntimes, axis=0)
+                fit[ns_key] = np.repeat(ns_avg, Ntimes, axis=0)
 
         # form result
         self._dly_slope = odict(map(lambda k: (k, copy.copy(np.array([fit["T_ew_{}".format(k[1])], fit["T_ns_{}".format(k[1])]]))), flatten(self._gain_keys)))

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -1028,7 +1028,7 @@ def fft_dly(data, df, wgts=None, window=None, medfilt=False, kernel=(1, 11),
 
     # fft w/ window and find argmax
     vfft = np.fft.fft(data * win * wgts, axis=1)
-    amp = np.abs(np.fft.fftshift(vfft))
+    amp = np.abs(np.fft.fftshift(vfft, axes=1))
     argmaxes = np.argmax(amp, axis=1)
     fftfreqs = np.fft.fftshift(np.fft.fftfreq(Nfreqs, df))
     dlys, peak_shifts = np.zeros((Ntimes, 1)), np.zeros((Ntimes, 1))

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -524,7 +524,7 @@ def delay_lincal(model, data, wgts=None, refant=None, df=9.765625e4, solve_offse
 
 
 def delay_slope_lincal(model, data, antpos, wgts=None, refant=None, df=9.765625e4, medfilt=True,
-                    kernel=(1, 5), verbose=True, four_pol=False, window=None, edge_cut=0):
+                       kernel=(1, 5), verbose=True, four_pol=False, window=None, edge_cut=0):
     """
     Solve for an array-wide delay slope according to the equation
 
@@ -610,7 +610,7 @@ def delay_slope_lincal(model, data, antpos, wgts=None, refant=None, df=9.765625e
 
         # get delays
         dly, _ = fft_dly(ratio, df, wgts=wgts[k], medfilt=medfilt, kernel=kernel,
-                              window=window, edge_cut=edge_cut)
+                         window=window, edge_cut=edge_cut)
 
         # set nans to zero
         rwgts = np.nanmean(wgts[k], axis=1, keepdims=True)
@@ -1035,8 +1035,8 @@ def fft_dly(data, df, wgts=None, window=None, medfilt=False, kernel=(1, 11),
     # use parabolic peak interpolation: https://ccrma.stanford.edu/~jos/sasp/Quadratic_Interpolation_Spectral_Peaks.html
     for i in range(Ntimes):
         a, b, c, = amp[i][(argmaxes[i] - 1) % len(amp[i])], amp[i][argmaxes[i]], amp[i][(argmaxes[i] + 1) % len(amp[i])]
-        if (np.abs(a - 2*b + c) > 0) and (np.abs(a - c) > 0):
-            peak_shifts[i] = .5 * (a - c) / (a - 2*b + c)
+        if (np.abs(a - 2 * b + c) > 0) and (np.abs(a - c) > 0):
+            peak_shifts[i] = .5 * (a - c) / (a - 2 * b + c)
         else:
             peak_shifts[i] = 0
         # use peak shift to linearly interpolate to get appropriate delay

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -41,7 +41,7 @@ def freq_filter(gains, wgts, freqs, filter_scale=10.0, tol=1e-09, window='tukey'
     '''
     sdf = np.median(np.diff(freqs)) / 1e9  # in GHz
     filter_size = (filter_scale / 1e3)**-1  # Puts it in ns
-    (dlys, phi) = fft_dly(gains, wgts, df=sdf * 1e9, medfilt=False)  # delays are in seconds
+    (dlys, phi) = fft_dly(gains, sdf * 1e9, wgts, medfilt=False, solve_phase=False)  # delays are in seconds
     rephasor = np.exp(-2.0j * np.pi * np.outer(dlys, freqs))
     filtered, res, info = uvtools.dspec.high_pass_fourier_filter(gains * rephasor, wgts, filter_size, sdf, tol=tol, window=window,
                                                                  skip_wgt=skip_wgt, maxiter=maxiter, **win_kwargs)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -548,28 +548,28 @@ class Test_AbsCal:
         hc.abscal.fill_dict_nans(vis, nan_fill=0.0, inf_fill=0.0, array=True)
         df = np.median(np.diff(self.AC.freqs))
         # basic execution
-        dly, offset = hc.abscal.fft_dly(vis, df=df, medfilt=False, solve_phase=False)
+        dly, offset = hc.abscal.fft_dly(vis, df, medfilt=False, solve_phase=False)
         nt.assert_equal(dly.shape, (60, 1))
         nt.assert_equal(offset, None)
         # median filtering
-        dly, offset = hc.abscal.fft_dly(vis, df=df, medfilt=True, solve_phase=False)
+        dly, offset = hc.abscal.fft_dly(vis, df, medfilt=True, solve_phase=False)
         nt.assert_equal(dly.shape, (60, 1))
         nt.assert_equal(offset, None)
         # solve phase
-        dly, offset = hc.abscal.fft_dly(vis, df=df, medfilt=True, solve_phase=True)
+        dly, offset = hc.abscal.fft_dly(vis, df, medfilt=True, solve_phase=True)
         nt.assert_equal(dly.shape, (60, 1))
         nt.assert_equal(offset.shape, (60, 1))
         # test windows and edgecut
-        dly, offset = hc.abscal.fft_dly(vis, df=df, medfilt=False, solve_phase=False, edge_cut=2, window='hann')
-        dly, offset = hc.abscal.fft_dly(vis, df=df, medfilt=False, solve_phase=False, window='blackmanharris')
-        nt.assert_raises(ValueError, hc.abscal.fft_dly, vis, window='foo')
-        nt.assert_raises(AssertionError, hc.abscal.fft_dly, vis, edge_cut=1000)
+        dly, offset = hc.abscal.fft_dly(vis, df, medfilt=False, solve_phase=False, edge_cut=2, window='hann')
+        dly, offset = hc.abscal.fft_dly(vis, df, medfilt=False, solve_phase=False, window='blackmanharris')
+        nt.assert_raises(ValueError, hc.abscal.fft_dly, vis, df, window='foo')
+        nt.assert_raises(AssertionError, hc.abscal.fft_dly, vis, df, edge_cut=1000)
         # test mock data
         tau = np.array([1.5e-8]).reshape(1, -1)  # 15 nanoseconds
         f = np.linspace(0, 100e6, 1024)
         df = np.median(np.diff(f))
         r = np.exp(1j * 2 * np.pi * f * tau)
-        dly, offset = hc.abscal.fft_dly(r, df=df, medfilt=True, kernel=(1, 5))
+        dly, offset = hc.abscal.fft_dly(r, df, medfilt=True, kernel=(1, 5), solve_phase=False)
         nt.assert_almost_equal(float(dly), 1.5e-8, delta=1e-9)
 
     def test_abscal_arg_parser(self):
@@ -644,7 +644,7 @@ class Test_AbsCal:
         uvc = UVCal()
         uvc.read_calfits('./ex.calfits')
         nt.assert_true(uvc.total_quality_array is not None)
-        nt.assert_almost_equal(uvc.quality_array[1, 0, 32, 0, 0], 6378.8367138680978, places=4)
+        nt.assert_almost_equal(uvc.quality_array[1, 0, 32, 0, 0], 6378.8367138680978, places=3)
         nt.assert_true(uvc.flag_array[0].min())
         nt.assert_true(len(uvc.history) > 1000)
         # assert refant phase is zero


### PR DESCRIPTION
While fixing #349, I decided to rewrite a large part of fft_dly.

1. I fixed the issue in #349 where delay units weren't being corrected
2. I used a more standard, robust, and readable approach to quadratic interpolation
3. I removed the ability to specify the time and frequency dimension in order to make the code more readable and shorter.
4. I condensed and simplified window code.
5. I made medfilt and phases default false, since they drastically slow down the code.

In the process, I noticed that the unit tests really don't cover much of the functionality of fft_dly... only that it actually produces an output. Namely, there's no test that the phase offsets are right. There's no test that the windowing or the edge_cut works. And there's no test that shows that the median filter works. I'm going to add this all as to #262.