### PR TITLE
Update redcal apply to remove duplicated functionality

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1253,7 +1253,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             AC.delay_lincal(verbose=verbose, time_avg=False, window=window, edge_cut=edge_cut)
             result_gains = merge_gains((AC.ant_dly_gain, AC.ant_dly_phi_gain))
             cal_flags = odict(map(lambda k: (k, np.zeros_like(result_gains[k], np.bool)), result_gains.keys()))
-            apply_cal.calibrate_in_place(AC.data, result_gains, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, result_gains, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             merged_gains.append(AC.ant_dly_gain)
             merged_gains.append(AC.ant_dly_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
@@ -1265,14 +1265,14 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run avg_phs_cal when all_antenna_gains is True")
             AC.phs_logcal(avg=True, verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             merged_gains.append(AC.ant_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
 
         if avg_dly_slope_cal:
             AC.delay_slope_lincal(verbose=verbose, time_avg=True, window=window, edge_cut=edge_cut)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.dly_slope_gain[k], np.bool)), AC.dly_slope_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             if all_antenna_gains:
                 merged_gains.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
             else:
@@ -1282,7 +1282,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
         if delay_slope_cal:
             AC.delay_slope_lincal(verbose=verbose, time_avg=False, window=window, edge_cut=edge_cut)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.dly_slope_gain[k], np.bool)), AC.dly_slope_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             if all_antenna_gains:
                 merged_gains.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
             else:
@@ -1295,7 +1295,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             for i in range(phs_max_iter):
                 AC.global_phase_slope_logcal(tol=tol, edge_cut=edge_cut, verbose=verbose)
                 cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.phs_slope_gain[k], np.bool)), AC.phs_slope_gain.keys()))
-                apply_cal.calibrate_in_place(AC.data, AC.phs_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
+                apply_cal.calibrate_in_place(AC.data, AC.phs_slope_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
                 if all_antenna_gains:
                     merged_gains.append(AC.custom_phs_slope_gain(total_gain_keys, total_data_antpos))
                 else:
@@ -1316,7 +1316,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
         if abs_amp_cal:
             AC.abs_amp_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.abs_eta_gain[k], np.bool)), AC.abs_eta_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.abs_eta_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.abs_eta_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             if all_antenna_gains:
                 merged_gains.append(AC.custom_abs_eta_gain(total_gain_keys))
             else:
@@ -1329,7 +1329,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             for i in range(phs_max_iter):
                 AC.TT_phs_logcal(verbose=verbose)
                 cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.TT_Phi_gain[k], np.bool)), AC.TT_Phi_gain.keys()))
-                apply_cal.calibrate_in_place(AC.data, AC.TT_Phi_gain, AC.wgts, cal_flags, gain_convention='divide')
+                apply_cal.calibrate_in_place(AC.data, AC.TT_Phi_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
                 if all_antenna_gains:
                     merged_gains.append(AC.custom_TT_Phi_gain(total_gain_keys, total_data_antpos))
                     merged_gains.append(AC.custom_abs_psi_gain(total_gain_keys))
@@ -1354,7 +1354,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run gen_amp_cal when all_antenna_gains is True")
             AC.amp_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_eta_gain[k], np.bool)), AC.ant_eta_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.ant_eta_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_eta_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             merged_gains.append(AC.ant_eta_gain)
             merged_gains = [merge_gains(merged_gains)]
 
@@ -1365,7 +1365,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run gen_phs_cal when all_antenna_gains is True")
             AC.phs_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
