### PR TITLE
Abscal Updates: remove abscal_funcs.fft_dly and speed up get_file_lst_range

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -179,8 +179,8 @@ class AbsCal(object):
         assert len(self.keys) > 0, "no shared keys exist between model and data"
 
         # append attributes
-        self.model = model
-        self.data = data
+        self.model = DataContainer(dict([(k, model[k]) for k in self.keys]))
+        self.data = DataContainer(dict([(k, data[k]) for k in self.keys]))
 
         # setup frequencies
         self.freqs = freqs
@@ -1033,6 +1033,7 @@ def omni_abscal_arg_parser():
     a.add_argument("--data_file", type=str, help="file path of data to-be-calibrated.", required=True)
     a.add_argument("--model_files", type=str, nargs='*', help="list of data-overlapping miriad files for visibility model.", required=True)
     a.add_argument("--filetype", type=str, default='uvh5', help="Filetype of input filepaths.")
+    a.add_argument("--polarizations", type=str, nargs='*', default=None, help="Polarizations to load from data_file and model_files. Default is all.")
     a.add_argument("--input_cal", type=str, help="Path to a calfits file to apply to the data before running abscal.")
     a.add_argument("--output_calfits_fname", type=str, default=None, help="name of output calfits files.")
     a.add_argument("--outdir", type=str, default=None, help="output directory")

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -395,7 +395,7 @@ class AbsCal(object):
         # form result
         self._ant_dly = odict(list(map(lambda k: (k, copy.copy(fit["tau_{}_{}".format(k[0], k[1])])), flatten(self._gain_keys))))
         self._ant_dly_arr = np.moveaxis(list(map(lambda pk: list(map(lambda k: self._ant_dly[k], pk)), self._gain_keys)), 0, -1)
-        
+
         self._ant_dly_phi = odict(list(map(lambda k: (k, copy.copy(fit["phi_{}_{}".format(k[0], k[1])])), flatten(self._gain_keys))))
         self._ant_dly_phi_arr = np.moveaxis(list(map(lambda pk: list(map(lambda k: self._ant_dly_phi[k], pk)), self._gain_keys)), 0, -1)
 
@@ -1056,8 +1056,7 @@ def omni_abscal_arg_parser():
     a.add_argument("--antflag_thresh", default=0.0, type=float, help="fraction of flagged visibilities per antenna needed to flag the antenna gain per time and frequency.")
     return a
 
