### PR TITLE
Added PseudoContainer to HERAData

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -420,8 +420,7 @@ class HERAData(UVData):
     def __getitem__(self, key):
         '''Shortcut for reading a single visibility waterfall given a baseline tuple.'''
         try:
-            return (self._get_slice(self.data_array, key), self._get_slice(self.flag_array, key),
-                    self._get_slice(self.nsample_array, key))
+            return self._get_slice(self.data_array, key)
         except KeyError:
             return self.read(bls=key)[0][key]
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -130,7 +130,7 @@ class HERACal(UVCal):
 
 def get_blt_slices(uvo):
     '''For a pyuvdata-style UV object, get the mapping from antenna pair to blt slice.
-    
+
     Arguments:
         uvo: a "UV-Object" like UVData or baseline-type UVFlag
 
@@ -597,7 +597,7 @@ def load_flags(flagfile, filetype='h5', return_meta=False):
     Arguments:
         flagfile: path to file containing flags and flagging metadata
         filetype: either 'h5' or 'npz'. 'h5' assumes the file is readable as a hera_qm
-            UVFlag object in the 'flag' mode (could be by baseline, by antenna, or by 
+            UVFlag object in the 'flag' mode (could be by baseline, by antenna, or by
             polarization). 'npz' provides legacy support for the IDR2.1 flagging npzs,
             but only for per-visibility flags.
         return_meta: if True, return a metadata dictionary with, e.g., 'times', 'freqs', 'history'

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -318,7 +318,7 @@ class Test_HERAData(unittest.TestCase):
         nt.assert_equal(len(hd._blt_slices), 3)
 
         # test that getitem of key that doesn't exist is a read
-        hd.read(bls=[(53, 53),(53, 54)])
+        hd.read(bls=[(53, 53), (53, 54)])
         d = hd[(54, 54, 'xx')]
         nt.assert_equal(len(hd._blt_slices), 1)
 


### PR DESCRIPTION
Forgive me @jsdillon for the numerous PRs: but I think I may have solved an issue that was bugging us for a while, which is the fact that in the `DelayFilter` and `FRFilter` objects, upon instantiation, we automatically double the memory footprint by linking the input `UVData` object and __then__ making series of `DataContainers` from them. This gets around this by utilizing a new object `SoftContainer` that mimics some of the basic functionality of a `DataContainer` but doesn't make a copy of the data, instead it just references the data in the `HERAData` object via its `get_slice` method.

Once we implement this we should be able use the `SoftContainer` linked as `HERAData.data` and `HERAData.flags` in our `DelayFilter` and `FRFilter` objects and not have to double the memory footprint...

Btw, I'm loving the new `HERAData` object and its `blt_slice` caching...