### PR TITLE
add ability to apply omnical solution to cut baselines

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -254,6 +254,43 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
                                                        and (max_bl_cut is None or l < max_bl_cut))]
     return reds
 
+def extract_cutbls(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None, ex_ubls=None,
+                   pols=None, ex_pols=None, antpos=None, min_bl_cut=None, max_bl_cut=None):
+    '''
+    Extracts all baselines that was filtered out using min_bl_cut ot max_bl_cut. These baselines
+    do not include those that were excluded using 
+    Args:
+        reds: list of lists of redundant (i,j,pol) baseline tuples, e.g. the output of get_reds()
+        bls (optional): baselines to include. Baselines of the form (i,j,pol) include that specific
+            visibility.  Baselines of the form (i,j) are broadcast across all polarizations present in reds.
+        ex_bls (optional): same as bls, but excludes baselines.
+        ants (optional): antennas to include. Only baselines where both antenna indices are in ants
+            are included.  Antennas of the form (i,pol) include that antenna/pol. Antennas of the form i are
+            broadcast across all polarizations present in reds.
+        ex_ants (optional): same as ants, but excludes antennas.
+        ubls (optional): redundant (unique baseline) groups to include. Each baseline in ubls is taken to
+            represent the redundant group containing it. Baselines of the form (i,j) are broadcast across all
+            polarizations, otherwise (i,j,pol) selects a specific redundant group.
+        ex_ubls (optional): same as ubls, but excludes groups.
+        pols (optional): polarizations to include in reds. e.g. ['xx','yy','xy','yx']. Default includes all
+            polarizations in reds.
+        ex_pols (optional): same as pols, but excludes polarizations.
+        antpos: dictionary of antenna positions in the form {ant_index: np.array([x,y,z])}. 1D and 2D also OK.
+        min_bl_cut: cut redundant groups with average baseline lengths shorter than this. Same units as antpos
+            which must be specified.
+        max_bl_cut: cut redundant groups with average baselines lengths longer than this. Same units as antpos
+            which must be specified.
+    Return:
+        cutbls: list of lists of redundant baselines that were cut in the same form as input reds.
+    '''
+    filter_bls =  filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
+                               ex_ubls=None, pols=pols, ex_pols=ex_pols, antpos=antpos)
+    if min_bl_cut is not None or max_bl_cut is not None:
+        assert antpos is not None, 'antpos must be passed in if min_bl_cut or max_bl_cut is specified.'
+        lengths = [np.mean([np.linalg.norm(antpos[bl[1]] - antpos[bl[0]]) for bl in gp]) for gp in filter_bls]
+        cut_bls = [gp for gp, l in zip(reds, lengths) if ((min_bl_cut is None or l < min_bl_cut)
+                                                       and (max_bl_cut is None or l > max_bl_cut))]
+    return cut_bls
 
 def reds_to_antpos(reds, tol=1e-10):
     '''Computes a set of antenna positions consistent with the given redundancies.
@@ -967,7 +1004,7 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, conv_crit=1e
 
 def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_horizon=0.0,
                      flag_nchan_low=0, flag_nchan_high=0, conv_crit=1e-10, maxiter=500,
-                     check_every=10, check_after=50, gain=.4, verbose=False, **filter_reds_kwargs):
+                     check_every=10, check_after=50, gain=.4, verbose=False, fill_cutbls=False, **filter_reds_kwargs):
     '''Perform redundant calibration (firstcal, logcal, and omnical) an entire HERAData object, loading only
     nInt_to_load integrations at a time and skipping and flagging times when the sun is above solar_horizon.
 
@@ -989,6 +1026,8 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
         check_after: start computing omnical convergence only after N iterations (saves computation).
         gain: The fractional step made toward the new solution each omnical iteration. Values in the
             range 0.1 to 0.5 are generally safe. Increasing values trade speed for stability.
+        fill_cutbls: applies the omnical solutions to get the model visibilities for baselines that were 
+                     disregarded while running redcal.
         verbose: print calibration progress updates
         filter_reds_kwargs: additional filters for the redundancies (see redcal.filter_reds for documentation)
 
@@ -1082,6 +1121,26 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
                 for bl in cal['v_omnical'].keys():
                     rv['v_omnical'][bl][tinds, fSlice] = cal['v_omnical'][bl]
                     rv['vf_omnical'][bl][tinds, fSlice] = cal['vf_omnical'][bl]
