### PR TITLE
Remove matplotlib imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,11 @@ First install dependencies.
 
 * numpy >= 1.10
 * scipy
-* matplotlib
 * astropy >=1.2
 * pyephem
 * [uvtools](https://github.com/HERA-Team/uvtools)
 * [aipy](https://github.com/HERA-Team/aipy/)
 * [pyuvdata](https://github.com/HERA-Team/pyuvdata/)
-* [omnical](https://github.com/HERA-Team/omnical/) >= 5.0.2
 * [linsolve](https://github.com/HERA-Team/linsolve)
 * [hera_qm](https://github.com/HERA-Team/hera_qm)
 

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -69,7 +69,6 @@ import numpy as np
 import aipy
 import os
 import copy
-import matplotlib.pyplot as plt
 from pyuvdata import UVData, UVCal
 import pyuvdata.utils as uvutils
 from scipy.signal import windows

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -13,7 +13,6 @@ import sys
 import shutil
 from six.moves import zip
 from scipy import stats
-from matplotlib import pyplot as plt
 from pyuvdata import UVCal, UVData
 import operator
 import functools


### PR DESCRIPTION
`matplotlib` was being imported (but not actually used) in a few places, leading to runtime issues for some users. The list of required packages in the README has also been updated, to reflect the fact that matplotlib is no longer required (as well as omnical, which has been true for some time now).