### PR TITLE
Fix issue where abscal fails to run (flagging everything) in python 3

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2920,7 +2920,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, output_file=None
                     auto_bls = [bl for bl in hd.bls if (bl[0] == bl[1]) and bl[2] == pol]
                     autocorrs = DataContainer({bl: copy.deepcopy(data[bl]) for bl in auto_bls})
 
-                    if not np.all(flags.values()):
+                    if not np.all(list(flags.values())):
                         # load model and rephase
                         model_times_to_load = [d2m_time_map[time] for time in hd.times[tinds]]
                         model, model_flags, _ = io.partial_time_io(hdm, model_times_to_load, polarizations=[pol])

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -752,6 +752,7 @@ class Test_Post_Redcal_Abscal_Run:
             nt.assert_equal(ac_flags[k].shape, rc_flags[k].shape)
             nt.assert_equal(ac_flags[k].dtype, bool)
             np.testing.assert_array_equal(ac_flags[k][rc_flags[k]], rc_flags[k][rc_flags[k]])
+        nt.assert_false(np.all(list(ac_flags.values())))
         for pol in ['Jxx', 'Jyy']:
             nt.assert_true(pol in ac_total_qual)
             nt.assert_equal(ac_total_qual[pol].shape, rc_total_qual[pol].shape)


### PR DESCRIPTION
We missed a .values() --> list(.values())