-from memory_profiler import profile
-@profile
+
 def abscal_run(data_file, model_files, filetype='miriad', refant=None, input_cal=None, verbose=True, overwrite=False, write_calfits=True,
                min_bl_cut=None, max_bl_cut=None, bl_taper_fwhm=None, output_calfits_fname=None, return_gains=False, return_object=False, outdir=None,
                match_red_bls=False, tol=1.0, reweight=False, rephase_model=True, all_antenna_gains=False, edge_cut=0,

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -27,7 +27,7 @@ from . import redcal
 from . import io
 from . import apply_cal
 from .datacontainer import DataContainer
-from .utils import polnum2str, polstr2num, jnum2str, jstr2num, reverse_bl, echo
+from .utils import polnum2str, polstr2num, jnum2str, jstr2num, reverse_bl, echo, fft_dly
 
 
 def abs_amp_logcal(model, data, wgts=None, verbose=True):
@@ -983,95 +983,6 @@ def array_axis_to_data_key(data, array_index, array_keys, key_index=-1, copy_dic
         return new_data, new_copy
     else:
         return new_data
-
-
-def fft_dly(data, df, wgts=None, window=None, medfilt=False, kernel=(1, 11),
-            solve_phase=False, edge_cut=0):
-    """Get delay of visibility across band using FFT and quadratic fit to delay peak.
-
-    Arguments:
-        data : ndarray of complex data (e.g. gains or visibilities) of shape (Ntimes, Nfreqs)
-        df : frequency channel width in Hz
-        wgts : multiplicative wgts of the same shape as the data
-        medfilt : boolean, median filter data before fft
-        kernel : size of median filter kernel along (time, freq) axes
-        window : str, window to enact on data before FFT, options=['blackmanharris', 'hann', None]
-            None is a top-hat window.
-        solve_phase=False
-        edge_cut : int, number of channels to exclude at each band edge of vis in FFT window
-
-    Returns:
-        dlys : (Ntimes, 1) ndarray containing delay for each integration
-        phi : ndarray containing phase of delay mode for each integration (or None if solve_phase is False)
-    """
-    Ntimes, Nfreqs = data.shape
-    if wgts is None:
-        wgts = np.ones_like(data, dtype=np.float)
-
-    # smooth via median filter
-    kernel += tuple(np.ones((data.ndim - len(kernel)), np.int))
-    if medfilt:
-        data = signal.medfilt(np.real(data), kernel_size=kernel) + 1j * signal.medfilt(np.imag(data), kernel_size=kernel)
-
-    # construct window
-    win = np.zeros_like(data, dtype=np.float)
-    assert 2 * edge_cut < Nfreqs - 1, "edge_cut cannot be >= Nfreqs/2 - 1"
-    if window is None:  # tophat window
-        win[:, edge_cut:(Nfreqs - edge_cut)] = 1.0
-    elif window == 'blackmanharris':
-        win[:, edge_cut:(Nfreqs - edge_cut)] = signal.windows.blackmanharris(Nfreqs - 2 * edge_cut)
-    elif window == 'hann':
-        win[:, edge_cut:(Nfreqs - edge_cut)] = signal.windows.hann(Nfreqs - 2 * edge_cut)
-    else:
-        raise ValueError("didn't recognize window {} from ['blackmanharris', 'hann', None]".format(window))
-
-    # fft w/ window and find argmax
-    vfft = np.fft.fft(data * win * wgts, axis=1)
-    amp = np.abs(np.fft.fftshift(vfft, axes=1))
-    argmaxes = np.argmax(amp, axis=1)
-    fftfreqs = np.fft.fftshift(np.fft.fftfreq(Nfreqs, df))
-    dlys, peak_shifts = np.zeros((Ntimes, 1)), np.zeros((Ntimes, 1))
-    # use parabolic peak interpolation: https://ccrma.stanford.edu/~jos/sasp/Quadratic_Interpolation_Spectral_Peaks.html
-    for i in range(Ntimes):
-        a, b, c, = amp[i][(argmaxes[i] - 1) % len(amp[i])], amp[i][argmaxes[i]], amp[i][(argmaxes[i] + 1) % len(amp[i])]
-        if (np.abs(a - 2 * b + c) > 0) and (np.abs(a - c) > 0):
-            peak_shifts[i] = .5 * (a - c) / (a - 2 * b + c)
-        else:
-            peak_shifts[i] = 0
-        # use peak shift to linearly interpolate to get appropriate delay
-        dlys[i] = (1.0 - np.abs(peak_shifts[i])) * fftfreqs[argmaxes[i]] + np.abs(peak_shifts[i]) * \
-                  (fftfreqs[argmaxes[i]] + np.sign(peak_shifts[i]) * (fftfreqs[1] - fftfreqs[0]))
-
-    phi = None
-    if solve_phase:
-        # get phase offsets by interpolating real and imag component of FFT
-        argmax = np.moveaxis(np.argmax(np.abs(vfft), axis=1)[np.newaxis], 0, 1)
-        vfft_real = []
-        vfft_imag = []
-        for i, a in enumerate(argmax):
-            # get real and imag of each argmax
-            real = np.take(vfft.real, i, axis=0)
-            imag = np.take(vfft.imag, i, axis=0)
-
-            # wrap around
-            real = np.concatenate([real, real, real])
-            imag = np.concatenate([imag, imag, imag])
-            a += Nfreqs
-
-            # add interpolation component
-            rl = interpolate.interp1d(np.arange(Nfreqs * 3), real)(a + peak_shifts[i])
-            im = interpolate.interp1d(np.arange(Nfreqs * 3), imag)(a + peak_shifts[i])
-
-            # insert into arrays
-            vfft_real.append(rl)
-            vfft_imag.append(im)
-
-        vfft_real = np.moveaxis(np.array(vfft_real), 0, 0)
-        vfft_imag = np.moveaxis(np.array(vfft_imag), 0, 0)
-        vfft_interp = vfft_real + 1j * vfft_imag
-        phi = np.angle(vfft_interp)
-
-    return dlys, phi
 
 
 def wiener(data, window=(5, 11), noise=None, medfilt=True, medfilt_kernel=(3, 9), array=False):

--- a/hera_cal/abscal_funcs.py
+++ b/hera_cal/abscal_funcs.py
@@ -1447,7 +1447,6 @@ def avg_data_across_red_bls(data, antpos, wgts=None, broadcast_wgts=True, tol=1.
     keys = list(data.keys())
 
     # get data, wgts and ants
-    data = copy.deepcopy(data)
     pols = np.unique(list(map(lambda k: k[2], data.keys())))
     ants = np.unique(np.concatenate(keys))
     if wgts is None:

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -17,6 +17,7 @@ from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
 import aipy
 from astropy import units
+import h5py
 
 from .datacontainer import DataContainer
 from .utils import polnum2str, polstr2num, jnum2str, jstr2num
@@ -686,12 +687,7 @@ def get_file_lst_range(filepaths, filetype='uvh5', add_int_buffer=False):
             start += int_time / 2
             stop += int_time / 2
         elif filetype == 'uvh5':
-            hd = HERAData(f)
-            lsts = []
-            for l in hd.lst_array:
-                if l not in lsts:
-                    lsts.append(l)
-            lsts = np.unwrap(lsts)
+            lsts = np.unwrap(np.unique(h5py.File(f)[u'Header'][u'lst_array']))
             start, stop, int_time = lsts[0], lsts[-1], np.median(np.diff(lsts))
 
         # add integration buffer to end of file if desired

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -821,7 +821,7 @@ def to_HERAData(input_data, filetype='miriad'):
         raise TypeError('Input must be a UVData/HERAData object, a string, or a list of either.')
 
 
-def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, pick_data_ants=True, nested_dict=False):
+def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, pick_data_ants=True, nested_dict=False, **read_kwargs):
     '''Load miriad or uvfits files or UVData/HERAData objects into DataContainers, optionally returning
     the most useful metadata. More than one spectral window is not supported. Assumes every baseline
     has the same times present and that the times are in order.
@@ -835,6 +835,7 @@ def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, 
         pick_data_ants: boolean, if True and return_meta=True, return only antennas in data
         nested_dict: boolean, if True replace DataContainers with the legacy nested dictionary filetype
             where visibilities and flags are accessed as data[(0,1)]['xx']
+        read_kwargs : keyword arguments to pass to HERAData.read()
 
     Returns:
         if return_meta is True:
@@ -856,7 +857,7 @@ def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, 
     if hd.data_array is not None:
         d, f, n = hd.build_datacontainers()
     else:
-        d, f, n = hd.read()
+        d, f, n = hd.read(**read_kwargs)
 
     # remove autos if requested
     if pop_autos:

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -528,7 +528,7 @@ def config_lst_bin_files(data_files, filetype='uvh5', dlst=None, atol=1e-10, lst
 
 
 def lst_bin_files(data_files, filetype='uvh5', dlst=None, verbose=True, ntimes_per_file=60,
-                  file_ext="{}.{}.{:7.5f}.uv", outdir=None, overwrite=False, history=' ', lst_start=0, 
+                  file_ext="{}.{}.{:7.5f}.uv", outdir=None, overwrite=False, history='', lst_start=0, 
                   fixed_lst_start=False, atol=1e-6, sig_clip=True, sigma=5.0, min_N=5, rephase=False,
                   output_file_select=None, input_cals=None, **kwargs):
     """
@@ -557,12 +557,7 @@ def lst_bin_files(data_files, filetype='uvh5', dlst=None, verbose=True, ntimes_p
                Ex. ["LST", "STD", "NUM"] and third for starting LST bin of file.
     outdir : type=str, output directory
     overwrite : type=bool, if True overwrite output files
-<<<<<<< HEAD
-=======
-
     history : history to insert into output files
-
->>>>>>> master
     rephase : type=bool, if True, rephase data points in LST bin to center of bin
     bin_kwargs : type=dictionary, keyword arguments for lst_bin.
     atol : type=float, absolute tolerance for LST bin float comparison

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -18,7 +18,6 @@ from . import io
 from . import version
 from . import utils
 from . import flag_utils
-from .abscal import fft_dly
 
 
 def freq_filter(gains, wgts, freqs, filter_scale=10.0, tol=1e-09, window='tukey', skip_wgt=0.1,
@@ -49,7 +48,7 @@ def freq_filter(gains, wgts, freqs, filter_scale=10.0, tol=1e-09, window='tukey'
     '''
     sdf = np.median(np.diff(freqs)) / 1e9  # in GHz
     filter_size = (filter_scale / 1e3)**-1  # Puts it in ns
-    (dlys, phi) = fft_dly(gains, sdf * 1e9, wgts, medfilt=False, solve_phase=False)  # delays are in seconds
+    (dlys, phi) = utils.fft_dly(gains, sdf * 1e9, wgts, medfilt=False)  # delays are in seconds
     rephasor = np.exp(-2.0j * np.pi * np.outer(dlys, freqs))
     filtered, res, info = uvtools.dspec.high_pass_fourier_filter(gains * rephasor, wgts, filter_size, sdf, tol=tol, window=window,
                                                                  skip_wgt=skip_wgt, maxiter=maxiter, **win_kwargs)
@@ -153,7 +152,7 @@ def time_freq_2D_filter(gains, wgts, freqs, times, freq_scale=10.0, time_scale=1
     fringe_scale = (time_scale)**-1  # in Hz
 
     # find per-integration delays, smooth on the time_scale of gain smoothing, and rephase
-    taus = fft_dly(gains, df, wgts, medfilt=False, solve_phase=False)[0].astype(np.complex)  # delays are in seconds
+    taus = utils.fft_dly(gains, df, wgts, medfilt=False)[0].astype(np.complex)  # delays are in seconds
     if not np.all(taus == 0):  # this breaks CLEAN, but it means we don't need smoothing anyway
         taus = uvtools.dspec.high_pass_fourier_filter(taus.T, np.sum(wgts, axis=1, keepdims=True).T,
                                                       fringe_scale, dt, tol=tol, maxiter=maxiter)[0].T  # 0th index is the CLEAN components

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -409,13 +409,13 @@ class Test_AbsCal:
 
     def test_delay_lincal(self):
         # test w/o offsets
-        self.AC.delay_lincal(verbose=False, kernel=(1, 3), medfilt=False, solve_offsets=False)
+        self.AC.delay_lincal(verbose=False, kernel=(1, 3), medfilt=False)
         nt.assert_equal(self.AC.ant_dly[(24, 'Jxx')].shape, (60, 1))
         nt.assert_equal(self.AC.ant_dly_gain[(24, 'Jxx')].shape, (60, 64))
         nt.assert_equal(self.AC.ant_dly_arr.shape, (7, 60, 1, 1))
         nt.assert_equal(self.AC.ant_dly_gain_arr.shape, (7, 60, 64, 1))
         # test w/ offsets
-        self.AC.delay_lincal(verbose=False, kernel=(1, 3), medfilt=False, solve_offsets=True)
+        self.AC.delay_lincal(verbose=False, kernel=(1, 3), medfilt=False)
         nt.assert_equal(self.AC.ant_dly_phi[(24, 'Jxx')].shape, (60, 1))
         nt.assert_equal(self.AC.ant_dly_phi_gain[(24, 'Jxx')].shape, (60, 64))
         nt.assert_equal(self.AC.ant_dly_phi_arr.shape, (7, 60, 1, 1))

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -587,14 +587,14 @@ class Test_AbsCal:
         model_files = [os.path.join(DATA_PATH, "zen.2458042.12552.xx.HH.uvXA"),
                        os.path.join(DATA_PATH, "zen.2458042.13298.xx.HH.uvXA")]
         # blank run
-        gains, flags = abscal.abscal_run(data_files, model_files, gen_amp_cal=True, write_calfits=False, return_gains=True, verbose=False, filetype='miriad')
+        AC, gains, flags = abscal.abscal_run(data_files, model_files, gen_amp_cal=True, write_calfits=False, verbose=False, filetype='miriad')
         # assert shapes and types
         nt.assert_equal(gains[(24, 'Jxx')].dtype, np.complex)
         nt.assert_equal(gains[(24, 'Jxx')].shape, (60, 64))
         # first freq bin should be flagged due to complete flagging in model and data
         nt.assert_true(flags[(24, 'Jxx')][:, 0].all())
         # solar flag run
-        gains, flags = abscal.abscal_run(data_files, model_files, solar_horizon=0.0, gen_amp_cal=True, write_calfits=False, return_gains=True, verbose=False, filetype='miriad')
+        AC, gains, flags = abscal.abscal_run(data_files, model_files, solar_horizon=0.0, gen_amp_cal=True, write_calfits=False, verbose=False, filetype='miriad')
         # all data should be flagged
         nt.assert_true(flags[(24, 'Jxx')].all())
         # write calfits
@@ -602,8 +602,8 @@ class Test_AbsCal:
         cf_name = "ex.calfits"
         if os.path.exists(os.path.join(outdir, cf_name)):
             os.remove(os.path.join(outdir, cf_name))
-        gains, flags = abscal.abscal_run(data_files, model_files, gen_amp_cal=True, write_calfits=True, output_calfits_fname=cf_name, outdir=outdir,
-                                         return_gains=True, verbose=False, filetype='miriad')
+        AC, gains, flags = abscal.abscal_run(data_files, model_files, gen_amp_cal=True, write_calfits=True, output_calfits_fname=cf_name, outdir=outdir,
+                                             verbose=False, filetype='miriad')
         nt.assert_true(os.path.exists(os.path.join(outdir, cf_name)))
         if os.path.exists(os.path.join(outdir, cf_name)):
             os.remove(os.path.join(outdir, cf_name))
@@ -611,8 +611,8 @@ class Test_AbsCal:
         abscal.abscal_run(data_files, model_files, gen_amp_cal=True, write_calfits=False, verbose=False,
                           match_red_bls=True, reweight=True, filetype='miriad')
         # check all calibration routines
-        gains, flags = abscal.abscal_run(data_files, model_files, write_calfits=False, verbose=False, return_gains=True, delay_slope_cal=True, phase_slope_cal=True,
-                                         delay_cal=True, avg_phs_cal=True, abs_amp_cal=True, TT_phs_cal=True, gen_amp_cal=False, gen_phs_cal=False, filetype='miriad')
+        AC, gains, flags = abscal.abscal_run(data_files, model_files, write_calfits=False, verbose=False, delay_slope_cal=True, phase_slope_cal=True,
+                                             delay_cal=True, avg_phs_cal=True, abs_amp_cal=True, TT_phs_cal=True, gen_amp_cal=False, gen_phs_cal=False, filetype='miriad')
         nt.assert_equal(gains[(24, 'Jxx')].dtype, np.complex)
         nt.assert_equal(gains[(24, 'Jxx')].shape, (60, 64))
         if os.path.exists('./ex.calfits'):

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -576,37 +576,6 @@ class Test_AbsCal:
         nt.assert_almost_equal(wgts[(25, 38, 'xx')][15, 20], 0)
         nt.assert_almost_equal(wgts[(25, 38, 'xx')][20, 15], 0)
 
-    def test_fft_dly(self):
-        # test basic execution
-        k = (24, 25, 'xx')
-        vis = self.AC.model[k] / self.AC.data[k]
-        abscal.fill_dict_nans(vis, nan_fill=0.0, inf_fill=0.0, array=True)
-        df = np.median(np.diff(self.AC.freqs))
-        # basic execution
-        dly, offset = abscal.fft_dly(vis, df, medfilt=False, solve_phase=False)
-        nt.assert_equal(dly.shape, (60, 1))
-        nt.assert_equal(offset, None)
-        # median filtering
-        dly, offset = abscal.fft_dly(vis, df, medfilt=True, solve_phase=False)
-        nt.assert_equal(dly.shape, (60, 1))
-        nt.assert_equal(offset, None)
-        # solve phase
-        dly, offset = abscal.fft_dly(vis, df, medfilt=True, solve_phase=True)
-        nt.assert_equal(dly.shape, (60, 1))
-        nt.assert_equal(offset.shape, (60, 1))
-        # test windows and edgecut
-        dly, offset = abscal.fft_dly(vis, df, medfilt=False, solve_phase=False, edge_cut=2, window='hann')
-        dly, offset = abscal.fft_dly(vis, df, medfilt=False, solve_phase=False, window='blackmanharris')
-        nt.assert_raises(ValueError, abscal.fft_dly, vis, df, window='foo')
-        nt.assert_raises(AssertionError, abscal.fft_dly, vis, df, edge_cut=1000)
-        # test mock data
-        tau = np.array([1.5e-8]).reshape(1, -1)  # 15 nanoseconds
-        f = np.linspace(0, 100e6, 1024)
-        df = np.median(np.diff(f))
-        r = np.exp(1j * 2 * np.pi * f * tau)
-        dly, offset = abscal.fft_dly(r, df, medfilt=True, kernel=(1, 5), solve_phase=False)
-        nt.assert_almost_equal(float(dly), 1.5e-8, delta=1e-9)
-
     def test_abscal_arg_parser(self):
         a = abscal.abscal_arg_parser()
 

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -110,6 +110,9 @@ class TestFftDly(object):
         dlys, offs = utils.fft_dly(data, df)
         np.testing.assert_almost_equal(5 * dlys, 5 * true_dlys, -1)  # accuracy of 2 ns
         np.testing.assert_almost_equal(offs, 0.123, -2)
+        dlys, offs = utils.fft_dly(data, df, edge_cut=100)
+        np.testing.assert_almost_equal(5 * dlys, 5 * true_dlys, -1)  # accuracy of 2 ns
+        np.testing.assert_almost_equal(offs, 0.123, -2)
         dlys, offs = utils.fft_dly(data, df, medfilt=True)
         np.testing.assert_almost_equal(5 * dlys, 5 * true_dlys, -1)  # accuracy of 2 ns
         mdl = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * dlys + 1j * offs)

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -143,10 +143,10 @@ def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11), edge_cut=0):
 
     # Now that we know the slope, estimate the remaining phase offset
     freqs = np.arange(Nfreqs, dtype=data.dtype) * df
