### PR TITLE
Update extract_hh.py script

### DIFF
--- a/scripts/extract_hh.py
+++ b/scripts/extract_hh.py
@@ -1,69 +1,47 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2018 the HERA Project
+# Copyright 2019 The HERA Collaboration
 # Licensed under the MIT License
 
+from __future__ import print_function, division, absolute_import
 import os
-import argparse
-import pyuvdata
-from hera_cal.version import version_info
-import pyuvdata.utils as uvutils
+import sys
 import numpy as np
+import argparse
+from pyuvdata import UVData
+from pyuvdata.uvh5 import _hera_corr_dtype
 
-parser = argparse.ArgumentParser(description='Extract HERA hex antennas from data '
-                                 'file, and save with new extension.')
-parser.add_argument('--extension', type=str, help='Extension to be appended to '
-                    'filename for output. Default="HH".', default='HH')
-parser.add_argument('--filetype', type=str, help='Input and output file type. '
-                    'Allowed values are "miriad" (default), and "uvfits".',
-                    default='miriad')
-parser.add_argument('--fixuvws', action='store_true', help='Optional flag to '
-                    'use antenna positions to replace uvws.')
-parser.add_argument('--overwrite', action='store_true', default=False,
-                    help='Optional flag to overwrite output file if it exists.')
-parser.add_argument('files', metavar='files', type=str, nargs='+',
-                    help='Files to be processed.')
-parser.add_argument('--ex_ants_file', type=str, help='Text file with list of antennas'
-                    ' which are excluded downstream in RTP. Generally, these are '
-                    'antennas which are being actively commissioned, or known as bad.'
-                    ' Note these values are only stored in the history, not actually '
-                    'flagged at this step.',
-                    default=None)
-args = parser.parse_args()
+# create an argument parser and parse args
+ap = argparse.ArgumentParser(description="Extract only connected antennas from full correlator data")
+ap.add_argument("input_file", type=str, help="Full path to target file")
+ap.add_argument("output_file", type=str, help="Full path to output file")
+ap.add_argument("--overwrite", action="store_true", default=False,
+                help="Optional flag to overwrite output file if it exists")
+args = ap.parse_args()
 
-for filename in args.files:
-    uv = pyuvdata.UVData()
-    if args.filetype == 'miriad':
-        uv.read_miriad(filename)
-    elif args.filetype == 'uvfits':
-        uv.read_uvfits(filename)
-    else:
-        raise ValueError('Unrecognized file type ' + str(args.filetype))
-    st_type_str = uv.extra_keywords.pop('st_type').replace('\x00', '')
-    st_type_list = st_type_str[1:-1].split(', ')
-    ind = [i for i, x in enumerate(st_type_list) if x[:7] == 'herahex' or x == 'heraringa' or x == 'heraringb']
-    uv.select(antenna_nums=uv.antenna_numbers[ind])
-    st_type_list = list(np.array(st_type_list)[np.array(ind, dtype=int)])
-    uv.extra_keywords['st_type'] = '[' + ', '.join(st_type_list) + ']'
-    uv.history += ' Hera Hex antennas selected'
-    if args.fixuvws:
-        antpos = uv.antenna_positions + uv.telescope_location
-        antpos = uvutils.ENU_from_ECEF(antpos.T, *uv.telescope_location_lat_lon_alt).T
-        antmap = -np.ones(np.max(uv.antenna_numbers) + 1, dtype=int)
-        for i, ant in enumerate(uv.antenna_numbers):
-            antmap[ant] = i
-        uv.uvw_array = antpos[antmap[uv.ant_2_array], :] - antpos[antmap[uv.ant_1_array], :]
-        uv.history += ' and uvws corrected'
-    uv.history += ' with hera_cal/scripts/extract_hh.py, hera_cal version: ' +\
-                  str(version_info) + '.'
-    if args.ex_ants_file:
-        ex_ants = np.loadtxt(args.ex_ants_file, dtype=int)
-        ex_ants = [str(ant) for ant in ex_ants if ant in uv.get_ants()]
-        uv.history += ' Antennas to exclude in RTP: ' + ','.join(ex_ants) + '.'
-    if args.filetype == 'miriad':
-        base, ext = os.path.splitext(filename)
-        uv.write_miriad(base + '.' + args.extension + ext, clobber=args.overwrite)
-    else:
-        base, ext = os.path.splitext(filename)
-        uv.write_uvfits(base + args.extension + ext, clobber=args.overwrite)
-    del(uv)  # Reset for next loop
+# read in file metadata
+uvd = UVData()
+fn_in = args.input_file
+fn_out = args.output_file
+if os.path.exists(fn_out) and not args.overwrite:
+    print("skipping {}...".format(fn_in))
+    sys.exit(0)
+print("scanning {}...".format(fn_in))
+uvd.read_uvh5(fn_in, read_data=False, run_check=False)
+
+# figure out which antennas have valid data and perform select-on-read
+ant_nums = np.unique(uvd.ant_1_array)
+inds = np.where(ant_nums < 350)
+data_ants = ant_nums[inds]
+print("reading {}...".format(fn_in))
+uvd.read_uvh5(fn_in, antenna_nums=data_ants)
+
+# fix up the metadata to reflect the antennas in the dataset
+uvd.Nants_telescope = len(data_ants)
+uvd.antenna_names = [uvd.antenna_names[ind] for ind in data_ants]
+uvd.antenna_numbers = uvd.antenna_numbers[data_ants]
+uvd.antenna_positions = uvd.antenna_positions[data_ants, :]
+uvd.antenna_diameters = uvd.antenna_diameters[data_ants]
+print("writing {}...".format(fn_out))
+uvd.write_uvh5(fn_out, data_write_dtype=_hera_corr_dtype, flags_compression='lzf',
+               nsample_compression='lzf', clobber=True)

--- a/scripts/extract_hh.py
+++ b/scripts/extract_hh.py
@@ -29,8 +29,14 @@ if os.path.exists(fn_out) and not args.overwrite:
 print("scanning {}...".format(fn_in))
 uvd.read_uvh5(fn_in, read_data=False, run_check=False)
 
-# figure out which antennas have valid data and perform select-on-read
-ant_nums = np.unique(uvd.ant_1_array)
+# Figure out which antennas have valid data and perform select-on-read.
+# Here, "valid data" means data that comes from actual SNAP inputs
+# (instead of dummy placeholder data). The way that the correlator
+# denotes valid SNAP input is to change the antenna number in the
+# object's ant_[1,2]_array to a value less than 350 (the maximum number
+# of valid antennas for HERA). We find all such antenna numbers
+# corresponding to valid input, and downselect to keep only those.
+ant_nums = np.unique(np.concatenate((uvd.ant_1_array, uvd.ant_2_array)))
 inds = np.where(ant_nums < 350)
 data_ants = ant_nums[inds]
 print("reading {}...".format(fn_in))


### PR DESCRIPTION
This PR updates the `extract_hh.py` script for the H2C data coming from the correlator. The main difference is that the `st_type` variable is no longer saved in the `extra_keywords`, and instead the correlator uses antenna numbers less than 350 to signify valid data in the files. I've been using this script behind the scenes to do the data reduction so far, so I thought I'd make it officially part of a repo.