+                                # fill in model visibilities for cut baselines
+                if fill_cutbls:
+                    unfiltered_reds = get_reds(generate_antdict(hd))
+                    cutbls = extract_cutbls(unfiltered_reds, antpos=generate_antdict(hd), ex_ants=ex_ants,pols=pols,
+                                            **filter_reds_kwargs)
+                    for cgp in cutbls:
+                        k = 0
+                        for cbl in cgp:
+                            if k == 1: break
+                            cal_key0 = (cbl[0] , 'J{}'.format(cbl[2]))
+                            cal_key1 = (cbl[1] , 'J{}'.format(cbl[2]))
+                            try:
+                                rv['v_omnical'][cbl] = hd.get_data(cbl)[tinds, fSlice] / cal['g_omnical'][cal_key0] \
+                                                                                            * cal['g_omnical'][cal_key1]
+                                rv['vf_omnical'][cbl] = np.logical_or(hd.get_flags(cbl)[tinds, fSlice], \
+                                                        cal['gf_omnical'][cal_key0], cal['gf_omnical'][cal_key1])
+                                k += 1
+                            except KeyError:
+                                continue
+
                 if pol_mode in ['1pol', '2pol']:
                     for antpol in cal['chisq'].keys():
                         rv['chisq'][antpol][tinds, fSlice] = cal['chisq'][antpol]

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -254,6 +254,7 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
                                                        and (max_bl_cut is None or l < max_bl_cut))]
     return reds
 
+
 def extract_cutbls(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None, ex_ubls=None,
                    pols=None, ex_pols=None, antpos=None, min_bl_cut=None, max_bl_cut=None):
     '''
@@ -283,14 +284,15 @@ def extract_cutbls(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=No
     Return:
         cutbls: list of lists of redundant baselines that were cut in the same form as input reds.
     '''
-    filter_bls =  filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
-                               ex_ubls=None, pols=pols, ex_pols=ex_pols, antpos=antpos)
+    filter_bls = filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None, 
+                             ex_ubls=None, pols=pols, ex_pols=ex_pols, antpos=antpos)
     if min_bl_cut is not None or max_bl_cut is not None:
         assert antpos is not None, 'antpos must be passed in if min_bl_cut or max_bl_cut is specified.'
         lengths = [np.mean([np.linalg.norm(antpos[bl[1]] - antpos[bl[0]]) for bl in gp]) for gp in filter_bls]
-        cut_bls = [gp for gp, l in zip(reds, lengths) if ((min_bl_cut is None or l < min_bl_cut)
-                                                       and (max_bl_cut is None or l > max_bl_cut))]
+        cut_bls = [gp for gp, l in zip(reds, lengths) if ((min_bl_cut is None or l < min_bl_cut) 
+                                                          and (max_bl_cut is None or l > max_bl_cut))]
     return cut_bls