-
     fSlice = slice(edge_cut, len(freqs) - edge_cut)
-    offset = np.angle(np.mean(data[:, fSlice] * np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), axis=1))
-    return dlys, offset.reshape(-1, 1)
+    offset = np.angle(np.mean(data[:, fSlice] * np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), axis=1, keepdims=True))
+
+    return dlys, offset
 
 
 def interp_peak(data):

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -102,7 +102,7 @@ def make_bl(*args):
     return (i, j, _comply_vispol(pol))
 
 
-def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11)):
+def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11), edge_cut=0):
     """Get delay of visibility across band using FFT and quadratic fit to delay peak.
     Arguments:
         data : ndarray of complex data (e.g. gains or visibilities) of shape (Ntimes, Nfreqs)
@@ -110,8 +110,10 @@ def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11)):
         wgts : multiplicative wgts of the same shape as the data
         medfilt : boolean, median filter data before fft
         kernel : size of median filter kernel along (time, freq) axes
+        edge_cut : int, number of channels to exclude at each band edge of data in FFT window
     Returns:
         dlys : (Ntimes, 1) ndarray containing delay for each integration
+        offset : (Ntimes, 1) ndarray containing estimated frequency-independent phases
     """
     Ntimes, Nfreqs = data.shape
     if wgts is None:
