### PR TITLE
Fix lst-wrap in get_file_lst_range

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -749,7 +749,11 @@ def get_file_lst_range(filepaths, filetype='uvh5', add_int_buffer=False):
             start += int_time / 2
             stop += int_time / 2
         elif filetype == 'uvh5':
-            lsts = np.unwrap(np.unique(h5py.File(f)[u'Header'][u'lst_array']))
+            # get lsts directly from uhv5 file's header, much faster than using empty HERAData object
+            lst_array = np.array(h5py.File(f)[u'Header'][u'lst_array'])
+            lst_indices = np.unique(lst_array.ravel(), return_index=True)[1]
+            # resort by their appearance in lst_array, then unwrap
+            lsts = np.unwrap(lst_array.ravel()[np.sort(lst_indices)])
             start, stop, int_time = lsts[0], lsts[-1], np.median(np.diff(lsts))
 
         # add integration buffer to end of file if desired


### PR DESCRIPTION
Turns out my original solution for speeding this step up neglected the sorting we did in HERAData instantiation (and before that, in io.loav_vis). This addresses the issue for data and/or model files that go over the 2pi to 0 boundary in LST.

(And while I have you, I've moved the step where data is calibration in order to perform a skip when redcal is all flagged.)