### PR TITLE
Remove top level imports of hera_qm...again

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -10,8 +10,6 @@ import argparse
 import os
 from six.moves import range, zip
 import linsolve
-from hera_qm.ant_metrics import per_antenna_modified_z_scores
-from hera_qm.metrics_io import load_metric_file
 
 from . import utils
 from .datacontainer import DataContainer


### PR DESCRIPTION
These snuck back in with the python3 PR. The buried statements are still in the correct spots, but these top-level ones are back...