+
 
 def reds_to_antpos(reds, tol=1e-10):
     '''Computes a set of antenna positions consistent with the given redundancies.
@@ -1121,22 +1123,23 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
                 for bl in cal['v_omnical'].keys():
                     rv['v_omnical'][bl][tinds, fSlice] = cal['v_omnical'][bl]
                     rv['vf_omnical'][bl][tinds, fSlice] = cal['vf_omnical'][bl]
-                                # fill in model visibilities for cut baselines
+                    # fill in model visibilities for cut baselines
                 if fill_cutbls:
                     unfiltered_reds = get_reds(generate_antdict(hd))
-                    cutbls = extract_cutbls(unfiltered_reds, antpos=generate_antdict(hd), ex_ants=ex_ants,pols=pols,
+                    cutbls = extract_cutbls(unfiltered_reds, antpos=generate_antdict(hd), ex_ants=ex_ants, pols=pols,
                                             **filter_reds_kwargs)
                     for cgp in cutbls:
                         k = 0
                         for cbl in cgp:
-                            if k == 1: break
-                            cal_key0 = (cbl[0] , 'J{}'.format(cbl[2]))
-                            cal_key1 = (cbl[1] , 'J{}'.format(cbl[2]))
+                            if k == 1: 
+                                break
+                            cal_key0 = (cbl[0], 'J{}'.format(cbl[2]))
+                            cal_key1 = (cbl[1], 'J{}'.format(cbl[2]))
                             try:
-                                rv['v_omnical'][cbl] = hd.get_data(cbl)[tinds, fSlice] / cal['g_omnical'][cal_key0] \
-                                                                                            * cal['g_omnical'][cal_key1]
-                                rv['vf_omnical'][cbl] = np.logical_or(hd.get_flags(cbl)[tinds, fSlice], \
-                                                        cal['gf_omnical'][cal_key0], cal['gf_omnical'][cal_key1])
+                                v_omnical = hd.get_data(cbl)[tinds, fSlice] / cal['g_omnical'][cal_key0] * cal['g_omnical'][cal_key1]
+                                rv['v_omnical'][cbl] = v_omnical
+                                rv['vf_omnical'][cbl] = np.logical_or(hd.get_flags(cbl)[tinds, fSlice],
+                                                                      cal['gf_omnical'][cal_key0], cal['gf_omnical'][cal_key1])
                                 k += 1
                             except KeyError:
                                 continue

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -875,13 +875,58 @@ def _get_pol_load_list(pols, pol_mode='1pol'):
     return pol_load_list
 
 
+def expand_omni_vis(cal, all_reds, data, flags, nsamples):
+    '''This function expands and harmonizes a calibration solution produced by redcal.redundantly_calibrate
+    to a set of un-filtered redundancies. This only affects omnical visibility solutions. It has three effects:
+        1) Visibility solutions are now keyed by the first entry in each red in all_reds, even if they were
+            originally keyed by a different entry.
+        2) Unique baselines that were exluded from the redundant calibration are filled in by averaging
+            unflagged calibrated visibilities.
+        3) cal gets a new entry, cal['vns_omnical'] which is a nsamples data container of the number of 
+            visibilites that went into each unique baseline solution/average. 
+
+    Arguments:
+        cal: dictionary of redundant calibration solutions produced by redcal.redundantly_calibrate. 
+            Modified in place, including adding an entry with key 'vns_omnical' that gives a number of
+            samples that went into each unique baseline visibility solution
+        all_reds: list of lists of redundant baseline tuples, e.g. (0,1,'xx'). The first
+            item in each list will be treated as the key for the unique baseline. Must be a superset of
+            the reds used for producing cal
+        data: DataContainer mapping baseline-pol tuples like (0,1,'xx') to complex data of 
+            shape (Nt, Nf). Calibrated in place using cal['g_omnical'] and cal['gf_omnical']
+        flags: DataContainer mapping baseline-pol tuples like (0,1,'xx') to boolean flags of
+            shape (Nt, Nf). Modified in place using cal['gf_omnical']
+        nsamples: DataContainer mapping baseline-pol tuples like (0,1,'xx') to float number of samples.
+            Used for counting the number of non-flagged visibilities that went into each redundant group.
+    '''
+    calibrate_in_place(data, cal['g_omnical'], data_flags=flags, cal_flags=cal['gf_omnical'])
+    cal['vns_omnical'] = {}
+
+    for red in all_reds:
+        omni_keys = [bl for bl in red if bl in cal['v_omnical']]
+        assert len(omni_keys) <= 1, "The input calibration's 'v_omnical' entry can have at most visibility per unique baseline group."
+        cal['vns_omnical'][red[0]] = np.sum([nsamples[bl] * (1.0 - flags[bl]) for bl in red], axis=0)
+
+        if len(omni_keys) == 0:  # the omnical solution doesn't have this baseline, so compute it by averaging the calibrated data
+            cal['v_omnical'][red[0]] = np.sum([data[bl] * (1.0 - flags[bl]) * nsamples[bl] for bl in red], axis=0)
+            cal['v_omnical'][red[0]] /= cal['vns_omnical'][red[0]]
+            cal['vf_omnical'][red[0]] = np.logical_or(cal['vns_omnical'][red[0]] == 0, ~np.isfinite(cal['v_omnical'][red[0]]))
+            cal['v_omnical'][red[0]][~np.isfinite(cal['v_omnical'][red[0]])] = 1.0 + 0.0j
+        elif omni_keys[0] != red[0]:  # the omnical solution has the baseline, but it's keyed by something other than red[0]
+            cal['v_omnical'][red[0]] = deepcopy(cal['v_omnical'][omni_keys[0]])
+            cal['vf_omnical'][red[0]] = deepcopy(cal['vf_omnical'][omni_keys[0]])
+            del cal['v_omnical'][omni_keys[0]], cal['vf_omnical'][omni_keys[0]]
+    
+    cal['vns_omnical'] = DataContainer(cal['vns_omnical'])
+
+
 def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, conv_crit=1e-10,
                           maxiter=500, check_every=10, check_after=50, gain=.4):
     '''Performs all three steps of redundant calibration: firstcal, logcal, and omnical.
 
     Arguments:
         data: dictionary or DataContainer mapping baseline-pol tuples like (0,1,'xx') to
