### PR TITLE
fixed io.write_cal for 2pol case and added test

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1007,7 +1007,7 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, total_qual=N
     '''
 
     # get antenna info
-    ant_array = np.array(sorted(map(lambda k: k[0], gains.keys())), np.int)
+    ant_array = np.unique(map(lambda k: k[0], gains.keys())).astype(np.int)
     antenna_numbers = copy.copy(ant_array)
     antenna_names = np.array(map(lambda a: "ant{}".format(a), antenna_numbers))
     Nants_data = len(ant_array)


### PR DESCRIPTION
quick bug fix to `io.write_cal` in case when `gains` contains multiple polarizations. Old code was extending `ants` instead of `jones` axis in this case. Tests are added.