### PR TITLE
Make unittest pass deterministically on python3

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -49,8 +49,8 @@ def sim_red_data(reds, gains=None, shape=(10, 10), gain_scatter=.1):
     """
 
     data, true_vis = {}, {}
-    ants = list(set([ant for bls in reds for bl in bls for ant in
-                    [(bl[0], split_pol(bl[2])[0]), (bl[1], split_pol(bl[2])[1])]]))
+    ants = sorted(list(set([ant for bls in reds for bl in bls for ant in
+                  [(bl[0], split_pol(bl[2])[0]), (bl[1], split_pol(bl[2])[1])]])))
     if gains is None:
         gains = {}
     else:

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1064,10 +1064,10 @@ class TestRedcalAndAbscal(unittest.TestCase):
         up to an overall phase (which is handled by using a reference antenna).'''
         # Simulate Redundant Data
         np.random.seed(21)
-        antpos = build_hex_array(2)
+        antpos = build_hex_array(3)
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
         rc = om.RedundantCalibrator(reds)
-        freqs = np.linspace(1e8, 2e8, 1024)
+        freqs = np.linspace(1e8, 2e8, 256)
         gains, true_vis, d = om.sim_red_data(reds, gain_scatter=.1, shape=(2, len(freqs)))
         fc_delays = {ant: 100e-9 * np.random.randn() for ant in gains.keys()}  # in s
         fc_offsets = {ant: 2 * np.pi * np.random.rand() for ant in gains.keys()}  # random phase offsets


### PR DESCRIPTION
The issue @bhazelton was seeing was with the list of antennas coming from a set, which could change its order under different runs of the unittest. This fixes it so that the test passes deterministically.