### PR TITLE
Add manual edge flagging to redcal.

### DIFF
--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1037,10 +1037,12 @@ class TestRunMethods(unittest.TestCase):
         hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            rv = om.redcal_iteration(hd, nInt_to_load=1)
+            rv = om.redcal_iteration(hd, nInt_to_load=1, flag_nchan_high=40, flag_nchan_low=30)
         for t in range(len(hd.times)):
             for flag in rv['gf_omnical'].values():
                 self.assertFalse(np.all(flag[t, :]))
+                self.assertTrue(np.all(flag[t, 0:30]))
+                self.assertTrue(np.all(flag[t, -40:]))
 
         hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))
         with warnings.catch_warnings():

--- a/scripts/redcal_run.py
+++ b/scripts/redcal_run.py
@@ -15,6 +15,6 @@ a = redcal_argparser()
 
 redcal_run(a.input_data, firstcal_ext=a.firstcal_ext, omnical_ext=a.omnical_ext, omnivis_ext=a.omnivis_ext,
            outdir=a.outdir, ant_metrics_file=a.ant_metrics_file, clobber=a.clobber, nInt_to_load=a.nInt_to_load, pol_mode=a.pol_mode,
-           ex_ants=a.ex_ants, ant_z_thresh=a.ant_z_thresh, max_rerun=a.max_rerun, solar_horizon=a.solar_horizon, min_bl_cut=a.min_bl_cut, 
-           max_bl_cut=a.max_bl_cut, conv_crit=a.conv_crit, maxiter=a.maxiter, check_every=a.check_every, check_after=a.check_after, 
-           gain=a.gain, add_to_history=' '.join(sys.argv), verbose=a.verbose)
+           ex_ants=a.ex_ants, ant_z_thresh=a.ant_z_thresh, max_rerun=a.max_rerun, solar_horizon=a.solar_horizon, flag_nchan_low=a.flag_nchan_low,
+           flag_nchan_high=a.flag_nchan_high, min_bl_cut=a.min_bl_cut, max_bl_cut=a.max_bl_cut, conv_crit=a.conv_crit, maxiter=a.maxiter, 
+           check_every=a.check_every, check_after=a.check_after, gain=a.gain, add_to_history=' '.join(sys.argv), verbose=a.verbose)


### PR DESCRIPTION
Added the ability to manually flag edge channels in redcal, mimicking the functionality of apply_cal. 

In this case, firstcal, logcal, and omnical will not even try to calibrate those channels. They will be reported as flagged in firstcal, omnical, and the omnical visibilities with gains of 1 and unique baseline visibilities of 1.

This closes #415. 