-            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
             merged_gains.append(AC.ant_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1253,7 +1253,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             AC.delay_lincal(verbose=verbose, time_avg=False, window=window, edge_cut=edge_cut)
             result_gains = merge_gains((AC.ant_dly_gain, AC.ant_dly_phi_gain))
             cal_flags = odict(map(lambda k: (k, np.zeros_like(result_gains[k], np.bool)), result_gains.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, result_gains, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, result_gains, AC.wgts, cal_flags, gain_convention='divide')
             merged_gains.append(AC.ant_dly_gain)
             merged_gains.append(AC.ant_dly_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
@@ -1265,14 +1265,14 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run avg_phs_cal when all_antenna_gains is True")
             AC.phs_logcal(avg=True, verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide')
             merged_gains.append(AC.ant_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
 
         if avg_dly_slope_cal:
             AC.delay_slope_lincal(verbose=verbose, time_avg=True, window=window, edge_cut=edge_cut)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.dly_slope_gain[k], np.bool)), AC.dly_slope_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.dly_slope_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
             if all_antenna_gains:
                 merged_gains.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
             else:
@@ -1282,7 +1282,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
         if delay_slope_cal:
             AC.delay_slope_lincal(verbose=verbose, time_avg=False, window=window, edge_cut=edge_cut)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.dly_slope_gain[k], np.bool)), AC.dly_slope_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.dly_slope_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.dly_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
             if all_antenna_gains:
                 merged_gains.append(AC.custom_dly_slope_gain(total_gain_keys, total_data_antpos))
             else:
@@ -1295,7 +1295,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             for i in range(phs_max_iter):
                 AC.global_phase_slope_logcal(tol=tol, edge_cut=edge_cut, verbose=verbose)
                 cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.phs_slope_gain[k], np.bool)), AC.phs_slope_gain.keys()))
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.phs_slope_gain, cal_flags, gain_convention='divide')
+                apply_cal.calibrate_in_place(AC.data, AC.phs_slope_gain, AC.wgts, cal_flags, gain_convention='divide')
                 if all_antenna_gains:
                     merged_gains.append(AC.custom_phs_slope_gain(total_gain_keys, total_data_antpos))
                 else:
@@ -1316,7 +1316,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
         if abs_amp_cal:
             AC.abs_amp_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.abs_eta_gain[k], np.bool)), AC.abs_eta_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.abs_eta_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.abs_eta_gain, AC.wgts, cal_flags, gain_convention='divide')
             if all_antenna_gains:
                 merged_gains.append(AC.custom_abs_eta_gain(total_gain_keys))
             else:
@@ -1329,7 +1329,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
             for i in range(phs_max_iter):
                 AC.TT_phs_logcal(verbose=verbose)
                 cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.TT_Phi_gain[k], np.bool)), AC.TT_Phi_gain.keys()))
-                apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.TT_Phi_gain, cal_flags, gain_convention='divide')
+                apply_cal.calibrate_in_place(AC.data, AC.TT_Phi_gain, AC.wgts, cal_flags, gain_convention='divide')
                 if all_antenna_gains:
                     merged_gains.append(AC.custom_TT_Phi_gain(total_gain_keys, total_data_antpos))
                     merged_gains.append(AC.custom_abs_psi_gain(total_gain_keys))
@@ -1354,7 +1354,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run gen_amp_cal when all_antenna_gains is True")
             AC.amp_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_eta_gain[k], np.bool)), AC.ant_eta_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_eta_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_eta_gain, AC.wgts, cal_flags, gain_convention='divide')
             merged_gains.append(AC.ant_eta_gain)
             merged_gains = [merge_gains(merged_gains)]
 
@@ -1365,7 +1365,7 @@ def abscal_run(data_file, model_files, refant=None, calfits_infile=None, verbose
                 raise ValueError("can't run gen_phs_cal when all_antenna_gains is True")
             AC.phs_logcal(verbose=verbose)
             cal_flags = odict(map(lambda k: (k, np.zeros_like(AC.ant_phi_gain[k], np.bool)), AC.ant_phi_gain.keys()))
-            apply_cal.recalibrate_in_place(AC.data, AC.wgts, AC.ant_phi_gain, cal_flags, gain_convention='divide')
+            apply_cal.calibrate_in_place(AC.data, AC.ant_phi_gain, AC.wgts, cal_flags, gain_convention='divide')
             merged_gains.append(AC.ant_phi_gain)
             merged_gains = [merge_gains(merged_gains)]
 

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -59,31 +59,32 @@ def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gai
             except KeyError:
                 flag_all = True
 
-        # update data_flags in the case where flags are booleans, flag all if cal_flags are missing
-        if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):
-            try:
-                data_flags[(i, j, pol)] += cal_flags[(i, ap1)]
-                data_flags[(i, j, pol)] += cal_flags[(j, ap2)]
-            except KeyError:
-                flag_all = True
-        # update data_flags in the case where flags are weights, flag all if cal_flags are missing
-        elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):
-            try:
-                data_flags[(i, j, pol)] *= (~cal_flags[(i, ap1)]).astype(np.float)
-                data_flags[(i, j, pol)] *= (~cal_flags[(j, ap2)]).astype(np.float)
-            except KeyError:
-                flag_all = True
-        else:
-            raise ValueError("didn't recognize dtype of data_flags")
-
-        # if the flag object is given, update it for this baseline to be totally flagged
-        if flag_all and (data_flags is not None):
-            if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):  # boolean flags
-                data_flags[(i, j, pol)] = np.ones_like(data[(i, j, pol)], dtype=np.bool)
-            elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):  # weights
-                data_flags[(i, j, pol)] = np.zeros_like(data[(i, j, pol)], dtype=np.float)
+        if data_flags is not None:
+            # update data_flags in the case where flags are booleans, flag all if cal_flags are missing
+            if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):
+                try:
+                    data_flags[(i, j, pol)] += cal_flags[(i, ap1)]
+                    data_flags[(i, j, pol)] += cal_flags[(j, ap2)]
+                except KeyError:
+                    flag_all = True
+            # update data_flags in the case where flags are weights, flag all if cal_flags are missing
+            elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):
+                try:
+                    data_flags[(i, j, pol)] *= (~cal_flags[(i, ap1)]).astype(np.float)
+                    data_flags[(i, j, pol)] *= (~cal_flags[(j, ap2)]).astype(np.float)
+                except KeyError:
+                    flag_all = True
             else:
                 raise ValueError("didn't recognize dtype of data_flags")
