### PR TITLE
Fix HERAData's handling of metadata when multiple files are loaded

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -224,11 +224,11 @@ class HERAData(UVData):
             if len(self.filepaths) > 1:  # save HERAData_metas in dicts
                 for meta in self.HERAData_metas:
                     setattr(self, meta, {})
-                for hd in self.filepaths:
-                    hc = HERAData(hd, filetype='uvh5', **check_kwargs)
-                    meta_dict = self.get_metadata_dict()
+                for f in self.filepaths:
+                    hd = HERAData(f, filetype='uvh5', **check_kwargs)
+                    meta_dict = hd.get_metadata_dict()
                     for meta in self.HERAData_metas:
-                        getattr(self, meta)[hd] = meta_dict[meta]
+                        getattr(self, meta)[f] = meta_dict[meta]
             else:  # save HERAData_metas as attributes
                 self._writers = {}
                 for key, value in self.get_metadata_dict().items():

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -123,14 +123,19 @@ class Test_HERAData(unittest.TestCase):
         # multiple uvh5 files
         files = [self.uvh5_1, self.uvh5_2]
         hd = HERAData(files)
+        individual_hds = {files[0]: HERAData(files[0]), files[1]: HERAData(files[1])}
         self.assertEqual(hd.filepaths, files)
         for meta in hd.HERAData_metas:
             self.assertIsNotNone(getattr(hd, meta))
         for f in files:
             self.assertEqual(len(hd.freqs[f]), 1024)
+            np.testing.assert_array_equal(hd.freqs[f], individual_hds[f].freqs)
             self.assertEqual(len(hd.bls[f]), 3)
+            np.testing.assert_array_equal(hd.bls[f], individual_hds[f].bls)
             self.assertEqual(len(hd.times[f]), 60)
+            np.testing.assert_array_equal(hd.times[f], individual_hds[f].times)
             self.assertEqual(len(hd.lsts[f]), 60)
+            np.testing.assert_array_equal(hd.lsts[f], individual_hds[f].lsts)
         self.assertFalse(hasattr(hd, '_writers'))
 
         # miriad


### PR DESCRIPTION
This closes #426.