### PR TITLE
[delay_filter] get filled data uses clean_flags

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -78,24 +78,19 @@ class DelayFilter(VisClean):
 
         Returns
             filled_data: DataContainer with original data and flags filled with CLEAN model
-            filled_flags: DataContainer with flags set to False unless time is skipped
+            filled_flags: DataContainer with flags set to False unless the time is skipped in delay filter
         """
-        assert hasattr(self, 'clean_model') and hasattr(self, 'data') and hasattr(self, 'flags'), "self.clean_model, "\
-            "self.data and self.flags must all exist to get filled data"
+        assert np.all([hasattr(self, n) for n in ['clean_model', 'clean_flags', 'data', 'flags']), "self.data, self.flags, self.clean_model and self.clean_flags must all exist to get filled data"
         # construct filled data and filled flags
-        filled_data = deepcopy(self.data)
-        filled_flags = deepcopy(self.flags)
+        filled_data = deepcopy(self.clean_model)
+        filled_flags = deepcopy(self.clean_flags)
 
         # iterate over filled_data keys
         for k in filled_data.keys():
-            # get flags
-            f = filled_flags[k].copy()
-            # if flagged across all freqs, "unflag" this f
-            f[np.sum(f, axis=1) / float(self.Nfreqs) > 0.99999] = False
-            # replace data_out with clean_model at f == True
-            filled_data[k][f] = self.clean_model[k][f]
-            # unflag at f == True
-            filled_flags[k][f] = False
+            # get original data flags
+            f = self.flags[k]
+            # replace filled_data with original data at f == False
+            filled_data[k][~f] = self.data[k][~f]
 
         return filled_data, filled_flags
 

--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -80,7 +80,7 @@ class DelayFilter(VisClean):
             filled_data: DataContainer with original data and flags filled with CLEAN model
             filled_flags: DataContainer with flags set to False unless the time is skipped in delay filter
         """
-        assert np.all([hasattr(self, n) for n in ['clean_model', 'clean_flags', 'data', 'flags']), "self.data, self.flags, self.clean_model and self.clean_flags must all exist to get filled data"
+        assert np.all([hasattr(self, n) for n in ['clean_model', 'clean_flags', 'data', 'flags']]), "self.data, self.flags, self.clean_model and self.clean_flags must all exist to get filled data"
         # construct filled data and filled flags
         filled_data = deepcopy(self.clean_model)
         filled_flags = deepcopy(self.clean_flags)

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -221,8 +221,12 @@ class VisClean(object):
         """
         Perform a CLEAN deconvolution.
 
-        Run a CLEAN on data and insert results into
-        self.clean_model and self.clean_resid.
+        Run a CLEAN on data and insert the CLEAN components
+        into self.clean_model, the CLEAN residual into self.clean_resid,
+        the CLEAN flags into self.clean_flags and other relevant info
+        into self.clean_info. CLEAN flags are by definition all False
+        unless a skip_wgt is triggered, in which case all pixels
+        along the CLEAN axis are set to True.
 
         Args:
             keys : list of bl-pol keys in data to CLEAN


### PR DESCRIPTION
Fixes a typo (that was just introduced in a recent PR) in `DelayFilter.get_filled_data`where `filled_data` was deepcopy of data, when it should have been deepcopy of clean_model...