### PR TITLE
Significantly improve fft_dly and fix phase offset solving

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -384,7 +384,7 @@ def phs_logcal(model, data, wgts=None, refant=None, verbose=True):
     return fit
 
 
-def delay_lincal(model, data, wgts=None, refant=None, df=9.765625e4, solve_offsets=True, medfilt=True,
+def delay_lincal(model, data, wgts=None, refant=None, df=9.765625e4, f0=0., solve_offsets=True, medfilt=True,
                  kernel=(1, 5), verbose=True, antpos=None, four_pol=False, edge_cut=0):
     """
     Solve for per-antenna delays according to the equation
@@ -416,6 +416,8 @@ def delay_lincal(model, data, wgts=None, refant=None, df=9.765625e4, solve_offse
         zero across all freqs. By default use the first key in data.
 
     df : type=float, frequency spacing between channels in Hz
+
+    f0 : type=float, frequency of the first channel in the data (used for offsets)
 
     medfilt : type=boolean, median filter visiblity ratio before taking fft
 
@@ -461,7 +463,7 @@ def delay_lincal(model, data, wgts=None, refant=None, df=9.765625e4, solve_offse
         wgts[k][inf_select] = 0.0
 
         # get delays
-        dly, offset = utils.fft_dly(ratio, df, wgts=wgts[k], medfilt=medfilt, kernel=kernel, edge_cut=edge_cut)
+        dly, offset = utils.fft_dly(ratio, df, f0=f0, wgts=wgts[k], medfilt=medfilt, kernel=kernel, edge_cut=edge_cut)
 
         # set nans to zero
         rwgts = np.nanmean(wgts[k], axis=1, keepdims=True)
@@ -2030,7 +2032,7 @@ class AbsCal(object):
 
         # run delay_lincal
         fit = delay_lincal(model, data, wgts=wgts, refant=self.refant, medfilt=medfilt, df=df, 
-                           kernel=kernel, verbose=verbose, edge_cut=edge_cut)
+                           f0=self.freqs[0], kernel=kernel, verbose=verbose, edge_cut=edge_cut)
 
         # time average
         if time_avg:

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -594,7 +594,7 @@ class RedundantCalibrator:
         """
         Nfreqs = data[next(iter(data))].shape[1]  # hardcode freq is axis 1 (time is axis 0)
         if len(wgts) == 0:
-            wgts = {k: np.float32(1) for k in data}
+            wgts = {k: np.ones_like(data[k], dtype=np.float32) for k in data}
         wgts = DataContainer(wgts)
         taus_offs, twgts = {}, {}
         for bls in self.reds:

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -690,7 +690,7 @@ def fit_reflection_delay(dfft, dly_range, dlys, return_peak=False):
 
     # locate peak bin within dly range
     abs_dfft = np.abs(dfft)[:, select]
-    ref_dly_inds, bin_shifts, _, ref_peaks = interp_peak(dfft[:, select])
+    ref_dly_inds, bin_shifts, _, ref_peaks = interp_peak(abs_dfft, method='quadratic')
     ref_dly_inds += select.min()
     ref_dlys = dlys[ref_dly_inds, None] + bin_shifts[:, None] * np.median(np.diff(dlys))
     ref_peaks = ref_peaks[:, None]
@@ -753,7 +753,7 @@ def fit_reflection_phase(dfft, dly_range, dlys, ref_dlys, fthin=1, Nphs=500, iff
     residuals = np.sum((filt[None, :, ::fthin].real - cosines.real)**2, axis=-1)
 
     # quadratic interp of residuals to get reflection phase
-    inds, bin_shifts, _, _ = interp_peak(-residuals.T)
+    inds, bin_shifts, _, _ = interp_peak(-residuals.T, method='quadratic')
     ref_phs = (phases[inds] + bin_shifts * np.median(np.diff(phases)))[:, None] % (2 * np.pi)
 
     # get reflection phase by interpolation: this didn't work well in practice

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -690,7 +690,7 @@ def fit_reflection_delay(dfft, dly_range, dlys, return_peak=False):
 
     # locate peak bin within dly range
     abs_dfft = np.abs(dfft)[:, select]
-    ref_dly_inds, bin_shifts, _, ref_peaks = interp_peak(abs_dfft)
+    ref_dly_inds, bin_shifts, _, ref_peaks = interp_peak(dfft[:, select])
     ref_dly_inds += select.min()
     ref_dlys = dlys[ref_dly_inds, None] + bin_shifts[:, None] * np.median(np.diff(dlys))
     ref_peaks = ref_peaks[:, None]

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -122,7 +122,7 @@ class TestFftDly(object):
     def test_noisy(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
         true_dlys.shape = (60, 1)
-        data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys) + 5*noise((60, 1024))
+        data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys) + 5 * noise((60, 1024))
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df)
         nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1)  # median accuracy of 1 ns