@@ -122,6 +124,10 @@ def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11)):
         data.imag = signal.medfilt(data.imag, kernel_size=kernel)
     # fft w/ window and find argmax
     dw = data * wgts
+    if edge_cut > 0:
+        assert 2 * edge_cut < Nfreqs - 1, "edge_cut cannot be >= Nfreqs/2 - 1"
+        dw[:, :edge_cut] = 0
+        dw[:, -edge_cut:] = 0
     dw[np.isnan(dw)] = 0
     vfft = np.fft.fft(dw, axis=1)
     amp = np.abs(vfft)
@@ -140,7 +146,8 @@ def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11)):
         dlys[i] = (1.0 - np.abs(shift)) * fftfreqs[mx] + np.abs(shift) * (fftfreqs[mx] + np.sign(shift) * dtau)
     # Now that we know the slope, estimate the remaining phase offset
     freqs = np.arange(Nfreqs, dtype=data.dtype) * df
-    offset = np.angle(np.mean(data * np.exp(-np.complex64(2j * np.pi) * dlys * freqs.reshape(1, -1)), axis=1))
+    fSlice = slice(edge_cut, len(freqs) - edge_cut)
+    offset = np.angle(np.mean(data[:, fSlice] * np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), axis=1))
     return dlys, offset.reshape(-1, 1)
 
 


### PR DESCRIPTION
- Speeds up get_file_lst_range for uvh5 files dramatically by using h5py directly. This is useful because each file's abscal must go through all model files to check 
- Removes abscal_funcs.fft_dly in favor of utils.fft_dly, though edge_cut is added from the former to the latter. This closes #367.