-            complex data of shape
+            complex data of shape. Asummed to have no flags.
         reds: list of lists of redundant baseline tuples, e.g. (0,1,'xx'). The first
             item in each list will be treated as the key for the unique baseline.
         freqs: 1D numpy array frequencies in Hz. Optional if inferable from data DataContainer,
@@ -973,6 +1018,7 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
 
     Arguments:
         hd: HERAData object, instantiated with the datafile or files to calibrate. Must be loaded using uvh5.
+            Assumed to have no prior flags.
         nInt_to_load: number of integrations to load and calibrate simultaneously. Default None loads all integrations.
             Partial io requires 'uvh5' filetype for hd. Lower numbers save memory, but incur a CPU overhead.
         pol_mode: polarization mode of redundancies. Can be '1pol', '2pol', '4pol', or '4pol_minV'.
@@ -1002,6 +1048,7 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
         'v_omnical': omnical visibility solutions dictionary with baseline-pol tuple keys that are the
             first elements in each of the sub-lists of reds. Flagged visibilities will be 0.0s.
         'vf_omnical': omnical visibility flag dictionary in the same format. Flags arise from NaNs.
+        'vns_omnical': omnical visibility nsample dictionary that counts the number of unflagged redundancies.
         'chisq': chi^2 per degree of freedom for the omnical solution. Normalized using noise derived
             from autocorrelations. If the inferred pol_mode from reds (see redcal.parse_pol_mode) is
             '1pol' or '2pol', this is a dictionary mapping antenna polarization (e.g. 'Jxx') to chi^2.
@@ -1038,9 +1085,10 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
     # get reds and then intitialize omnical visibility solutions to all 1s and all flagged
     all_reds = get_reds({ant: hd.antpos[ant] for ant in ant_nums}, pol_mode=pol_mode,
                         pols=set([pol for pols in pol_load_list for pol in pols]))
+    rv['v_omnical'] = DataContainer({red[0]: np.ones((nTimes, nFreqs), dtype=np.complex64) for red in all_reds})
+    rv['vf_omnical'] = DataContainer({red[0]: np.ones((nTimes, nFreqs), dtype=bool) for red in all_reds})
+    rv['vns_omnical'] = DataContainer({red[0]: np.ones((nTimes, nFreqs), dtype=np.float32) for red in all_reds})
     filtered_reds = filter_reds(all_reds, ex_ants=ex_ants, antpos=hd.antpos, **filter_reds_kwargs)
-    rv['v_omnical'] = DataContainer({red[0]: np.ones((nTimes, nFreqs), dtype=np.complex64) for red in filtered_reds})
-    rv['vf_omnical'] = DataContainer({red[0]: np.ones((nTimes, nFreqs), dtype=bool) for red in filtered_reds})
 
     # solar flagging
     lat, lon, alt = hd.telescope_location_lat_lon_alt_degrees
@@ -1048,26 +1096,6 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
     solar_flagged = solar_alts > solar_horizon
     if verbose and np.any(solar_flagged):
         print(len(hd.times[solar_flagged]), 'integrations flagged due to sun above', solar_horizon, 'degrees.')
-
-    # function to fill visibilities for missing baselines
-    def fill_in_missing_ubl(all_reds, rv, data):
-        for blg in all_reds:
-            n = 0
-            for blp in blg:
-                if blp in rv['v_omnical'].keys():
-                    break
-                else:
-                    if n == 1:
-                        break
-                    cal_key0 = (blp[0], 'J{}'.format(blp[2]))
-                    cal_key1 = (blp[1], 'J{}'.format(blp[2]))
-                    try:
-                        rv['v_omnical'][blp] = data[blp] / rv['g_omnical'][cal_key0] * rv['g_omnical'][cal_key1]
-                        rv['vf_omnical'][blp] = np.logical_or(rv['gf_omnical'][cal_key0], rv['gf_omnical'][cal_key1])
-                        n += 1
-                    except KeyError:
-                        rv['v_omnical'][blp] = data[blp]
-                        rv['vf_omnical'][blp] = np.ones((nTimes, nFreqs), dtype=bool)
 
     # loop over polarizations and times, performing partial loading if desired
     for pols in pol_load_list:
@@ -1084,14 +1112,16 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
                 if verbose:
                     print('    Now calibrating times', hd.times[tinds[0]], 'through', hd.times[tinds[-1]], '...')
                 if nInt_to_load is None:  # don't perform partial I/O
-                    data, _, _ = hd.build_datacontainers()  # this may contain unused polarizations, but that's OK
+                    data, flags, nsamples = hd.build_datacontainers()  # this may contain unused polarizations, but that's OK
                     for bl in data:
                         data[bl] = data[bl][tinds, :]  # cut down size of DataContainers to match unflagged indices
                 else:  # perform partial i/o
-                    data, _, _ = hd.read(times=hd.times[tinds], frequencies=hd.freqs[fSlice], polarizations=pols)
+                    data, flags, nsamples = hd.read(times=hd.times[tinds], frequencies=hd.freqs[fSlice], polarizations=pols)
                 cal = redundantly_calibrate(data, reds, freqs=hd.freqs[fSlice], times_by_bl=hd.times_by_bl,
                                             conv_crit=conv_crit, maxiter=maxiter,
                                             check_every=check_every, check_after=check_after, gain=gain)
+                expand_omni_vis(cal, filter_reds(all_reds, pols=pols), data, flags, nsamples)
+                
                 # gather results
                 for ant in cal['g_omnical'].keys():
                     rv['g_firstcal'][ant][tinds, fSlice] = cal['g_firstcal'][ant]
@@ -1102,8 +1132,7 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
                 for bl in cal['v_omnical'].keys():
                     rv['v_omnical'][bl][tinds, fSlice] = cal['v_omnical'][bl]
                     rv['vf_omnical'][bl][tinds, fSlice] = cal['vf_omnical'][bl]
-                # fill in model visibilities for cut baselines
-                fill_in_missing_ubl(all_reds, rv, data)
+                    rv['vns_omnical'][bl][tinds, fSlice] = cal['vns_omnical'][bl]
                 if pol_mode in ['1pol', '2pol']:
                     for antpol in cal['chisq'].keys():
                         rv['chisq'][antpol][tinds, fSlice] = cal['chisq'][antpol]
@@ -1224,7 +1253,7 @@ def redcal_run(input_data, filetype='uvh5', firstcal_ext='.first.calfits', omnic
     if verbose:
         print('Now saving omnical visibilities to', os.path.join(outdir, filename_no_ext + omnivis_ext))
     hd.read(bls=cal['v_omnical'].keys())
-    hd.update(data=cal['v_omnical'], flags=cal['vf_omnical'])
+    hd.update(data=cal['v_omnical'], flags=cal['vf_omnical'], nsamples=cal['vns_omnical'])
     hd.history += version.history_string(add_to_history + '\n' + high_z_ant_hist)
     hd.write_uvh5(os.path.join(outdir, filename_no_ext + omnivis_ext), clobber=True)
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -239,6 +239,29 @@ class TestMethods(unittest.TestCase):
         # exclude crosspols
         # reds = omni.filter_reds(self.info.get_reds(), ex_crosspols=()
 
+    def test_extract_cutbls(self):
+        antpos = build_linear_array(7)
+        reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
+        # extractng baselines shorter than 15 m
+        r = om.extract_cutbls(reds, min_bl_cut=15, antpos=antpos)
+        self.assertEqual(r, [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (4, 5, 'xx'), (5, 6, 'xx')]])
+        antpos = build_linear_array(7)
+        reds = om.get_reds(antpos, pols=['xx', 'yy'], pol_mode='2pol')
+        r = om.extract_cutbls(reds, min_bl_cut=15, antpos=antpos)
+        self.assertEqual(r, [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (4, 5, 'xx'), (5, 6, 'xx')],
+                            [(0, 1, 'yy'), (1, 2, 'yy'), (2, 3, 'yy'), (3, 4, 'yy'), (4, 5, 'yy'), (5, 6, 'yy')]])
+        # extracting baselines greater than 60 m
+        reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
+        r = om.extract_cutbls(reds, max_bl_cut=60, antpos=antpos)
+        self.assertEqual(r, [[(0, 5, 'xx'), (1, 6, 'xx')], [(0, 6, 'xx')]])
+
+        antpos = build_hex_array(2)
+        reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
+        r = om.extract_cutbls(reds, min_bl_cut=15, antpos=antpos)
+        self.assertEqual(r, [[(0, 3, 'xx'), (1, 4, 'xx'), (2, 5, 'xx'), (3, 6, 'xx')],
+                            [(0, 2, 'xx'), (1, 3, 'xx'), (3, 5, 'xx'), (4, 6, 'xx')],
+                            [(0, 1, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (5, 6, 'xx')]])
+
     def test_filter_reds_2pol(self):
         antpos = build_linear_array(4)
         reds = om.get_reds(antpos, pols=['xx', 'yy'], pol_mode='1pol')
@@ -1094,6 +1117,17 @@ class TestRunMethods(unittest.TestCase):
             np.testing.assert_array_equal(flag, True)
         for flag in rv['vf_omnical'].values():
             np.testing.assert_array_equal(flag, True)
+
+        rv = om.redcal_iteration(hd, min_bl_cut=30)
+        if not (1, 12, 'xx') in rv['v_omnical'].keys(): stm=True
+        self.assertIs(stm, True)
+        if not (1, 12, 'xx') in rv['vf_omnical'].keys(): stm = True
+        self.assertIs(stm, True)
+        rv = om.redcal_iteration(hd, min_bl_cut=30, fill_cutbls=True)
+        if (1, 12, 'xx') in rv['v_omnical'].keys(): stm = True
+        self.assertIs(stm, True)
+        if (1, 12, 'xx') in rv['vf_omnical'].keys(): stm = True
+        self.assertIs(stm, True)
 
     def test_redcal_run(self):
         input_data = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -249,7 +249,7 @@ class TestMethods(unittest.TestCase):
         reds = om.get_reds(antpos, pols=['xx', 'yy'], pol_mode='2pol')
         r = om.extract_cutbls(reds, min_bl_cut=15, antpos=antpos)
         self.assertEqual(r, [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (4, 5, 'xx'), (5, 6, 'xx')],
-                            [(0, 1, 'yy'), (1, 2, 'yy'), (2, 3, 'yy'), (3, 4, 'yy'), (4, 5, 'yy'), (5, 6, 'yy')]])
+                         [(0, 1, 'yy'), (1, 2, 'yy'), (2, 3, 'yy'), (3, 4, 'yy'), (4, 5, 'yy'), (5, 6, 'yy')]])
         # extracting baselines greater than 60 m
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
         r = om.extract_cutbls(reds, max_bl_cut=60, antpos=antpos)