+
+            # if the flag object is given, update it for this baseline to be totally flagged
+            if flag_all:
+                if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):  # boolean flags
+                    data_flags[(i, j, pol)] = np.ones_like(data[(i, j, pol)], dtype=np.bool)
+                elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):  # weights
+                    data_flags[(i, j, pol)] = np.zeros_like(data[(i, j, pol)], dtype=np.float)
+                else:
+                    raise ValueError("didn't recognize dtype of data_flags")
 
 
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flags_npz=None,

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -13,68 +13,77 @@ from hera_cal.datacontainer import DataContainer
 from hera_cal import utils
 
 
-def recalibrate_in_place(data, data_flags, new_gains, cal_flags, old_gains=None, gain_convention='divide'):
-    '''Update data and data_flags in place, taking out old calibration solutions, putting in
-    new calibration solutions, and updating flags from those calibration solutions. Previously
-    flagged data is modified, but left flagged. Missing antennas from either the new gains or (if it's not None),
-    the old gains are automatically flagged in the data's visibilities that involves those antennas.
+def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gains=None, gain_convention='divide'):
+    '''Update data and data_flags in place, taking out old calibration solutions, putting in new calibration
+    solutions, and updating flags from those calibration solutions. Previously flagged data is modified, but
+    left flagged. Missing antennas from either the new gains, the cal_flags, or (if it's not None) the old
+    gains are automatically flagged in the data's visibilities that involves those antennas.
 
     Arguments:
         data: DataContainer containing baseline-pol complex visibility data. This is modified in place.
-        data_flags: DataContainer containing data flags. This is modified in place. Can also be fed as a
-            data weights dictionary with float dtype. In this case, wgts of 0 are treated as flagged
-            data and non-zero wgts are unflagged data.
         new_gains: Dictionary of complex calibration gains to apply with keys like (1,'x')
+        data_flags: DataContainer containing data flags. This is modified in place if its not None. Can 
+            also be fed as a data weights dictionary with np.float dtype. In this case, wgts of 0 are
+            treated as flagged data and non-zero wgts are unflagged data.
         cal_flags: Dictionary with keys like (1,'x') of per-antenna boolean flags to update data_flags
-            if either antenna in a visibility is flagged.
+            if either antenna in a visibility is flagged. Any missing antennas are assumed to be totally
+            flagged, so leaving this as None will result in input data_flags becoming totally flagged.
         old_gains: Dictionary of complex calibration gains to take out with keys like (1,'x').
             Default of None implies that the data is raw (i.e. uncalibrated).
         gain_convention: str, either 'divide' or 'multiply'. 'divide' means V_obs = gi gj* V_true,
             'multiply' means V_true = gi gj* V_obs. Assumed to be the same for new_gains and old_gains.
     '''
-    # get datatype of data_flags to determine if flags or wgts
-    if np.all([(df.dtype == np.bool) for df in data_flags.values()]):
-        bool_flags = True
-    elif np.all([(df.dtype == np.float) for df in data_flags.values()]):
-        bool_flags = False
-        wgts = data_flags
-        data_flags = DataContainer(dict(map(lambda k: (k, ~wgts[k].astype(np.bool)), wgts.keys())))
-    else:
-        raise ValueError("didn't recognize dtype of data_flags")
-
-    # loop over keys
+    exponent = {'divide': 1, 'multiply': -1}[gain_convention]
+    # loop over baselines in data
     for (i, j, pol) in data.keys():
         ap1, ap2 = utils.split_pol(pol)
-        # Check to see that all necessary antennas are present in the gains
-        if (i, ap1) in new_gains and (j, ap2) in new_gains and (old_gains is None
-                                                                or ((i, ap1) in old_gains and (j, ap2) in old_gains)):
-            gigj_new = new_gains[(i, ap1)] * np.conj(new_gains[(j, ap2)])
-            if old_gains is not None:
-                gigj_old = old_gains[(i, ap1)] * np.conj(old_gains[(j, ap2)])
-            else:
-                gigj_old = np.ones_like(gigj_new)
-            # update all the data, even if it was flagged
-            if gain_convention == 'divide':
-                data[(i, j, pol)] *= (gigj_old / gigj_new)
-            elif gain_convention == 'multiply':
-                data[(i, j, pol)] *= (gigj_new / gigj_old)
-            else:
-                raise KeyError("gain_convention must be either 'divide' or 'multiply'.")
-            # update data flags
-            if bool_flags:
-                # treat as flags
+        flag_all = False
+        
+        # apply new gains for antennas i and j. If either is missing, flag the whole baseline
+        try:
+            data[(i, j, pol)] /= (new_gains[(i, ap1)])**exponent
+        except KeyError:
+            flag_all = True
+        try:
+            data[(i, j, pol)] /= np.conj(new_gains[(j, ap2)])**exponent
+        except KeyError:
+            flag_all = True
+        # unapply old gains for antennas i and j. If either is missing, flag the whole baseline
+        if old_gains is not None:
+            try:
+                data[(i, j, pol)] *= (old_gains[(i, ap1)])**exponent
+            except KeyError:
+                flag_all = True
+            try:
+                data[(i, j, pol)] *= (old_gains[(j, ap2)])**exponent
+            except KeyError:
+                flag_all = True
+
+        # update data_flags in the case where flags are booleans, flag all if cal_flags are missing
+        if np.all([np.issubdtype(df.dtype, np.bool) for df in data_flags.values()]):
+            try:
                 data_flags[(i, j, pol)] += cal_flags[(i, ap1)]
                 data_flags[(i, j, pol)] += cal_flags[(j, ap2)]
-            else:
-                # treat as data weights
-                wgts[(i, j, pol)] *= (~cal_flags[(i, ap1)]).astype(np.float)
-                wgts[(i, j, pol)] *= (~cal_flags[(j, ap2)]).astype(np.float)
+            except KeyError:
+                flag_all = True
+        # update data_flags in the case where flags are weights, flag all if cal_flags are missing
+        if np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):
+            try:
+                data_flags[(i, j, pol)] *= (~cal_flags[(i, ap1)]).astype(np.float)
+                data_flags[(i, j, pol)] *= (~cal_flags[(j, ap2)]).astype(np.float)
+            except KeyError:
+                flag_all = True
         else:
-            # If any antenna is missing from the gains, the data is flagged
-            if bool_flags:
-                data_flags[(i, j, pol)] = np.ones_like(data_flags[(i, j, pol)], dtype=np.bool)
+            raise ValueError("didn't recognize dtype of data_flags")
+
+        # if the flag object is given, update it for this baseline to be totally flagged
+        if flag_all and (flags is not None):
+            if np.all([np.issubdtype(df.dtype, np.bool) for df in data_flags.values()]):  # boolean flags
+                data_flags[(i, j, pol)] = np.ones_like(data[(i, j, pol)], dtype=np.bool)
+            if np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):  # weights
+                data_flags[(i, j, pol)] = np.zeros_like(data[(i, j, pol)], dtype=np.float)
             else:
-                wgts[(i, j, pol)] = np.zeros_like(wgts[(i, j, pol)], dtype=np.float)
+                raise ValueError("didn't recognize dtype of data_flags")
 
 
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flags_npz=None,
@@ -138,7 +147,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 # apply npz flags
                 if flags_npz is not None:
                     data_flags[bl] = np.logical_or(data_flags[bl], npz_flag_dc[bl])
-            recalibrate_in_place(data, data_flags, new_gains, new_flags,
+            calibrate_in_place(data, new_gains, data_flags=data_flags, cal_flags=new_flags,
                                  old_gains=old_calibration, gain_convention=gain_convention)
             hd.partial_write(data_outfilename, data=data, flags=data_flags,
                              inplace=True, clobber=clobber, add_to_history=add_to_history)
@@ -158,7 +167,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             # apply npz flags
             if flags_npz is not None:
                 data_flags[bl] = np.logical_or(data_flags[bl], npz_flag_dc[bl])
-        recalibrate_in_place(data, data_flags, new_gains, new_flags, old_gains=old_calibration, gain_convention=gain_convention)
+        calibrate_in_place(data, new_gains, data_flags=data_flags, cal_flags=new_flags,
+                           old_gains=old_calibration, gain_convention=gain_convention)
         io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
                       data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs)
 

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -149,7 +149,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 if flags_npz is not None:
                     data_flags[bl] = np.logical_or(data_flags[bl], npz_flag_dc[bl])
             calibrate_in_place(data, new_gains, data_flags=data_flags, cal_flags=new_flags,
-                                 old_gains=old_calibration, gain_convention=gain_convention)
+                               old_gains=old_calibration, gain_convention=gain_convention)
             hd.partial_write(data_outfilename, data=data, flags=data_flags,
                              inplace=True, clobber=clobber, add_to_history=add_to_history)
 

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -55,19 +55,19 @@ def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gai
             except KeyError:
                 flag_all = True
             try:
-                data[(i, j, pol)] *= (old_gains[(j, ap2)])**exponent
+                data[(i, j, pol)] *= np.conj(old_gains[(j, ap2)])**exponent
             except KeyError:
                 flag_all = True
 
         # update data_flags in the case where flags are booleans, flag all if cal_flags are missing
-        if np.all([np.issubdtype(df.dtype, np.bool) for df in data_flags.values()]):
+        if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):
             try:
                 data_flags[(i, j, pol)] += cal_flags[(i, ap1)]
                 data_flags[(i, j, pol)] += cal_flags[(j, ap2)]
             except KeyError:
                 flag_all = True
         # update data_flags in the case where flags are weights, flag all if cal_flags are missing
-        if np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):
+        elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):
             try:
                 data_flags[(i, j, pol)] *= (~cal_flags[(i, ap1)]).astype(np.float)
                 data_flags[(i, j, pol)] *= (~cal_flags[(j, ap2)]).astype(np.float)
@@ -77,10 +77,10 @@ def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gai
             raise ValueError("didn't recognize dtype of data_flags")
 
         # if the flag object is given, update it for this baseline to be totally flagged
-        if flag_all and (flags is not None):
-            if np.all([np.issubdtype(df.dtype, np.bool) for df in data_flags.values()]):  # boolean flags
+        if flag_all and (data_flags is not None):
+            if np.all([np.issubdtype(df.dtype, np.bool_) for df in data_flags.values()]):  # boolean flags
                 data_flags[(i, j, pol)] = np.ones_like(data[(i, j, pol)], dtype=np.bool)
-            if np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):  # weights
+            elif np.all([np.issubdtype(df.dtype, np.floating) for df in data_flags.values()]):  # weights
                 data_flags[(i, j, pol)] = np.zeros_like(data[(i, j, pol)], dtype=np.float)
             else:
                 raise ValueError("didn't recognize dtype of data_flags")

--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -47,7 +47,7 @@ class Delay_Filter():
         # optionally apply calibration and calibration flags
         if input_cal is not None:
             g, f = io.load_cal(input_cal)
-            apply_cal.recalibrate_in_place(self.data, self.flags, g, f)
+            apply_cal.calibrate_in_place(self.data, g, data_flags=self.flags, cal_flags=f)
 
         # save metadata
         self.antpos = deepcopy(self.data.antpos)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -9,6 +9,7 @@ from hera_cal.datacontainer import DataContainer
 from hera_cal.utils import split_pol, conj_pol, polnum2str, polstr2num, jnum2str, jstr2num
 from hera_cal.apply_cal import recalibrate_in_place
 
+
 def noise(size):
     """Return complex random gaussian array with given size and variance = 1."""
 
@@ -233,7 +234,7 @@ def divide_by_gains(data, gains):
     for (i, j, pol) in data.keys():
         ap1, ap2 = split_pol(pol)
         for key in [(i, ap1), (j, ap2)]:
-            if not key in full_gains:
+            if key not in full_gains:
                 if key in gains:
                     full_gains[key] = deepcopy(gains[key])
                 else:  # recalibrate_in_place requires all gains to be present, or else it'll flag
@@ -243,7 +244,6 @@ def divide_by_gains(data, gains):
     output = deepcopy(data)
     recalibrate_in_place(output, data_flags, full_gains, gain_flags)
     return output
-
 
 
 class RedundantCalibrator:

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -83,7 +83,7 @@ class Test_Update_Cal(unittest.TestCase):
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
         wgts = DataContainer(dict(map(lambda k: (k, (~flags[k]).astype(np.float)), flags.keys())))
         del g_new[(0, 'jxx')]
-        ac.calibrate_in_place(dc, g_new, wgts, cal_flags, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, wgts, cal_flags, gain_convention='divide', flags_are_wgts=True)
         self.assertAlmostEqual(wgts[(0, 1, 'xx')].max(), 0.0)
 
     def test_apply_cal(self):

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -23,7 +23,7 @@ import warnings
 
 class Test_Update_Cal(unittest.TestCase):
 
-    def test_recalibrate_in_place(self):
+    def test_calibrate_in_place(self):
         np.random.seed(21)
         vis = np.random.randn(10, 10) + 1.0j * np.random.randn(10, 10)
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
@@ -37,7 +37,7 @@ class Test_Update_Cal(unittest.TestCase):
         g_old = {(0, 'jxx'): g0_old, (1, 'jxx'): g1_old}
         cal_flags = {(0, 'jxx'): np.random.randn(10, 10) > 0, (1, 'jxx'): np.random.randn(10, 10) > 0}
         # test standard operation
-        ac.recalibrate_in_place(dc, flags, g_new, cal_flags, old_gains=g_old, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains=g_old, gain_convention='divide')
         for i in range(10):
             for j in range(10):
                 self.assertAlmostEqual(dc[(0, 1, 'xx')][i, j], vis[i, j] * g0_old[i, j] * np.conj(g1_old[i, j]) / g0_new[i, j] / np.conj(g1_new[i, j]))
@@ -49,7 +49,7 @@ class Test_Update_Cal(unittest.TestCase):
         # test without old cal
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.recalibrate_in_place(dc, flags, g_new, cal_flags, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, gain_convention='divide')
         for i in range(10):
             for j in range(10):
                 self.assertAlmostEqual(dc[(0, 1, 'xx')][i, j], vis[i, j] / g0_new[i, j] / np.conj(g1_new[i, j]))
@@ -57,7 +57,7 @@ class Test_Update_Cal(unittest.TestCase):
         # test multiply
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.recalibrate_in_place(dc, flags, g_new, cal_flags, old_gains=g_old, gain_convention='multiply')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains=g_old, gain_convention='multiply')
         for i in range(10):
             for j in range(10):
                 self.assertAlmostEqual(dc[(0, 1, 'xx')][i, j], vis[i, j] / g0_old[i, j] / np.conj(g1_old[i, j]) * g0_new[i, j] * np.conj(g1_new[i, j]))
@@ -65,25 +65,25 @@ class Test_Update_Cal(unittest.TestCase):
         # test flag propagation when missing antennas in gains
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.recalibrate_in_place(dc, flags, {}, cal_flags, gain_convention='divide')
+        ac.calibrate_in_place(dc, {}, flags, cal_flags, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.recalibrate_in_place(dc, flags, g_new, cal_flags, old_gains={}, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains={}, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
 
         # test error
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
         with self.assertRaises(KeyError):
-            ac.recalibrate_in_place(dc, flags, g_new, cal_flags, old_gains=g_old, gain_convention='blah')
+            ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains=g_old, gain_convention='blah')
 
         # test w/ data weights
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
         wgts = DataContainer(dict(map(lambda k: (k, (~flags[k]).astype(np.float)), flags.keys())))
         del g_new[(0, 'jxx')]
-        ac.recalibrate_in_place(dc, wgts, g_new, cal_flags, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, wgts, cal_flags, gain_convention='divide')
         self.assertAlmostEqual(wgts[(0, 1, 'xx')].max(), 0.0)
 
     def test_apply_cal(self):

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -170,27 +170,15 @@ class TestMethods(unittest.TestCase):
         polReds = om.add_pol_reds(reds, pols=['XX', 'XY', 'YX', 'YY'], pol_mode='4pol_minV', ex_ants=[(2, 'jyy')])
         self.assertEqual(polReds, [[(1, 2, 'XX')], [(1, 2, 'YX')], []])
 
-    def test_multiply_by_gains(self):
-        vis_in = {(1, 2, 'XX'): 1.6 + 2.3j}
-        gains = {(1, 'jxx'): .3 + 2.6j, (2, 'jxx'): -1.2 - 7.3j}
-        vis_out = om.multiply_by_gains(vis_in, gains, target_type='vis')
-        self.assertAlmostEqual(1.6 + 2.3j, vis_in[(1, 2, 'XX')], 10)
-        self.assertAlmostEqual(-28.805 - 45.97j, vis_out[(1, 2, 'XX')], 10)
-
-        gains_out = om.multiply_by_gains(gains, gains, target_type='gain')
-        self.assertAlmostEqual(.3 + 2.6j, gains[(1, 'jxx')], 10)
-        self.assertAlmostEqual(-6.67 + 1.56j, gains_out[(1, 'jxx')], 10)
-
     def test_divide_by_gains(self):
         vis_in = {(1, 2, 'XX'): 1.6 + 2.3j}
         gains = {(1, 'jxx'): .3 + 2.6j, (2, 'jxx'): -1.2 - 7.3j}
-        vis_out = om.divide_by_gains(vis_in, gains, target_type='vis')
+        vis_out = om.divide_by_gains(vis_in, gains)
         self.assertAlmostEqual(1.6 + 2.3j, vis_in[(1, 2, 'XX')], 10)
         self.assertAlmostEqual(-0.088244747606364887 - 0.11468109538397521j, vis_out[(1, 2, 'XX')], 10)
-
-        gains_out = om.divide_by_gains(gains, gains, target_type='gain')
-        self.assertAlmostEqual(.3 + 2.6j, gains[(1, 'jxx')], 10)
-        self.assertAlmostEqual(1.0, gains_out[(1, 'jxx')], 10)
+        gains = {}
+        vis_out = om.divide_by_gains(vis_in, gains)
+        self.assertAlmostEqual(1.6 + 2.3j, vis_out[(1, 2, 'XX')], 10)
 
 
 class TestRedundantCalibrator(unittest.TestCase):

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -170,16 +170,6 @@ class TestMethods(unittest.TestCase):
         polReds = om.add_pol_reds(reds, pols=['XX', 'XY', 'YX', 'YY'], pol_mode='4pol_minV', ex_ants=[(2, 'jyy')])
         self.assertEqual(polReds, [[(1, 2, 'XX')], [(1, 2, 'YX')], []])
 
-    def test_divide_by_gains(self):
-        vis_in = {(1, 2, 'XX'): 1.6 + 2.3j}
-        gains = {(1, 'jxx'): .3 + 2.6j, (2, 'jxx'): -1.2 - 7.3j}
-        vis_out = om.divide_by_gains(vis_in, gains)
-        self.assertAlmostEqual(1.6 + 2.3j, vis_in[(1, 2, 'XX')], 10)
-        self.assertAlmostEqual(-0.088244747606364887 - 0.11468109538397521j, vis_out[(1, 2, 'XX')], 10)
-        gains = {}
-        vis_out = om.divide_by_gains(vis_in, gains)
-        self.assertAlmostEqual(1.6 + 2.3j, vis_out[(1, 2, 'XX')], 10)
-
 
 class TestRedundantCalibrator(unittest.TestCase):
 


### PR DESCRIPTION
This addresses #320.

Unfortunately, this wasn't quite as simple as I hoped. `apply_cal.recalibrate_in_place` requires data_flags and gain_flags and also assumes that missing gains are flagged. Here we want to make a different assumption, which is that missing gains are 1.0. I had to leave `divide_by_gains` and turn it into a wrapper around `apply_cal.recalibrate_in_place` to make it perform the way we want.