### PR TITLE
Speed up reference antenna selection

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -204,7 +204,6 @@ def pick_reference_antenna(gains, flags, freqs, per_pol=True):
         (dlys, phis) = utils.fft_dly(gains[ant], df, wgts, medfilt=False, f0=freqs[0])
         rephasors[ant] = np.exp(-2.0j * np.pi * np.mean(dlys), freqs - 1.0j * np.mean(phis))
 
-    # least noisy phases in other antennas when its the reference antenna (after taking out delays)
     def narrow_refant_candidates(candidates):
     '''Helper function for comparing refant candidates to another another looking for the one with the 
     least noisy phases in other antennas when its the reference antenna (after taking out delays)'''

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -206,6 +206,8 @@ def pick_reference_antenna(gains, flags, freqs, per_pol=True):
 
     # least noisy phases in other antennas when its the reference antenna (after taking out delays)
     def narrow_refant_candidates(candidates):
+    '''Helper function for comparing refant candidates to another another looking for the one with the 
+    least noisy phases in other antennas when its the reference antenna (after taking out delays)'''
         median_angle_noise_as_refant = {}
         for ref in candidates:
             refant_rephasor = np.abs(gains[ref] * rephasors[ref]) / (gains[ref] * rephasors[ref])

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -205,8 +205,8 @@ def pick_reference_antenna(gains, flags, freqs, per_pol=True):
         rephasors[ant] = np.exp(-2.0j * np.pi * np.mean(dlys), freqs - 1.0j * np.mean(phis))
 
     def narrow_refant_candidates(candidates):
-    '''Helper function for comparing refant candidates to another another looking for the one with the 
-    least noisy phases in other antennas when its the reference antenna (after taking out delays)'''
+        '''Helper function for comparing refant candidates to another another looking for the one with the 
+        least noisy phases in other antennas when its the reference antenna (after taking out delays)'''
         median_angle_noise_as_refant = {}
         for ref in candidates:
             refant_rephasor = np.abs(gains[ref] * rephasors[ref]) / (gains[ref] * rephasors[ref])

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -224,6 +224,7 @@ def pick_reference_antenna(gains, flags, freqs, per_pol=True):
         refant_candidates = sorted([ant for ant, nflags in flags_per_ant.items() 
                                     if nflags == np.min(list(flags_per_ant.values()))])
         while len(refant_candidates) > 1:  # loop over groups of 3 (the smallest, non-trivial size)
+            # compare phase noise imparted by reference antenna candidates on two other reference antenna candidates
             refant_candidates = [narrow_refant_candidates(candidates) for candidates in [refant_candidates[i:i + 3]
                                  for i in range(0, len(refant_candidates), 3)]]
         if not per_pol:

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -104,7 +104,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         for n in range(0, 7):  # add flags to disqualify antennas 0, 1, 2, 3, 4, 5, 6
             flags[(n, 'Jxx')][:, 4] = True
         for n in range(6, 9):  # add phase noise to disqualify antennas 6, 7, 8
-            gains[(n, 'Jxx')] *= np.exp(.1j * np.pi * np.random.rand(10, 10))
+            gains[(n, 'Jxx')] *= np.exp(.1j * np.pi * np.random.rand(10, 10))  # want this to be << 2pi to avoid phase wraps
         self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs, per_pol=False), (9, 'Jxx'))
         self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs), {'Jxx': (9, 'Jxx')})
 

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -104,7 +104,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         for n in range(0, 7):  # add flags to disqualify antennas 0, 1, 2, 3, 4, 5, 6
             flags[(n, 'Jxx')][:, 4] = True
         for n in range(6, 9):  # add phase noise to disqualify antennas 6, 7, 8
-            gains[(n, 'Jxx')] *= np.exp(2j * np.pi * np.random.rand(10, 10))
+            gains[(n, 'Jxx')] *= np.exp(.1j * np.pi * np.random.rand(10, 10))
         self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs, per_pol=False), (9, 'Jxx'))
         self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs), {'Jxx': (9, 'Jxx')})
 

--- a/scripts/smooth_cal_run.py
+++ b/scripts/smooth_cal_run.py
@@ -21,7 +21,7 @@ if a.window == 'tukey':  # set window kwargs
 
 if a.run_if_first is None or sorted(a.calfits_list)[0] == a.run_if_first:
     cs = CalibrationSmoother(a.calfits_list, flag_file_list=a.flag_file_list, flag_filetype=a.flag_filetype,
-                             pick_refant=a.pick_refant, antflag_thresh=a.antflag_thresh)
+                             pick_refant=a.pick_refant, antflag_thresh=a.antflag_thresh, verbose=a.verbose)
     cs.time_freq_2D_filter(freq_scale=a.freq_scale, time_scale=a.time_scale, tol=a.tol,
                            filter_mode=a.filter_mode, window=a.window, maxiter=a.maxiter, **win_kwargs)
     cs.write_smoothed_cal(output_replace=(a.infile_replace, a.outfile_replace),


### PR DESCRIPTION
This PR speeds up reference antenna selection in smooth_cal, which was quite slow (roughly half an hour for a whole day). 

Before, the algorithm looked at the phase noise in every antenna if a given reference antenna is chosen. This scales like O(Nantennas^2). Instead, I now look at groups of 3 antennas (the smallest non-trivial case), pick the best antenna, and then iterate, continually downselecting by a factor of 3 until a single antenna is chosen. This scales like O(NlogN) and should be able to pick a reference antenna for the whole day in a few minutes.

I've also added a verbose option to smooth_cal.