@@ -259,8 +259,8 @@ class TestMethods(unittest.TestCase):
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
         r = om.extract_cutbls(reds, min_bl_cut=15, antpos=antpos)
         self.assertEqual(r, [[(0, 3, 'xx'), (1, 4, 'xx'), (2, 5, 'xx'), (3, 6, 'xx')],
-                            [(0, 2, 'xx'), (1, 3, 'xx'), (3, 5, 'xx'), (4, 6, 'xx')],
-                            [(0, 1, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (5, 6, 'xx')]])
+                         [(0, 2, 'xx'), (1, 3, 'xx'), (3, 5, 'xx'), (4, 6, 'xx')],
+                         [(0, 1, 'xx'), (2, 3, 'xx'), (3, 4, 'xx'), (5, 6, 'xx')]])
 
     def test_filter_reds_2pol(self):
         antpos = build_linear_array(4)
@@ -1119,14 +1119,14 @@ class TestRunMethods(unittest.TestCase):
             np.testing.assert_array_equal(flag, True)
 
         rv = om.redcal_iteration(hd, min_bl_cut=30)
-        if not (1, 12, 'xx') in rv['v_omnical'].keys(): stm=True
+        stm = True if not (1, 12, 'xx') in rv['v_omnical'].keys()
         self.assertIs(stm, True)
-        if not (1, 12, 'xx') in rv['vf_omnical'].keys(): stm = True
+        stm = True if not (1, 12, 'xx') in rv['vf_omnical'].keys()
         self.assertIs(stm, True)
         rv = om.redcal_iteration(hd, min_bl_cut=30, fill_cutbls=True)
-        if (1, 12, 'xx') in rv['v_omnical'].keys(): stm = True
+        stm = True if (1, 12, 'xx') in rv['v_omnical'].keys()
         self.assertIs(stm, True)
-        if (1, 12, 'xx') in rv['vf_omnical'].keys(): stm = True
+        stm = True if (1, 12, 'xx') in rv['vf_omnical'].keys()
         self.assertIs(stm, True)
 
     def test_redcal_run(self):


### PR DESCRIPTION
If max_bl_cut or min_bl_cut is enable while running redcal, there are no model visibilities for those cut baselines, there it is useful to add the ability to generated the model visibilities for those baselines using the gain solutions.