@@ -145,7 +145,7 @@ class TestFftDly(object):
         data[:, ::16] = np.nan
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df)
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-3) # median accuracy of 1 ps
+        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-3)  # median accuracy of 1 ps
 
     def test_realistic(self):
         # load into pyuvdata object
@@ -153,21 +153,22 @@ class TestFftDly(object):
         model_fname = os.path.join(DATA_PATH, "zen.2458042.12552.xx.HH.uvXA")
         # make custom gain keys
         d, fl, antpos, a, freqs, t, l, p = io.load_vis(data_fname, return_meta=True, pick_data_ants=False)
-        freqs /= 1e9 # in GHz
+        freqs /= 1e9  # in GHz
         # test basic execution
         k1 = (24, 25, 'xx')
         k2 = (37, 38, 'xx')
         flat_phs = d[k1] * d[k2].conj()
         df = np.median(np.diff(freqs))
         # basic execution
-        dlys, offs = utils.fft_dly(flat_phs, df, medfilt=True, f0=freqs[0]) # dlys in ns
+        dlys, offs = utils.fft_dly(flat_phs, df, medfilt=True, f0=freqs[0])  # dlys in ns
         nt.assert_equal(dlys.shape, (60, 1))
-        nt.assert_true(np.all(np.abs(dlys) < 1)) # all delays near zero
+        nt.assert_true(np.all(np.abs(dlys) < 1))  # all delays near zero
         true_dlys = np.random.uniform(-20, 20, size=60)
         true_dlys.shape = (60, 1)
         phs = np.exp(2j * np.pi * freqs.reshape((1, -1)) * (true_dlys + dlys))
         dlys, offs = utils.fft_dly(flat_phs * phs, df, medfilt=True, f0=freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 2) # median accuracy better than 2 ns
+        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 2)  # median accuracy better than 2 ns
+
 
 class TestAAFromUV(object):
     def setUp(self):

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -169,6 +169,12 @@ class TestFftDly(object):
         dlys, offs = utils.fft_dly(flat_phs * phs, df, medfilt=True, f0=freqs[0])
         nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 2)  # median accuracy better than 2 ns
 
+    def test_error(self):
+        true_dlys = np.random.uniform(-200, 200, size=60)
+        true_dlys.shape = (60, 1)
+        data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys)
+        nt.assert_raises(ValueError, utils.interp_peak, np.fft.fft(data), method='blah')
+
 
 class TestAAFromUV(object):
     def setUp(self):

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -189,6 +189,7 @@ def interp_peak(ft_data):
     delta1 = alpha1 / (1 - alpha1)
     delta2 = -alpha2 / (1 - alpha2)
     d = (delta1 + delta2) / 2 + tau(delta1**2) - tau(delta2**2)
+    d[~np.isfinite(d)] = 0.
     
     ck = np.array([(np.exp(2.0j*np.pi*d) - 1) / (2.0j * np.pi * (d - k)) for k in [-1, 0, 1]])
     rho = np.abs(k0 * ck[0] + k1 * ck[1] + k2 * ck[2]) / np.abs(np.sum(ck**2))

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -102,12 +102,13 @@ def make_bl(*args):
     return (i, j, _comply_vispol(pol))
 
 
