### PR TITLE
vis_clean.write_data fix for subset of data write

### DIFF
--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -14,7 +14,7 @@ from scipy import constants
 from pyuvdata import UVCal, UVData
 import nose.tools as nt
 
-from hera_cal import io
+from hera_cal import io, datacontainer
 from hera_cal.vis_clean import VisClean
 from hera_cal.data import DATA_PATH
 
@@ -82,6 +82,13 @@ class Test_VisClean(unittest.TestCase):
 
         # exceptions
         nt.assert_raises(ValueError, V.write_data, V.data, 'foo', filetype='what')
+
+        # test write on subset of data
+        V.read(read_data=True)
+        data = datacontainer.DataContainer(dict([(k, V.data[k]) for k in V.data.keys()[:2]]))
+        V.write_data(data, "ex.uvh5", overwrite=True, filetype='uvh5')
+        nt.assert_true(os.path.exists("ex.uvh5"))
+        os.remove('ex.uvh5')
 
     def test_vis_clean(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.uvXRAA")

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -187,10 +187,12 @@ class VisClean(object):
 
         # select out a copy of hd
         hd = self.hd.select(bls=keys, inplace=False)
+        hd._determine_blt_slicing()
+        hd._determine_pol_indexing()
 
         # update HERAData
         hd.update(data=data, flags=flags, nsamples=nsamples)
- 
+
         # add history
         if add_to_history is not None:
             hd.history = "{}\n{}".format(hd.history, add_to_history)


### PR DESCRIPTION
@jsdillon another small patch for `vis_clean.write_data`: when writing a subset of the input data it failed to re-compute `HERAData._determine_blt_slices`, which was a use-case I hadn't anticipated, but in making the IDR3 abscal model I stumbled upon. Anyways, its a quick fix. Thanks! Almost finished with the idr3 abscal model :)