### PR TITLE
Fix degeneracy counting in redcal edge cases

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -484,17 +484,27 @@ class OmnicalSolver(linsolve.LinProductSolver):
 
 class RedundantCalibrator:
 
-    def __init__(self, reds):
+    def __init__(self, reds, check_redundancy=False):
         """Initialization of a class object for performing redundant calibration with logcal
         and lincal, both utilizing linsolve, and also degeneracy removal.
 
         Args:
             reds: list of lists of redundant baseline tuples, e.g. (ind1,ind2,pol). The first
                 item in each list will be treated as the key for the unique baseline
+            check_redundancy: if True, raise an error if the array is not redundantly calibratable, 
+                allowing an arbitrary number of phase slope degeneracies.
         """
 
         self.reds = reds
         self.pol_mode = parse_pol_mode(self.reds)
+
+        if check_redundancy:
+            nDegens = self.count_degens(assume_redundant=False)
+            nDegensExpected = self.count_degens()
+            if nDegens != nDegensExpected:
+                nPhaseSlopes = len(list(reds_to_antpos(self.reds).values())[0])
+                raise ValueError('{} degeneracies found, but {} '.format(nDegens, nDegensExpected) +
+                                 'degeneracies expected (assuming {} phase slopes).'.format(nPhaseSlopes))
 
     def build_eqs(self, dc=None):
         """Function for generating linsolve equation strings. Optionally takes in a DataContainer to check

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -492,7 +492,7 @@ class RedundantCalibrator:
             reds: list of lists of redundant baseline tuples, e.g. (ind1,ind2,pol). The first
                 item in each list will be treated as the key for the unique baseline
             check_redundancy: if True, raise an error if the array is not redundantly calibratable, 
-                allowing an arbitrary number of phase slope degeneracies.
+                even when allowing for an arbitrary number of phase slope degeneracies.
         """
 
         self.reds = reds

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -503,8 +503,8 @@ class RedundantCalibrator:
             nDegensExpected = self.count_degens()
             if nDegens != nDegensExpected:
                 nPhaseSlopes = len(list(reds_to_antpos(self.reds).values())[0])
-                raise ValueError('{} degeneracies found, but {} '.format(nDegens, nDegensExpected) +
-                                 'degeneracies expected (assuming {} phase slopes).'.format(nPhaseSlopes))
+                raise ValueError('{} degeneracies found, but {} '.format(nDegens, nDegensExpected)
+                                 + 'degeneracies expected (assuming {} phase slopes).'.format(nPhaseSlopes))
 
     def build_eqs(self, dc=None):
         """Function for generating linsolve equation strings. Optionally takes in a DataContainer to check
@@ -893,7 +893,7 @@ class RedundantCalibrator:
             else:  # '4pol_minV'
                 return 2 + 1 + nPhaseSlopes  # 4pol_minV ties overall phase together, so just 1 overall phase
         else:
-            dummy_data = DataContainer({bl: np.ones((1,1), dtype=np.complex) for red in self.reds for bl in red})
+            dummy_data = DataContainer({bl: np.ones((1, 1), dtype=np.complex) for red in self.reds for bl in red})
             solver = self._solver(linsolve.LogProductSolver, dummy_data)
             return np.sum([A.shape[1] - np.linalg.matrix_rank(np.dot(np.squeeze(A).T, np.squeeze(A)))
                            for A in [solver.ls_amp.get_A(), solver.ls_phs.get_A()]])


### PR DESCRIPTION
I noticed some cases where the array was too small to be redundantly calibratable but was being counted as redundant, creating issues in `is_redundantly_calibratable()` and chi^2.

This PR:
* modifies `RedundantCalibrator.count_degens()` to use the matrix rank method when asked
* modifies `RedundantCalibrator.__init__()` to include an optional check for redundancy
* modifies `is_redundantly_calibratable()` to use the matrix rank method and optionally impose the coplanarity requirement (2 or fewer phase slope degeneracies)
* adds unit tests to expose the issue

This closes #458.