### PR TITLE
Remove get_aa_from_calfile

### DIFF
--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -184,21 +184,6 @@ class TestAAFromUV(object):
         nt.assert_equal(len(aa), 88)
 
 
-class TestAAFromCalfile(object):
-    def setUp(self):
-        # define frequencies
-        self.freqs = np.array([0.15])
-
-        # add directory with calfile
-        if CAL_PATH not in sys.path:
-            sys.path.append(CAL_PATH)
-        self.calfile = "hera_test_calfile"
-
-    def test_get_aa_from_calfile(self):
-        aa = utils.get_aa_from_calfile(self.freqs, self.calfile)
-        nt.assert_equal(len(aa), 128)
-
-
 class TestAA(object):
     def setUp(self):
         # define test file that is compatible with get_aa_from_uv

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -318,28 +318,6 @@ def get_aa_from_uv(uvd, freqs=[0.15]):
     return aa
 
 
-def get_aa_from_calfile(freqs, calfile, **kwargs):
-    '''
-    Generate an AntennaArray object from the specified calfile.
-
-    Arguments:
-    ====================
-    freqs: list of frequencies in data file, in GHz
-    calfile: name of calfile, without the .py extension (e.g., hsa7458_v001). Note that this
-        file must be in sys.path.
-
-    Returns:
-    ====================
-    aa: AntennaArray object
-    '''
-    namespace = {}
-    exec('from {calfile} import get_aa'.format(calfile=calfile), namespace)
-
-    # generate aa
-    get_aa = namespace['get_aa']
-    return get_aa(freqs, **kwargs)
-
-
 def JD2LST(JD, longitude=21.42830):
     """
     Input:


### PR DESCRIPTION
This PR removes `get_aa_from_calfile`, which generates aipy `AntennaArray` objects from calfiles. This function involves an `exec` statement, which is significantly slower in python3, and can lead to [stalling out when running automated tests](https://circleci.com/gh/RadioAstronomySoftwareGroup/pyuvdata/35?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). We probably won't need support for calfiles going forward, and any raw data files from H1C onwards can use the `get_aa_from_uv` function.