-def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11), edge_cut=0):
+def fft_dly(data, df, wgts=None, f0=0.0, medfilt=False, kernel=(1, 11), edge_cut=0):
     """Get delay of visibility across band using FFT and quadratic fit to delay peak.
     Arguments:
         data : ndarray of complex data (e.g. gains or visibilities) of shape (Ntimes, Nfreqs)
         df : frequency channel width in Hz
         wgts : multiplicative wgts of the same shape as the data
+        f0 : float lowest frequency channel. Optional parameter used in getting the offset correct.
         medfilt : boolean, median filter data before fft
         kernel : size of median filter kernel along (time, freq) axes
         edge_cut : int, number of channels to exclude at each band edge of data in FFT window
@@ -141,7 +142,7 @@ def fft_dly(data, df, wgts=None, medfilt=False, kernel=(1, 11), edge_cut=0):
     dlys = (fftfreqs[inds] + bin_shifts * dtau).reshape(-1, 1)
 
     # Now that we know the slope, estimate the remaining phase offset
-    freqs = np.arange(Nfreqs, dtype=data.dtype) * df
+    freqs = np.arange(Nfreqs, dtype=data.dtype) * df  + f0
     fSlice = slice(edge_cut, len(freqs) - edge_cut)
     offset = np.angle(np.mean(data[:, fSlice] * np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), axis=1, keepdims=True))
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -141,10 +141,10 @@ def fft_dly(data, df, wgts=None, f0=0.0, medfilt=False, kernel=(1, 11), edge_cut
     dlys = (fftfreqs[inds] + bin_shifts * dtau).reshape(-1, 1)
 
     # Now that we know the slope, estimate the remaining phase offset
-    freqs = np.arange(Nfreqs, dtype=data.dtype) * df  + f0
+    freqs = np.arange(Nfreqs, dtype=data.dtype) * df + f0
     fSlice = slice(edge_cut, len(freqs) - edge_cut)
-    offset = np.angle(np.sum(wgts[:, fSlice] * data[:, fSlice] * 
-                             np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), 
+    offset = np.angle(np.sum(wgts[:, fSlice] * data[:, fSlice]
+                             * np.exp(-np.complex64(2j * np.pi) * dlys * freqs[fSlice].reshape(1, -1)), 
                              axis=1, keepdims=True) / np.sum(wgts[:, fSlice], axis=1, keepdims=True))
 
     return dlys, offset
@@ -191,7 +191,7 @@ def interp_peak(ft_data):
     d = (delta1 + delta2) / 2 + tau(delta1**2) - tau(delta2**2)
     d[~np.isfinite(d)] = 0.
     
-    ck = np.array([(np.exp(2.0j*np.pi*d) - 1) / (2.0j * np.pi * (d - k)) for k in [-1, 0, 1]])
+    ck = np.array([(np.exp(2.0j * np.pi * d) - 1) / (2.0j * np.pi * (d - k)) for k in [-1, 0, 1]])
     rho = np.abs(k0 * ck[0] + k1 * ck[1] + k2 * ck[2]) / np.abs(np.sum(ck**2))
     
     return indices, d, np.abs(peaks), rho

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -191,8 +191,10 @@ def interp_peak(ft_data):
     d = (delta1 + delta2) / 2 + tau(delta1**2) - tau(delta2**2)
     d[~np.isfinite(d)] = 0.
     
-    ck = np.array([(np.exp(2.0j * np.pi * d) - 1) / (2.0j * np.pi * (d - k)) for k in [-1, 0, 1]])
+    ck = np.array([np.true_divide(np.exp(2.0j * np.pi * d) - 1, 2.0j * np.pi * (d - k), 
+                                  where=~(d == 0)) for k in [-1, 0, 1]])
     rho = np.abs(k0 * ck[0] + k1 * ck[1] + k2 * ck[2]) / np.abs(np.sum(ck**2))
+    rho[d == 0] = np.abs(k1[d == 0])
     
     return indices, d, np.abs(peaks), rho
 


### PR DESCRIPTION
As mentioned in https://github.com/HERA-Team/hera_cal/issues/141#issuecomment-470417003, I found a much better way to estimate delays using an improved peak-finding algorithm. I've implemented that.

In the process of doing that, I found a bug in how phase offsets were calculated and fixed it (see #445).

It's not 100% obvious whether we want to include phase offsets in firstcal (we currently don't, but at least now we can), so I haven't modified redcal substantially. That's an issue I'll look into later in the context of validation. 

This closes #141 and closes #445.