### PR TITLE
Fix flag_nchan_high/low in redcal with no partial I/O

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1114,7 +1114,9 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', ex_ants=[], solar_h
                 if nInt_to_load is None:  # don't perform partial I/O
                     data, flags, nsamples = hd.build_datacontainers()  # this may contain unused polarizations, but that's OK
                     for bl in data:
-                        data[bl] = data[bl][tinds, :]  # cut down size of DataContainers to match unflagged indices
+                        data[bl] = data[bl][tinds, fSlice]  # cut down size of DataContainers to match unflagged indices
+                        flags[bl] = flags[bl][tinds, fSlice]
+                        nsamples[bl] = nsamples[bl][tinds, fSlice] 
                 else:  # perform partial i/o
                     data, flags, nsamples = hd.read(times=hd.times[tinds], frequencies=hd.freqs[fSlice], polarizations=pols)
                 cal = redundantly_calibrate(data, reds, freqs=hd.freqs[fSlice], times_by_bl=hd.times_by_bl,

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1129,6 +1129,16 @@ class TestRunMethods(unittest.TestCase):
                 self.assertFalse(np.all(flag[t, :]))
                 self.assertTrue(np.all(flag[t, 0:30]))
                 self.assertTrue(np.all(flag[t, -40:]))
+        
+        hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))  # test w/o partial loading
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            rv = om.redcal_iteration(hd, flag_nchan_high=40, flag_nchan_low=30)
+        for t in range(len(hd.times)):
+            for flag in rv['gf_omnical'].values():
+                self.assertFalse(np.all(flag[t, :]))
+                self.assertTrue(np.all(flag[t, 0:30]))
+                self.assertTrue(np.all(flag[t, -40:]))                
 
         hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))
         with warnings.catch_warnings():


### PR DESCRIPTION
In the case where redcal is performed without partial I/O but edge channels are flagged, we get an dimension mismatch error. This fixes the error and adds a test to expose it.