### PR TITLE
Convert testing framework from nose to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,18 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip matplotlib coverage pandas scikit-learn h5py six
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy pip matplotlib coverage pandas scikit-learn h5py six pytest-cov coveralls cached-property
   - source activate test-environment
   - conda install -c conda-forge healpy aipy pycodestyle
-  - pip install coveralls
-  - pip install cached_property
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/hera_qm.git
   - pip install git+https://github.com/HERA-Team/uvtools.git
   - pip install git+https://github.com/HERA-Team/hera_sim.git
   - conda list
-  - python --version  
+  - python --version
 script:
-  - nosetests hera_cal --with-coverage --cover-package=hera_cal
+  - pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
   - pycodestyle . --ignore=E501,W291,W293,W503,W601
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ First install dependencies.
 
 ## Install hera_cal
 Install with ```python setup.py install```
+
+## Running tests
+Tests use the `pytest` framework. To run all tests, call `pytest` or
+`python -m pytest` from the base directory of the repo.

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1130,7 +1130,7 @@ def interp2d_vis(model, model_lsts, model_freqs, data_lsts, data_freqs, flags=No
 
     # ensure flags are booleans
     if flags is not None:
-        if np.issubdtype(flags[list(flags.keys())[0]].dtype, np.float):
+        if np.issubdtype(flags[list(flags.keys())[0]].dtype, np.floating):
             flags = DataContainer(odict(list(map(lambda k: (k, ~flags[k].astype(np.bool)), flags.keys()))))
 
     # loop over keys
@@ -1202,7 +1202,7 @@ def interp2d_vis(model, model_lsts, model_freqs, data_lsts, data_freqs, flags=No
         if flags is not None:
             f = flags[k][time_nn, freq_nn]
             # check f is boolean type
-            if np.issubdtype(f.dtype, np.float):
+            if np.issubdtype(f.dtype, np.floating):
                 f = ~(f.astype(np.bool))
         else:
             f = np.zeros_like(real, bool)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -30,7 +30,7 @@ from ..apply_cal import calibrate_in_place
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
 class Test_AbsCal_Funcs(object):
-    def setup_method(self, method):
+    def setup_method(self):
         np.random.seed(0)
 
         # load into pyuvdata object
@@ -263,7 +263,7 @@ class Test_AbsCal_Funcs(object):
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in log")
 class Test_AbsCal(object):
-    def setup_method(self, method):
+    def setup_method(self):
         np.random.seed(0)
         # load into pyuvdata object
         self.data_fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
@@ -603,7 +603,7 @@ class Test_AbsCal(object):
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 class Test_Post_Redcal_Abscal_Run(object):
-    def setup_method(self, method):
+    def setup_method(self):
         self.data_file = os.path.join(DATA_PATH, 'test_input/zen.2458098.45361.HH.uvh5_downselected')
         self.redcal_file = os.path.join(DATA_PATH, 'test_input/zen.2458098.45361.HH.omni.calfits_downselected')
         self.model_files = [os.path.join(DATA_PATH, 'test_input/zen.2458042.60288.HH.uvRXLS.uvh5_downselected'),

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -97,11 +97,11 @@ class Test_AbsCal_Funcs(object):
         # test flag propagation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array, self.freq_array, flags=self.wgts, medfilt_flagged=True)
-        assert np.isclose(mf[(24, 25, 'xx')][10, 0], True)
+        assert np.all(mf[(24, 25, 'xx')][10, 0] == True)
         # test flag extrapolation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array + .0001, self.freq_array, flags=self.wgts, flag_extrapolate=True)
-        assert np.isclose(mf[(24, 25, 'xx')][-1].min(), True)
+        assert np.all(mf[(24, 25, 'xx')][-1].min() == True)
 
     def test_wiener(self):
         # test smoothing
@@ -186,7 +186,7 @@ class Test_AbsCal_Funcs(object):
         # test averaging worked
         rd, rf, rk = abscal.avg_data_across_red_bls(data, antpos, tol=2.0, broadcast_wgts=False)
         v = np.mean([data[(52, 53, 'xx')], data[(37, 38, 'xx')], data[(24, 25, 'xx')], data[(38, 39, 'xx')]], axis=0)
-        assert np.isclose(rd[(24, 25, 'xx')], v).min()
+        assert np.allclose(rd[(24, 25, 'xx')], v)
         # test mirror_red_data
         rd, rf, rk = abscal.avg_data_across_red_bls(data, antpos, wgts=self.wgts, tol=2.0, mirror_red_data=True)
         assert len(rd.keys()) == 21
@@ -220,8 +220,8 @@ class Test_AbsCal_Funcs(object):
 
         k = list(new_m.keys())[0]
         assert new_m[k].shape == d[k].shape
-        assert np.isclose(new_f[k][-1].min(), True)
-        assert np.isclose(new_f[k][0].max(), False)
+        assert np.all(new_f[k][-1] == True)
+        assert np.all(new_f[k][0] == False)
 
     def test_cut_bl(self):
         Nbls = len(self.data)
@@ -346,7 +346,7 @@ class Test_AbsCal(object):
         assert self.AC.abs_psi_gain[(24, 'Jxx')].shape == (60, 64)
         assert self.AC.TT_Phi[(24, 'Jxx')].shape == (2, 60, 64)
         assert self.AC.TT_Phi_gain[(24, 'Jxx')].shape == (60, 64)
-        assert np.isclose(np.angle(self.AC.TT_Phi_gain[(24, 'Jxx')]), 0.0).all()
+        assert np.allclose(np.angle(self.AC.TT_Phi_gain[(24, 'Jxx')]), 0.0)
         # test merge pols
         self.AC.TT_phs_logcal(verbose=False, four_pol=True)
         assert self.AC.TT_Phi_arr.shape == (7, 2, 60, 64, 1)
@@ -396,7 +396,7 @@ class Test_AbsCal(object):
         assert self.AC.ant_phi_arr.dtype == np.float
         assert self.AC.ant_phi_gain_arr.shape == (7, 60, 64, 1)
         assert self.AC.ant_phi_gain_arr.dtype == np.complex
-        assert np.isclose(np.angle(self.AC.ant_phi_gain[(24, 'Jxx')]), 0.0).all()
+        assert np.allclose(np.angle(self.AC.ant_phi_gain[(24, 'Jxx')]), 0.0)
         self.AC.phs_logcal(verbose=False, avg=True)
         AC = abscal.AbsCal(self.AC.model, self.AC.data)
         assert AC.ant_phi is None
@@ -424,8 +424,8 @@ class Test_AbsCal(object):
         assert self.AC.ant_dly_arr.dtype == np.float
         assert self.AC.ant_dly_gain_arr.shape == (7, 60, 64, 1)
         assert self.AC.ant_dly_gain_arr.dtype == np.complex
-        assert np.isclose(np.angle(self.AC.ant_dly_gain[(24, 'Jxx')]), 0.0).all()
-        assert np.isclose(np.angle(self.AC.ant_dly_phi_gain[(24, 'Jxx')]), 0.0).all()
+        assert np.allclose(np.angle(self.AC.ant_dly_gain[(24, 'Jxx')]), 0.0)
+        assert np.allclose(np.angle(self.AC.ant_dly_phi_gain[(24, 'Jxx')]), 0.0)
         # test exception
         AC = abscal.AbsCal(self.AC.model, self.AC.data)
         pytest.raises(AttributeError, AC.delay_lincal)
@@ -458,7 +458,7 @@ class Test_AbsCal(object):
         assert self.AC.dly_slope_arr.shape == (7, 2, 60, 1, 1)
         assert self.AC.dly_slope_gain_arr.shape == (7, 60, 64, 1)
         assert self.AC.dly_slope_ant_dly_arr.shape == (7, 60, 1, 1)
-        assert np.isclose(np.angle(self.AC.dly_slope_gain[(24, 'Jxx')]), 0.0).all()
+        assert np.allclose(np.angle(self.AC.dly_slope_gain[(24, 'Jxx')]), 0.0)
         g = self.AC.custom_dly_slope_gain(self.gk, self.ap)
         assert g[(0, 'Jxx')].shape == (60, 64)
         # test exception
@@ -497,7 +497,7 @@ class Test_AbsCal(object):
             assert self.AC.phs_slope_arr.shape == (7, 2, 60, 1, 1)
             assert self.AC.phs_slope_gain_arr.shape == (7, 60, 64, 1)
             assert self.AC.phs_slope_ant_phs_arr.shape == (7, 60, 1, 1)
-            assert np.isclose(np.angle(self.AC.phs_slope_gain[(24, 'Jxx')]), 0.0).all()
+            assert np.allclose(np.angle(self.AC.phs_slope_gain[(24, 'Jxx')]), 0.0)
             g = self.AC.custom_phs_slope_gain(self.gk, self.ap)
             assert g[(0, 'Jxx')].shape == (60, 64)
             # test Nones

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -97,11 +97,11 @@ class Test_AbsCal_Funcs(object):
         # test flag propagation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array, self.freq_array, flags=self.wgts, medfilt_flagged=True)
-        assert np.all(mf[(24, 25, 'xx')][10, 0] == True)
+        assert np.all(mf[(24, 25, 'xx')][10, 0])
         # test flag extrapolation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array + .0001, self.freq_array, flags=self.wgts, flag_extrapolate=True)
-        assert np.all(mf[(24, 25, 'xx')][-1].min() == True)
+        assert np.all(mf[(24, 25, 'xx')][-1].min())
 
     def test_wiener(self):
         # test smoothing
@@ -220,8 +220,8 @@ class Test_AbsCal_Funcs(object):
 
         k = list(new_m.keys())[0]
         assert new_m[k].shape == d[k].shape
-        assert np.all(new_f[k][-1] == True)
-        assert np.all(new_f[k][0] == False)
+        assert np.all(new_f[k][-1])
+        assert not np.any(new_f[k][0])
 
     def test_cut_bl(self):
         Nbls = len(self.data)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -254,8 +254,8 @@ class Test_AbsCal_Funcs(object):
                                 + 2.0j * np.pi * y * phase_slopes_y) for x, y in zip(xs, ys)])
 
         x_slope_est, y_slope_est = abscal.dft_phase_slope_solver(xs, ys, data)
-        assert np.allclose(phase_slopes_x - x_slope_est, 0, atol=1e-7)
-        assert np.allclose(phase_slopes_y - y_slope_est, 0, atol=1e-7)
+        np.testing.assert_array_almost_equal(phase_slopes_x - x_slope_est, 0, decimal=7)
+        np.testing.assert_array_almost_equal(phase_slopes_y - y_slope_est, 0, decimal=7)
 
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
@@ -309,7 +309,7 @@ class Test_AbsCal(object):
         gf = (uvc.flag_array[aa.index(bl[0])] + uvc.flag_array[aa.index(bl[1])]).squeeze().T
         w = self.AC.wgts[bl] * ~gf
         AC2 = abscal.AbsCal(copy.deepcopy(self.AC.model), copy.deepcopy(self.AC.data), wgts=copy.deepcopy(self.AC.wgts), refant=24, input_cal=self.input_cal)
-        assert np.allclose(self.AC.data[bl] / g * w, AC2.data[bl] * w)
+        np.testing.assert_array_almost_equal(self.AC.data[bl] / g * w, AC2.data[bl] * w)
 
     def test_abs_amp_logcal(self):
         # test execution and variable assignments
@@ -615,13 +615,13 @@ class Test_Post_Redcal_Abscal_Run(object):
         all_times, all_lsts = abscal.get_all_times_and_lsts(hd)
         assert len(all_times) == 120
         assert len(all_lsts) == 120
-        assert np.all(all_times == sorted(all_times))
+        np.testing.assert_array_equal(all_times, sorted(all_times))
 
         for f in hd.lsts.keys():
             hd.lsts[f] += 4.75
         all_times, all_lsts = abscal.get_all_times_and_lsts(hd, unwrap=True)
         assert all_lsts[-1] > 2 * np.pi
-        assert np.allclose(all_lsts, sorted(all_lsts))
+        np.testing.assert_array_equal(all_lsts, sorted(all_lsts))
         c = abscal.get_all_times_and_lsts(hd)
         assert all_lsts[0] < all_lsts[-1]
 
@@ -694,9 +694,9 @@ class Test_Post_Redcal_Abscal_Run(object):
                 assert delta_gains[k].shape == (3, rc_gains[k].shape[1])
                 assert delta_gains[k].dtype == np.complex
         for k in AC.model.keys():
-            assert np.allclose(model[k], AC.model[k])
+            np.testing.assert_array_equal(model[k], AC.model[k])
         for k in AC.data.keys():
-            assert np.allclose(data[k][~flags[k]], AC.data[k][~flags[k]], atol=1e-4)
+            np.testing.assert_array_almost_equal(data[k][~flags[k]], AC.data[k][~flags[k]], decimal=4)
         assert AC.ant_dly is None
         assert AC.ant_dly_arr is None
         assert AC.ant_dly_phi is None
@@ -734,7 +734,7 @@ class Test_Post_Redcal_Abscal_Run(object):
             assert k in ac_flags
             assert ac_flags[k].shape == rc_flags[k].shape
             assert ac_flags[k].dtype == bool
-            assert np.allclose(ac_flags[k][rc_flags[k]], rc_flags[k][rc_flags[k]])
+            np.testing.assert_array_equal(ac_flags[k][rc_flags[k]], rc_flags[k][rc_flags[k]])
         assert not np.all(list(ac_flags.values()))
         for pol in ['Jxx', 'Jyy']:
             assert pol in ac_total_qual
@@ -751,10 +751,10 @@ class Test_Post_Redcal_Abscal_Run(object):
             hca = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, [temp_outfile], phs_conv_crit=1e-4, 
                                                 nInt_to_load=30, verbose=False, add_to_history='testing')
         assert os.path.exists(self.redcal_file.replace('.omni.', '.abs.'))
-        assert np.allclose(hca.total_quality_array, 0.0)
-        assert np.allclose(hca.gain_array, hcr.gain_array)
-        assert np.allclose(hca.flag_array, True)
-        assert np.allclose(hca.quality_array, 0.0)
+        np.testing.assert_array_equal(hca.total_quality_array, 0.0)
+        np.testing.assert_array_equal(hca.gain_array, hcr.gain_array)
+        np.testing.assert_array_equal(hca.flag_array, True)
+        np.testing.assert_array_equal(hca.quality_array, 0.0)
         os.remove(self.redcal_file.replace('.omni.', '.abs.'))
         os.remove(temp_outfile)
 

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -97,11 +97,11 @@ class Test_AbsCal_Funcs(object):
         # test flag propagation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array, self.freq_array, flags=self.wgts, medfilt_flagged=True)
-        assert mf[(24, 25, 'xx')][10, 0] == True
+        assert np.isclose(mf[(24, 25, 'xx')][10, 0], True)
         # test flag extrapolation
         m, mf = abscal.interp2d_vis(self.data, self.time_array, self.freq_array,
                                     self.time_array + .0001, self.freq_array, flags=self.wgts, flag_extrapolate=True)
-        assert mf[(24, 25, 'xx')][-1].min() == True
+        assert np.isclose(mf[(24, 25, 'xx')][-1].min(), True)
 
     def test_wiener(self):
         # test smoothing
@@ -181,7 +181,7 @@ class Test_AbsCal_Funcs(object):
         wgts[(24, 25, 'xx')][45, 45] = 0.0
         rd, rf, rk = abscal.avg_data_across_red_bls(data, antpos, tol=2.0, wgts=wgts, broadcast_wgts=True)
         assert len(rd.keys()) == 9
-        assert len(rf.keys())== 9
+        assert len(rf.keys()) == 9
         assert np.allclose(rf[(24, 25, 'xx')][45, 45], 0.0)
         # test averaging worked
         rd, rf, rk = abscal.avg_data_across_red_bls(data, antpos, tol=2.0, broadcast_wgts=False)
@@ -220,8 +220,8 @@ class Test_AbsCal_Funcs(object):
 
         k = list(new_m.keys())[0]
         assert new_m[k].shape == d[k].shape
-        assert new_f[k][-1].min() == True
-        assert new_f[k][0].max() == False
+        assert np.isclose(new_f[k][-1].min(), True)
+        assert np.isclose(new_f[k][0].max(), False)
 
     def test_cut_bl(self):
         Nbls = len(self.data)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -45,9 +45,9 @@ class Test_Update_Cal(object):
             for j in range(10):
                 assert np.allclose(dc[(0, 1, 'xx')][i, j], vis[i, j] * g0_old[i, j] * np.conj(g1_old[i, j]) / g0_new[i, j] / np.conj(g1_new[i, j]))
                 if f[i, j] or cal_flags[(0, 'Jxx')][i, j] or cal_flags[(1, 'Jxx')][i, j]:
-                    assert np.all(flags[(0, 1, 'xx')][i, j] == True)
+                    assert np.all(flags[(0, 1, 'xx')][i, j])
                 else:
-                    assert np.all(flags[(0, 1, 'xx')][i, j] == False)
+                    assert not np.any(flags[(0, 1, 'xx')][i, j])
 
         # test without old cal
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
@@ -126,7 +126,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert np.all(new_flags[k][i, j] == True)
+                        assert np.all(new_flags[k][i, j])
 
         # test partial load
         ac.apply_cal(uvh5, outname_uvh5, new_cal, old_calibration=calout, gain_convention='divide',
@@ -142,7 +142,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert np.all(new_flags[k][i, j] == True)
+                        assert np.all(new_flags[k][i, j])
         os.remove(outname_uvh5)
 
         # test errors

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -45,9 +45,9 @@ class Test_Update_Cal(object):
             for j in range(10):
                 assert np.allclose(dc[(0, 1, 'xx')][i, j], vis[i, j] * g0_old[i, j] * np.conj(g1_old[i, j]) / g0_new[i, j] / np.conj(g1_new[i, j]))
                 if f[i, j] or cal_flags[(0, 'Jxx')][i, j] or cal_flags[(1, 'Jxx')][i, j]:
-                    assert flags[(0, 1, 'xx')][i, j] == True
+                    assert np.isclose(flags[(0, 1, 'xx')][i, j], True)
                 else:
-                    assert flags[(0, 1, 'xx')][i, j] == False
+                    assert np.isclose(flags[(0, 1, 'xx')][i, j], False)
 
         # test without old cal
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
@@ -126,7 +126,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert new_flags[k][i, j] == True
+                        assert np.isclose(new_flags[k][i, j], True)
 
         # test partial load
         ac.apply_cal(uvh5, outname_uvh5, new_cal, old_calibration=calout, gain_convention='divide',
@@ -142,7 +142,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert new_flags[k][i, j] == True
+                        assert np.isclose(new_flags[k][i, j], True)
         os.remove(outname_uvh5)
 
         # test errors

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -69,11 +69,11 @@ class Test_Update_Cal(object):
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
         ac.calibrate_in_place(dc, {}, flags, cal_flags, gain_convention='divide')
-        assert np.all(flags[(0, 1, 'xx')])
+        np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
         ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains={}, gain_convention='divide')
-        assert np.all(flags[(0, 1, 'xx')])
+        np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
 
         # test error
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -45,9 +45,9 @@ class Test_Update_Cal(object):
             for j in range(10):
                 assert np.allclose(dc[(0, 1, 'xx')][i, j], vis[i, j] * g0_old[i, j] * np.conj(g1_old[i, j]) / g0_new[i, j] / np.conj(g1_new[i, j]))
                 if f[i, j] or cal_flags[(0, 'Jxx')][i, j] or cal_flags[(1, 'Jxx')][i, j]:
-                    assert np.isclose(flags[(0, 1, 'xx')][i, j], True)
+                    assert np.all(flags[(0, 1, 'xx')][i, j] == True)
                 else:
-                    assert np.isclose(flags[(0, 1, 'xx')][i, j], False)
+                    assert np.all(flags[(0, 1, 'xx')][i, j] == False)
 
         # test without old cal
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
@@ -126,7 +126,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert np.isclose(new_flags[k][i, j], True)
+                        assert np.all(new_flags[k][i, j] == True)
 
         # test partial load
         ac.apply_cal(uvh5, outname_uvh5, new_cal, old_calibration=calout, gain_convention='divide',
@@ -142,7 +142,7 @@ class Test_Update_Cal(object):
                         assert np.allclose(new_data[k][i, j] / 25.0 / data[k][i, j], 1.0, atol=1e-4)
                     # from flag_nchan_low and flag_nchan_high above with 1024 total channels
                     if j < 450 or j > 623:
-                        assert np.isclose(new_flags[k][i, j], True)
+                        assert np.all(new_flags[k][i, j] == True)
         os.remove(outname_uvh5)
 
         # test errors

--- a/hera_cal/tests/test_autos.py
+++ b/hera_cal/tests/test_autos.py
@@ -6,20 +6,20 @@
 
 from __future__ import absolute_import, division, print_function
 
-import unittest
+import pytest
 import numpy as np
 import os
 import sys
 
-from hera_cal import io
-from hera_cal import autos
-from hera_cal.data import DATA_PATH
-from hera_cal.utils import split_pol
-from hera_cal.apply_cal import apply_cal
+from .. import io, autos
+from ..data import DATA_PATH
+from ..utils import split_pol
+from ..apply_cal import apply_cal
 
 
-class Test_Autos(unittest.TestCase):
-
+@pytest.mark.filterwarnings("ignore:It seems that the latitude and longitude are in radians")
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
+class Test_Autos(object):
     def test_read_and_write_autocorrelations(self):
         infile = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')
         outfile = os.path.join(DATA_PATH, 'test_output/autos.uvh5')
@@ -30,12 +30,12 @@ class Test_Autos(unittest.TestCase):
         hd = io.HERAData(outfile)
         d, f, _ = hd.read()
         for bl in d.keys():
-            self.assertEqual(bl[0], bl[1])
-            self.assertEqual(split_pol(bl[2])[0], split_pol(bl[2])[1])
-            np.testing.assert_array_equal(d_full[bl], d[bl])
-            np.testing.assert_array_equal(f_full[bl], f[bl])
-        self.assertTrue('testing' in hd.history.replace('\n', '').replace(' ', ''))
-        self.assertTrue('Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', ''))
+            assert bl[0] == bl[1]
+            assert split_pol(bl[2])[0] == split_pol(bl[2])[1]
+            assert np.all(d_full[bl] == d[bl])
+            assert np.all(f_full[bl] == f[bl])
+        assert 'testing' in hd.history.replace('\n', '').replace(' ', '')
+        assert 'Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', '')
         os.remove(outfile)
 
     def test_read_calibrate_and_write_autocorrelations(self):
@@ -51,10 +51,10 @@ class Test_Autos(unittest.TestCase):
         hd = io.HERAData(outfile)
         d, f, _ = hd.read()
         for bl in d.keys():
-            self.assertEqual(bl[0], bl[1])
-            self.assertEqual(split_pol(bl[2])[0], split_pol(bl[2])[1])
-            np.testing.assert_array_equal(d_full_cal[bl], d[bl])
-            np.testing.assert_array_equal(f_full_cal[bl], f[bl])
+            assert bl[0] == bl[1]
+            assert split_pol(bl[2])[0] == split_pol(bl[2])[1]
+            assert np.all(d_full_cal[bl] == d[bl])
+            assert np.all(f_full_cal[bl] == f[bl])
         os.remove(outfile)
         os.remove(calibrated)
 
@@ -62,10 +62,6 @@ class Test_Autos(unittest.TestCase):
         sys.argv = [sys.argv[0], 'a', 'b', '--calfile', 'd']
         a = autos.extract_autos_argparser()
         args = a.parse_args()
-        self.assertEqual(args.infile, 'a')
-        self.assertEqual(args.outfile, 'b')
-        self.assertEqual(args.calfile, ['d'])
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert args.infile == 'a'
+        assert args.outfile == 'b'
+        assert args.calfile == ['d']

--- a/hera_cal/tests/test_autos.py
+++ b/hera_cal/tests/test_autos.py
@@ -32,8 +32,8 @@ class Test_Autos(object):
         for bl in d.keys():
             assert bl[0] == bl[1]
             assert split_pol(bl[2])[0] == split_pol(bl[2])[1]
-            assert np.all(d_full[bl] == d[bl])
-            assert np.all(f_full[bl] == f[bl])
+            np.testing.assert_array_equal(d_full[bl], d[bl])
+            np.testing.assert_array_equal(f_full[bl], f[bl])
         assert 'testing' in hd.history.replace('\n', '').replace(' ', '')
         assert 'Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', '')
         os.remove(outfile)
@@ -53,8 +53,8 @@ class Test_Autos(object):
         for bl in d.keys():
             assert bl[0] == bl[1]
             assert split_pol(bl[2])[0] == split_pol(bl[2])[1]
-            assert np.all(d_full_cal[bl] == d[bl])
-            assert np.all(f_full_cal[bl] == f[bl])
+            np.testing.assert_array_equal(d_full_cal[bl], d[bl])
+            np.testing.assert_array_equal(f_full_cal[bl], f[bl])
         os.remove(outfile)
         os.remove(calibrated)
 

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -4,20 +4,18 @@
 
 from __future__ import print_function, division, absolute_import
 
-import unittest
+import pytest
 import numpy as np
 import os
 from six.moves import zip
 
-from hera_cal import abscal
-from hera_cal import io
-from hera_cal import datacontainer
-from hera_cal.data import DATA_PATH
+from .. import abscal, datacontainer, io
+from ..data import DATA_PATH
 
 
-class TestDataContainer(unittest.TestCase):
-
-    def setUp(self):
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
+class TestDataContainer(object):
+    def setup_method(self, method):
         self.antpairs = [(1, 2), (2, 3), (3, 4), (1, 3), (2, 4)]  # not (1,4)
         self.pols = ['xx', 'yy']
         self.blpol = {}
@@ -38,340 +36,338 @@ class TestDataContainer(unittest.TestCase):
     def test_init(self):
         dc = datacontainer.DataContainer(self.blpol)
         for k in dc._data.keys():
-            self.assertEqual(len(k), 3)
-        self.assertEqual(set(self.antpairs), dc._antpairs)
-        self.assertEqual(set(self.pols), dc._pols)
+            assert len(k) == 3
+        assert set(self.antpairs) == dc._antpairs
+        assert set(self.pols) == dc._pols
         dc = datacontainer.DataContainer(self.polbl)
         for k in dc._data.keys():
-            self.assertEqual(len(k), 3)
-        self.assertEqual(set(self.antpairs), dc._antpairs)
-        self.assertEqual(set(self.pols), dc._pols)
+            assert len(k) == 3
+        assert set(self.antpairs) == dc._antpairs
+        assert set(self.pols) == dc._pols
         dc = datacontainer.DataContainer(self.both)
         for k in dc._data.keys():
-            self.assertEqual(len(k), 3)
-        self.assertEqual(set(self.antpairs), dc._antpairs)
-        self.assertEqual(set(self.pols), dc._pols)
-        self.assertIsNone(dc.antpos)
-        self.assertIsNone(dc.freqs)
-        self.assertIsNone(dc.times)
-        self.assertIsNone(dc.lsts)
-        self.assertIsNone(dc.times_by_bl)
-        self.assertIsNone(dc.lsts_by_bl)
-        self.assertRaises(KeyError, datacontainer.DataContainer, {(1, 2, 3, 4): 2})
+            assert len(k) == 3
+        assert set(self.antpairs) == dc._antpairs
+        assert set(self.pols) == dc._pols
+        assert dc.antpos is None
+        assert dc.freqs is None
+        assert dc.times is None
+        assert dc.lsts is None
+        assert dc.times_by_bl is None
+        assert dc.lsts_by_bl is None
+        pytest.raises(KeyError, datacontainer.DataContainer, {(1, 2, 3, 4): 2})
 
     def test_antpairs(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(set(self.antpairs), dc.antpairs())
-        self.assertEqual(set(self.antpairs), dc.antpairs('xx'))
-        self.assertEqual(set(self.antpairs), dc.antpairs('yy'))
+        assert set(self.antpairs) == dc.antpairs()
+        assert set(self.antpairs) == dc.antpairs('xx')
+        assert set(self.antpairs) == dc.antpairs('yy')
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(set(self.antpairs), dc.antpairs())
-        self.assertEqual(set(self.antpairs), dc.antpairs('xx'))
-        self.assertEqual(set(self.antpairs), dc.antpairs('yy'))
+        assert set(self.antpairs) == dc.antpairs()
+        assert set(self.antpairs) == dc.antpairs('xx')
+        assert set(self.antpairs) == dc.antpairs('yy')
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(set(self.antpairs), dc.antpairs())
-        self.assertEqual(set(self.antpairs), dc.antpairs('xx'))
-        self.assertEqual(set(self.antpairs), dc.antpairs('yy'))
+        assert set(self.antpairs) == dc.antpairs()
+        assert set(self.antpairs) == dc.antpairs('xx')
+        assert set(self.antpairs) == dc.antpairs('yy')
 
     def test_bls(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(set(dc.keys()), dc.bls())
+        assert set(dc.keys()) == dc.bls()
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(set(dc.keys()), dc.bls())
+        assert set(dc.keys()) == dc.bls()
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(set(dc.keys()), dc.bls())
+        assert set(dc.keys()) == dc.bls()
 
     def test_pols(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(set(self.pols), dc.pols())
-        self.assertEqual(set(self.pols), dc.pols((1, 2)))
+        assert set(self.pols) == dc.pols()
+        assert set(self.pols) == dc.pols((1, 2))
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(set(self.pols), dc.pols())
-        self.assertEqual(set(self.pols), dc.pols((1, 2)))
+        assert set(self.pols) == dc.pols()
+        assert set(self.pols) == dc.pols((1, 2))
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(set(self.pols), dc.pols())
-        self.assertEqual(set(self.pols), dc.pols((1, 2)))
+        assert set(self.pols) == dc.pols()
+        assert set(self.pols) == dc.pols((1, 2))
 
     def test_keys(self):
         dc = datacontainer.DataContainer(self.blpol)
         keys = dc.keys()
-        self.assertEqual(len(keys), len(self.pols) * len(self.antpairs))
+        assert len(keys) == len(self.pols) * len(self.antpairs)
         dc = datacontainer.DataContainer(self.polbl)
         keys = dc.keys()
-        self.assertEqual(len(keys), len(self.pols) * len(self.antpairs))
+        assert len(keys) == len(self.pols) * len(self.antpairs)
         dc = datacontainer.DataContainer(self.both)
         keys = dc.keys()
-        self.assertEqual(len(keys), len(self.pols) * len(self.antpairs))
+        assert len(keys) == len(self.pols) * len(self.antpairs)
 
         for key1, key2 in zip(dc.keys(), dc):
-            self.assertEqual(key1, key2)
+            assert key1 == key2
 
     def test_values(self):
         dc = datacontainer.DataContainer(self.blpol)
         values = list(dc.values())
-        self.assertEqual(len(values), len(self.pols) * len(self.antpairs))
-        self.assertEqual(values[0], 1j)
+        assert len(values) == len(self.pols) * len(self.antpairs)
+        assert values[0] == 1j
         dc = datacontainer.DataContainer(self.polbl)
         values = list(dc.values())
-        self.assertEqual(len(values), len(self.pols) * len(self.antpairs))
-        self.assertEqual(values[0], 1j)
+        assert len(values) == len(self.pols) * len(self.antpairs)
+        assert values[0] == 1j
         dc = datacontainer.DataContainer(self.both)
         values = list(dc.values())
-        self.assertEqual(len(values), len(self.pols) * len(self.antpairs))
-        self.assertEqual(values[0], 1j)
+        assert len(values) == len(self.pols) * len(self.antpairs)
+        assert values[0] == 1j
 
     def test_items(self):
         dc = datacontainer.DataContainer(self.blpol)
         items = list(dc.items())
-        self.assertEqual(len(items), len(self.pols) * len(self.antpairs))
-        self.assertTrue(items[0][0][0:2] in self.antpairs)
-        self.assertTrue(items[0][0][2] in self.pols)
-        self.assertEqual(items[0][1], 1j)
+        assert len(items) == len(self.pols) * len(self.antpairs)
+        assert items[0][0][0:2] in self.antpairs
+        assert items[0][0][2] in self.pols
+        assert items[0][1] == 1j
         dc = datacontainer.DataContainer(self.polbl)
         items = list(dc.items())
-        self.assertTrue(items[0][0][0:2] in self.antpairs)
-        self.assertTrue(items[0][0][2] in self.pols)
-        self.assertEqual(items[0][1], 1j)
+        assert items[0][0][0:2] in self.antpairs
+        assert items[0][0][2] in self.pols
+        assert items[0][1] == 1j
         dc = datacontainer.DataContainer(self.both)
         items = list(dc.items())
-        self.assertTrue(items[0][0][0:2] in self.antpairs)
-        self.assertTrue(items[0][0][2] in self.pols)
-        self.assertEqual(items[0][1], 1j)
+        assert items[0][0][0:2] in self.antpairs
+        assert items[0][0][2] in self.pols
+        assert items[0][1] == 1j
 
     def test_len(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(len(dc), 10)
+        assert len(dc) == 10
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(len(dc), 10)
+        assert len(dc) == 10
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(len(dc), 10)
+        assert len(dc) == 10
 
     def test_del(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertTrue((1, 2, 'xx') in dc)
-        self.assertTrue((1, 2, 'XX') in dc)
+        assert (1, 2, 'xx') in dc
+        assert (1, 2, 'XX') in dc
         del dc[(1, 2, 'xx')]
-        self.assertFalse((1, 2, 'xx') in dc)
-        self.assertTrue('xx' in dc.pols())
-        self.assertTrue((1, 2) in dc.antpairs())
+        assert (1, 2, 'xx') not in dc
+        assert 'xx' in dc.pols()
+        assert (1, 2) in dc.antpairs()
         del dc[(1, 2, 'yy')]
-        self.assertFalse((1, 2) in dc.antpairs())
+        assert (1, 2) not in dc.antpairs()
         del dc[(2, 3, 'XX')]
-        self.assertFalse((2, 3, 'xx') in dc)
-        self.assertTrue('xx' in dc.pols())
-        self.assertTrue((2, 3) in dc.antpairs())
+        assert (2, 3, 'xx') not in dc
+        assert 'xx' in dc.pols()
+        assert (2, 3) in dc.antpairs()
 
     def test_getitem(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(dc[(1, 2, 'xx')], 1j)
-        self.assertEqual(dc[(2, 1, 'xx')], -1j)
-        self.assertEqual(dc[(1, 2)], {'xx': 1j, 'yy': 1j})
-        self.assertEqual(set(dc['xx'].keys()), set(self.antpairs))
-        self.assertEqual(dc[(1, 2, 'xx')], dc.get_data((1, 2, 'xx')))
-        self.assertEqual(dc[(1, 2, 'xx')], dc.get_data(1, 2, 'xx'))
+        assert dc[(1, 2, 'xx')] == 1j
+        assert dc[(2, 1, 'xx')] == -1j
+        assert dc[(1, 2)] == {'xx': 1j, 'yy': 1j}
+        assert set(dc['xx'].keys()) == set(self.antpairs)
+        assert dc[(1, 2, 'xx')] == dc.get_data((1, 2, 'xx'))
+        assert dc[(1, 2, 'xx')] == dc.get_data(1, 2, 'xx')
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(dc[(1, 2, 'xx')], 1j)
-        self.assertEqual(dc[(2, 1, 'xx')], -1j)
-        self.assertEqual(dc[(1, 2)], {'xx': 1j, 'yy': 1j})
-        self.assertEqual(set(dc['xx'].keys()), set(self.antpairs))
-        self.assertEqual(dc[(2, 1, 'xx')], dc.get_data((2, 1, 'xx')))
-        self.assertEqual(dc[(2, 1, 'xx')], dc.get_data(2, 1, 'xx'))
+        assert dc[(1, 2, 'xx')] == 1j
+        assert dc[(2, 1, 'xx')] == -1j
+        assert dc[(1, 2)] == {'xx': 1j, 'yy': 1j}
+        assert set(dc['xx'].keys()) == set(self.antpairs)
+        assert dc[(2, 1, 'xx')] == dc.get_data((2, 1, 'xx'))
+        assert dc[(2, 1, 'xx')] == dc.get_data(2, 1, 'xx')
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(dc[(1, 2, 'xx')], 1j)
-        self.assertEqual(dc[(2, 1, 'xx')], -1j)
-        self.assertEqual(dc[(1, 2)], {'xx': 1j, 'yy': 1j})
-        self.assertEqual(set(dc['xx'].keys()), set(self.antpairs))
-        self.assertEqual(dc[(1, 2)], dc.get_data((1, 2)))
-        self.assertEqual(dc[(1, 2)], dc.get_data(1, 2))
-        self.assertEqual(dc[(1, 2, 'XX')], 1j)
-        self.assertEqual(dc[(2, 1, 'XX')], -1j)
-        self.assertEqual(dc[(2, 1, 'XX')], dc.get_data(2, 1, 'XX'))
-        self.assertEqual(dc[(2, 1, 'XX')], dc.get_data(2, 1, 'xx'))
+        assert dc[(1, 2, 'xx')] == 1j
+        assert dc[(2, 1, 'xx')] == -1j
+        assert dc[(1, 2)] == {'xx': 1j, 'yy': 1j}
+        assert set(dc['xx'].keys()) == set(self.antpairs)
+        assert dc[(1, 2)] == dc.get_data((1, 2))
+        assert dc[(1, 2)] == dc.get_data(1, 2)
+        assert dc[(1, 2, 'XX')] == 1j
+        assert dc[(2, 1, 'XX')] == -1j
+        assert dc[(2, 1, 'XX')] == dc.get_data(2, 1, 'XX')
+        assert dc[(2, 1, 'XX')] == dc.get_data(2, 1, 'xx')
 
     def test_has_key(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertTrue((2, 3, 'yy') in dc)
-        self.assertTrue(dc.has_key((2, 3), 'yy'))
-        self.assertTrue(dc.has_key((3, 2), 'yy'))
-        self.assertFalse('xy' in dc)
-        self.assertFalse((5, 6) in dc)
-        self.assertFalse((1, 2, 'xy') in dc)
+        assert (2, 3, 'yy') in dc
+        assert dc.has_key((2, 3), 'yy')
+        assert dc.has_key((3, 2), 'yy')
+        assert 'xy' not in dc
+        assert (5, 6) not in dc
+        assert (1, 2, 'xy') not in dc
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertTrue((2, 3, 'yy') in dc)
-        self.assertTrue(dc.has_key((2, 3), 'yy'))
-        self.assertTrue(dc.has_key((3, 2), 'yy'))
-        self.assertFalse('xy' in dc)
-        self.assertFalse((5, 6) in dc)
-        self.assertFalse((1, 2, 'xy') in dc)
+        assert (2, 3, 'yy') in dc
+        assert dc.has_key((2, 3), 'yy')
+        assert dc.has_key((3, 2), 'yy')
+        assert 'xy' not in dc
+        assert (5, 6) not in dc
+        assert (1, 2, 'xy') not in dc
         dc = datacontainer.DataContainer(self.both)
-        self.assertTrue((2, 3, 'yy') in dc)
-        self.assertTrue(dc.has_key((2, 3), 'yy'))
-        self.assertTrue(dc.has_key((3, 2), 'yy'))
-        self.assertFalse('xy' in dc)
-        self.assertFalse((5, 6) in dc)
-        self.assertFalse((1, 2, 'xy') in dc)
+        assert (2, 3, 'yy') in dc
+        assert dc.has_key((2, 3), 'yy')
+        assert dc.has_key((3, 2), 'yy')
+        assert 'xy' not in dc
+        assert (5, 6) not in dc
+        assert (1, 2, 'xy') not in dc
 
-        self.assertTrue((2, 3, 'YY') in dc)
-        self.assertTrue(dc.has_key((2, 3), 'YY'))
-        self.assertTrue(dc.has_key((3, 2), 'YY'))
-        self.assertFalse('XY' in dc)
-        self.assertFalse((5, 6) in dc)
-        self.assertFalse((1, 2, 'XY') in dc)
+        assert (2, 3, 'YY') in dc
+        assert dc.has_key((2, 3), 'YY')
+        assert dc.has_key((3, 2), 'YY')
+        assert 'XY' not in dc
+        assert (5, 6) not in dc
+        assert (1, 2, 'XY') not in dc
 
         # assert switch bl
         dc[(1, 2, 'xy')] = 1j
-        self.assertTrue((2, 1, 'yx') in dc)
+        assert (2, 1, 'yx') in dc
 
     def test_has_antpair(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertTrue(dc.has_antpair((2, 3)))
-        self.assertTrue(dc.has_antpair((3, 2)))
-        self.assertFalse(dc.has_antpair((0, 3)))
+        assert dc.has_antpair((2, 3))
+        assert dc.has_antpair((3, 2))
+        assert not dc.has_antpair((0, 3))
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertTrue(dc.has_antpair((2, 3)))
-        self.assertTrue(dc.has_antpair((3, 2)))
-        self.assertFalse(dc.has_antpair((0, 3)))
+        assert dc.has_antpair((2, 3))
+        assert dc.has_antpair((3, 2))
+        assert not dc.has_antpair((0, 3))
         dc = datacontainer.DataContainer(self.both)
-        self.assertTrue(dc.has_antpair((2, 3)))
-        self.assertTrue(dc.has_antpair((3, 2)))
-        self.assertFalse(dc.has_antpair((0, 3)))
+        assert dc.has_antpair((2, 3))
+        assert dc.has_antpair((3, 2))
+        assert not dc.has_antpair((0, 3))
 
     def test_has_pol(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertTrue(dc.has_pol('xx'))
-        self.assertTrue(dc.has_pol('XX'))
-        self.assertFalse(dc.has_pol('xy'))
-        self.assertFalse(dc.has_pol('XY'))
+        assert dc.has_pol('xx')
+        assert dc.has_pol('XX')
+        assert not dc.has_pol('xy')
+        assert not dc.has_pol('XY')
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertTrue(dc.has_pol('xx'))
-        self.assertTrue(dc.has_pol('XX'))
-        self.assertFalse(dc.has_pol('xy'))
-        self.assertFalse(dc.has_pol('XY'))
+        assert dc.has_pol('xx')
+        assert dc.has_pol('XX')
+        assert not dc.has_pol('xy')
+        assert not dc.has_pol('XY')
         dc = datacontainer.DataContainer(self.both)
-        self.assertTrue(dc.has_pol('xx'))
-        self.assertTrue(dc.has_pol('XX'))
-        self.assertFalse(dc.has_pol('xy'))
-        self.assertFalse(dc.has_pol('XY'))
+        assert dc.has_pol('xx')
+        assert dc.has_pol('XX')
+        assert not dc.has_pol('xy')
+        assert not dc.has_pol('XY')
 
     def test_get(self):
         dc = datacontainer.DataContainer(self.blpol)
-        self.assertEqual(dc.get((1, 2), 'yy'), 1j)
-        self.assertEqual(dc.get((2, 1), 'yy'), -1j)
+        assert dc.get((1, 2), 'yy') == 1j
+        assert dc.get((2, 1), 'yy') == -1j
         dc = datacontainer.DataContainer(self.polbl)
-        self.assertEqual(dc.get((1, 2), 'yy'), 1j)
-        self.assertEqual(dc.get((2, 1), 'yy'), -1j)
+        assert dc.get((1, 2), 'yy') == 1j
+        assert dc.get((2, 1), 'yy') == -1j
         dc = datacontainer.DataContainer(self.both)
-        self.assertEqual(dc.get((1, 2), 'yy'), 1j)
-        self.assertEqual(dc.get((2, 1), 'yy'), -1j)
-        self.assertEqual(dc.get((1, 2), 'YY'), 1j)
-        self.assertEqual(dc.get((2, 1), 'YY'), -1j)
+        assert dc.get((1, 2), 'yy') == 1j
+        assert dc.get((2, 1), 'yy') == -1j
+        assert dc.get((1, 2), 'YY') == 1j
+        assert dc.get((2, 1), 'YY') == -1j
 
     def test_setter(self):
         dc = datacontainer.DataContainer(self.blpol)
         # test basic setting
         dc[(100, 101, 'xy')] = np.arange(100) + np.arange(100) * 1j
-        self.assertEqual(dc[(100, 101, 'xy')].shape, (100,))
-        self.assertEqual(dc[(100, 101, 'xy')].dtype, np.complex)
-        self.assertAlmostEqual(dc[(100, 101, 'xy')][1], (1 + 1j))
-        self.assertAlmostEqual(dc[(101, 100, 'yx')][1], (1 - 1j))
-        self.assertEqual(len(dc.keys()), 11)
-        self.assertEqual((100, 101) in dc._antpairs, True)
-        self.assertEqual('xy' in dc._pols, True)
+        assert dc[(100, 101, 'xy')].shape == (100,)
+        assert dc[(100, 101, 'xy')].dtype == np.complex
+        assert np.allclose(dc[(100, 101, 'xy')][1], (1 + 1j))
+        assert np.allclose(dc[(101, 100, 'yx')][1], (1 - 1j))
+        assert len(dc.keys()) == 11
+        assert (100, 101) in dc._antpairs
+        assert 'xy' in dc._pols
         # test error
-        self.assertRaises(ValueError, dc.__setitem__, *((100, 101), 100j))
+        pytest.raises(ValueError, dc.__setitem__, *((100, 101), 100j))
 
     def test_adder(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d + d
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] * 2)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] * 2)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]
-        self.assertRaises(ValueError, d.__add__, d2)
+        pytest.raises(ValueError, d.__add__, d2)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:10, :]
-        self.assertRaises(ValueError, d.__add__, d2)
+        pytest.raises(ValueError, d.__add__, d2)
         d2 = d + 1
-        self.assertTrue(np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] + 1))
+        assert np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] + 1)
 
     def test_sub(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d - d
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], 0.0)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], 0.0)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]
-        self.assertRaises(ValueError, d.__sub__, d2)
+        pytest.raises(ValueError, d.__sub__, d2)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:10, :]
-        self.assertRaises(ValueError, d.__sub__, d2)
+        pytest.raises(ValueError, d.__sub__, d2)
         d2 = d - 1
-        self.assertTrue(np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] - 1))
+        assert np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] - 1)
 
     def test_mul(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         f[(24, 25, 'xx')][:, 0] = False
         f2 = f * f
-        self.assertFalse(f2[(24, 25, 'xx')][0, 0])
+        assert f2[(24, 25, 'xx')][0, 0] == False
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]
-        self.assertRaises(ValueError, d.__mul__, d2)
+        pytest.raises(ValueError, d.__mul__, d2)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:10, :]
-        self.assertRaises(ValueError, d.__mul__, d2)
+        pytest.raises(ValueError, d.__mul__, d2)
         d2 = d * 2
-        self.assertTrue(np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] * 2))
+        assert np.isclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] * 2)
 
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in floor_divide")
     def test_div(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d / d
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], 1.0)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], 1.0)
         d2 = d / 2.0
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] / 2.0)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] / 2.0)
         d2 = d // d
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], 1.0)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], 1.0)
         d2 = d // 2.0
-        self.assertAlmostEqual(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] // 2.0)
+        assert np.allclose(d2[(24, 25, 'xx')][30, 30], d[(24, 25, 'xx')][30, 30] // 2.0)
 
     def test_invert(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         f2 = ~f
         bl = (24, 25, 'xx')
-        self.assertEqual(f2[(bl)][0, 0], ~f[bl][0, 0])
-        self.assertRaises(TypeError, d.__invert__)
+        assert f2[(bl)][0, 0] == ~f[bl][0, 0]
+        pytest.raises(TypeError, d.__invert__)
 
     def test_transpose(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d.T
         bl = (24, 25, 'xx')
-        self.assertEqual(d2[(bl)][0, 0], d[bl].T[0, 0])
+        assert d2[(bl)][0, 0] == d[bl].T[0, 0]
 
     def test_neg(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = -d
         bl = (24, 25, 'xx')
-        self.assertEqual(d2[(bl)][0, 0], -d[(bl)][0, 0])
+        assert d2[(bl)][0, 0] == -d[(bl)][0, 0]
 
     def test_concatenate(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d.concatenate(d)
-        self.assertEqual(d2[(24, 25, 'xx')].shape[0], d[(24, 25, 'xx')].shape[0] * 2)
+        assert d2[(24, 25, 'xx')].shape[0] == d[(24, 25, 'xx')].shape[0] * 2
         d2 = d.concatenate(d, axis=1)
-        self.assertEqual(d2[(24, 25, 'xx')].shape[1], d[(24, 25, 'xx')].shape[1] * 2)
+        assert d2[(24, 25, 'xx')].shape[1] == d[(24, 25, 'xx')].shape[1] * 2
         d2 = d.concatenate([d, d], axis=0)
-        self.assertEqual(d2[(24, 25, 'xx')].shape[0], d[(24, 25, 'xx')].shape[0] * 3)
+        assert d2[(24, 25, 'xx')].shape[0] == d[(24, 25, 'xx')].shape[0] * 3
         # test exceptions
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:10, :10]
-        self.assertRaises(ValueError, d.concatenate, d2, axis=0)
-        self.assertRaises(ValueError, d.concatenate, d2, axis=1)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        pytest.raises(ValueError, d.concatenate, d2, axis=0)
+        pytest.raises(ValueError, d.concatenate, d2, axis=1)

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -15,7 +15,7 @@ from ..data import DATA_PATH
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 class TestDataContainer(object):
-    def setup_method(self, method):
+    def setup_method(self):
         self.antpairs = [(1, 2), (2, 3), (3, 4), (1, 3), (2, 4)]  # not (1,4)
         self.pols = ['xx', 'yy']
         self.blpol = {}

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -311,7 +311,7 @@ class TestDataContainer(object):
         d, f = io.load_vis(test_file, pop_autos=True)
         f[(24, 25, 'xx')][:, 0] = False
         f2 = f * f
-        assert f2[(24, 25, 'xx')][0, 0] == False
+        assert np.isclose(f2[(24, 25, 'xx')][0, 0], False)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -311,7 +311,7 @@ class TestDataContainer(object):
         d, f = io.load_vis(test_file, pop_autos=True)
         f[(24, 25, 'xx')][:, 0] = False
         f2 = f * f
-        assert np.all(f2[(24, 25, 'xx')][0, 0] == False)
+        assert not np.any(f2[(24, 25, 'xx')][0, 0])
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -311,7 +311,7 @@ class TestDataContainer(object):
         d, f = io.load_vis(test_file, pop_autos=True)
         f[(24, 25, 'xx')][:, 0] = False
         f2 = f * f
-        assert np.isclose(f2[(24, 25, 'xx')][0, 0], False)
+        assert np.all(f2[(24, 25, 'xx')][0, 0] == False)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-import unittest
+import pytest
 import numpy as np
 from copy import deepcopy
 import os
@@ -12,15 +12,16 @@ import sys
 import shutil
 from scipy import constants
 from pyuvdata import UVCal, UVData
-from uvtools.dspec import delay_filter
 
-from hera_cal import io
-import hera_cal.delay_filter as df
-from hera_cal.data import DATA_PATH
+from .. import io
+from .. import delay_filter as df
+from ..data import DATA_PATH
 
 
-class Test_DelayFilter(unittest.TestCase):
-
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
+@pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
+@pytest.mark.filterwarnings("ignore:It seems that the latitude and longitude are in radians")
+class Test_DelayFilter(object):
     def test_run_filter(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         k = (24, 25, 'xx')
@@ -31,9 +32,9 @@ class Test_DelayFilter(unittest.TestCase):
 
         dfil.run_filter(to_filter=dfil.data.keys(), tol=1e-2)
         for k in dfil.data.keys():
-            self.assertEqual(dfil.clean_resid[k].shape, (60, 64))
-            self.assertEqual(dfil.clean_model[k].shape, (60, 64))
-            self.assertTrue(k in dfil.clean_info)
+            assert dfil.clean_resid[k].shape == (60, 64)
+            assert dfil.clean_model[k].shape == (60, 64)
+            assert k in dfil.clean_info
 
         # test skip_wgt imposition of flags
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
@@ -43,10 +44,10 @@ class Test_DelayFilter(unittest.TestCase):
         wgts = {k: np.ones_like(dfil.flags[k], dtype=np.float)}
         wgts[k][0, :] = 0.0
         dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
-        self.assertTrue(dfil.clean_info[k][0]['skipped'])
-        np.testing.assert_array_equal(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
-        np.testing.assert_array_equal(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
-        np.testing.assert_array_equal(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+        assert dfil.clean_info[k][0]['skipped'] is True
+        assert np.allclose(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
+        assert np.allclose(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+        assert np.allclose(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
 
     def test_write_filtered_data(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
@@ -57,17 +58,17 @@ class Test_DelayFilter(unittest.TestCase):
         data = dfil.data
         dfil.run_filter(standoff=0., horizon=1., tol=1e-9, window='blackman-harris', skip_wgt=0.1, maxiter=100, edgecut_low=0, edgecut_hi=0)
         outfilename = os.path.join(DATA_PATH, 'test_output/zen.2458043.12552.xx.HH.filter_test.ORAD.uvh5')
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             dfil.write_filtered_data()
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             dfil.write_filtered_data(res_outfilename=outfilename, partial_write=True)
         dfil.write_filtered_data(res_outfilename=outfilename, add_to_history='Hello_world.', clobber=True, telescope_name='PAPER')
 
         uvd = UVData()
         uvd.read_uvh5(outfilename)
-        self.assertTrue('Hello_world.' in uvd.history.replace('\n', '').replace(' ', ''))
-        self.assertTrue('Thisfilewasproducedbythefunction' in uvd.history.replace('\n', '').replace(' ', ''))
-        self.assertEqual(uvd.telescope_name, 'PAPER')
+        assert 'Hello_world.' in uvd.history.replace('\n', '').replace(' ', '')
+        assert 'Thisfilewasproducedbythefunction' in uvd.history.replace('\n', '').replace(' ', '')
+        assert uvd.telescope_name == 'PAPER'
 
         filtered_residuals, flags = io.load_vis(uvd)
 
@@ -78,10 +79,10 @@ class Test_DelayFilter(unittest.TestCase):
         filled_data, filled_flags = io.load_vis(outfilename, filetype='uvh5')
 
         for k in data.keys():
-            np.testing.assert_array_almost_equal(filled_data[k][~flags[k]], data[k][~flags[k]])
-            np.testing.assert_array_almost_equal(dfil.clean_model[k], clean_model[k])
-            np.testing.assert_array_almost_equal(dfil.clean_resid[k], filtered_residuals[k])
-            np.testing.assert_array_almost_equal(data[k][~flags[k]], (clean_model[k] + filtered_residuals[k])[~flags[k]], 5)
+            assert np.allclose(filled_data[k][~flags[k]], data[k][~flags[k]])
+            assert np.allclose(dfil.clean_model[k], clean_model[k])
+            assert np.allclose(dfil.clean_resid[k], filtered_residuals[k])
+            assert np.allclose(data[k][~flags[k]], (clean_model[k] + filtered_residuals[k])[~flags[k]], 5)
         os.remove(outfilename)
 
     def test_partial_load_delay_filter_and_write(self):
@@ -94,25 +95,21 @@ class Test_DelayFilter(unittest.TestCase):
         dfil = df.DelayFilter(uvh5, filetype='uvh5')
         dfil.read(bls=[(53, 54, 'xx')])
         dfil.run_filter(to_filter=[(53, 54, 'xx')], tol=1e-4, verbose=True)
-        np.testing.assert_almost_equal(d[(53, 54, 'xx')], dfil.clean_resid[(53, 54, 'xx')], decimal=5)
-        np.testing.assert_array_equal(f[(53, 54, 'xx')], dfil.flags[(53, 54, 'xx')])
+        assert np.allclose(d[(53, 54, 'xx')], dfil.clean_resid[(53, 54, 'xx')], atol=1e-5)
+        assert np.allclose(f[(53, 54, 'xx')], dfil.flags[(53, 54, 'xx')])
 
         cal = os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only")
         outfilename = os.path.join(DATA_PATH, 'test_output/temp.h5')
         df.partial_load_delay_filter_and_write(uvh5, calfile=cal, tol=1e-4, res_outfilename=outfilename, Nbls=2, clobber=True)
         hd = io.HERAData(outfilename)
-        self.assertTrue('Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', ''))
+        assert 'Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', '')
         d, f, n = hd.read(bls=[(53, 54, 'xx')])
-        np.testing.assert_array_equal(f[(53, 54, 'xx')], True)
+        assert np.all(f[(53, 54, 'xx')])
         os.remove(outfilename)
 
     def test_delay_filter_argparser(self):
         sys.argv = [sys.argv[0], 'a', '--clobber']
         parser = df.delay_filter_argparser()
         a = parser.parse_args()
-        self.assertEqual(a.infilename, 'a')
-        self.assertTrue(a.clobber)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert a.infilename == 'a'
+        assert a.clobber is True

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -45,9 +45,9 @@ class Test_DelayFilter(object):
         wgts[k][0, :] = 0.0
         dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
         assert dfil.clean_info[k][0]['skipped'] is True
-        assert np.allclose(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
-        assert np.allclose(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
-        assert np.allclose(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+        np.testing.assert_array_equal(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
+        np.testing.assert_array_equal(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+        np.testing.assert_array_equal(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
 
     def test_write_filtered_data(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
@@ -79,10 +79,10 @@ class Test_DelayFilter(object):
         filled_data, filled_flags = io.load_vis(outfilename, filetype='uvh5')
 
         for k in data.keys():
-            assert np.allclose(filled_data[k][~flags[k]], data[k][~flags[k]])
-            assert np.allclose(dfil.clean_model[k], clean_model[k])
-            assert np.allclose(dfil.clean_resid[k], filtered_residuals[k])
-            assert np.allclose(data[k][~flags[k]], (clean_model[k] + filtered_residuals[k])[~flags[k]], 5)
+            np.testing.assert_array_almost_equal(filled_data[k][~flags[k]], data[k][~flags[k]])
+            np.testing.assert_array_almost_equal(dfil.clean_model[k], clean_model[k])
+            np.testing.assert_array_almost_equal(dfil.clean_resid[k], filtered_residuals[k])
+            np.testing.assert_array_almost_equal(data[k][~flags[k]], (clean_model[k] + filtered_residuals[k])[~flags[k]], 5)
         os.remove(outfilename)
 
     def test_partial_load_delay_filter_and_write(self):
@@ -95,8 +95,8 @@ class Test_DelayFilter(object):
         dfil = df.DelayFilter(uvh5, filetype='uvh5')
         dfil.read(bls=[(53, 54, 'xx')])
         dfil.run_filter(to_filter=[(53, 54, 'xx')], tol=1e-4, verbose=True)
-        assert np.allclose(d[(53, 54, 'xx')], dfil.clean_resid[(53, 54, 'xx')], atol=1e-5)
-        assert np.allclose(f[(53, 54, 'xx')], dfil.flags[(53, 54, 'xx')])
+        np.testing.assert_almost_equal(d[(53, 54, 'xx')], dfil.clean_resid[(53, 54, 'xx')], decimal=5)
+        np.testing.assert_array_equal(f[(53, 54, 'xx')], dfil.flags[(53, 54, 'xx')])
 
         cal = os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only")
         outfilename = os.path.join(DATA_PATH, 'test_output/temp.h5')
@@ -104,7 +104,7 @@ class Test_DelayFilter(object):
         hd = io.HERAData(outfilename)
         assert 'Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', '')
         d, f, n = hd.read(bls=[(53, 54, 'xx')])
-        assert np.all(f[(53, 54, 'xx')])
+        np.testing.assert_array_equal(f[(53, 54, 'xx')], True)
         os.remove(outfilename)
 
     def test_delay_filter_argparser(self):

--- a/hera_cal/tests/test_flag_utils.py
+++ b/hera_cal/tests/test_flag_utils.py
@@ -90,7 +90,7 @@ def test_factorize_flags():
 
     # run on datacontainer
     f2 = flag_utils.factorize_flags(copy.deepcopy(flags), time_thresh=0.5 / 60, inplace=False)
-    assert np.allclose(f2[(24, 25, 'xx')], f)
+    np.testing.assert_array_equal(f2[(24, 25, 'xx')], f)
 
     # test exceptions
     pytest.raises(ValueError, flag_utils.factorize_flags, flags, spw_ranges=(0, 1))

--- a/hera_cal/tests/test_frf.py
+++ b/hera_cal/tests/test_frf.py
@@ -105,7 +105,7 @@ def test_fir_filtering():
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 class Test_FRFilter(object):
-    def setup_method(self, method):
+    def setup_method(self):
         self.fname = os.path.join(DATA_PATH, "zen.2458042.12552.xx.HH.uvXA")
         self.F = frf.FRFilter(self.fname, filetype='miriad')
         self.F.read()

--- a/hera_cal/tests/test_frf.py
+++ b/hera_cal/tests/test_frf.py
@@ -92,8 +92,8 @@ def test_fir_filtering():
 
     # convert back
     _frp, _frbins = frf.frp_to_fir(fir, delta_bin=np.diff(tbins)[0], undo=True)
-    assert np.allclose(frp, _frp.real)
-    assert np.allclose(np.diff(frbins), np.diff(_frbins))
+    np.testing.assert_array_almost_equal(frp, _frp.real)
+    np.testing.assert_array_almost_equal(np.diff(frbins), np.diff(_frbins))
     assert np.allclose(np.abs(_frp.imag), 0.0)
 
     # test noise averaging properties

--- a/hera_cal/tests/test_frf.py
+++ b/hera_cal/tests/test_frf.py
@@ -87,8 +87,8 @@ def test_fir_filtering():
     frp[512 - 9:512 + 10] = 0.0
     fir, tbins = frf.frp_to_fir(frp, delta_bin=np.diff(frbins)[0])
     # confirm its purely real
-    assert not np.isclose(np.abs(fir.real), 0.0).any()
-    assert np.isclose(np.abs(fir.imag), 0.0).all()
+    assert not np.any(np.isclose(np.abs(fir.real), 0.0))
+    assert np.allclose(np.abs(fir.imag), 0.0)
 
     # convert back
     _frp, _frbins = frf.frp_to_fir(fir, delta_bin=np.diff(tbins)[0], undo=True)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -605,6 +605,7 @@ class Test_Visibility_IO_Legacy(object):
 
     @pytest.mark.filterwarnings("ignore:The expected shape of the ENU array")
     @pytest.mark.filterwarnings("ignore:antenna_diameters is not set")
+    @pytest.mark.filterwarnings("ignore:Unicode equal comparison failed")
     def test_write_vis(self):
         # get data
         uvd = UVData()

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -894,7 +894,7 @@ def test_get_file_times():
     # test execution
     dlsts, dtimes, larrs, tarrs = io.get_file_times(filepaths, filetype='miriad')
     assert np.isclose(larrs[0, 0], 4.7293432458811866)
-    asesrt np.isclose(larrs[0, -1], 4.7755393587036084)
+    assert np.isclose(larrs[0, -1], 4.7755393587036084)
     assert np.isclose(dlsts[0], 0.00078298496309189868)
     assert len(dlsts) == 2
     assert len(dtimes) == 2
@@ -905,10 +905,10 @@ def test_get_file_times():
 
     # test if fed as a str
     dlsts, dtimes, larrs, tarrs = io.get_file_times(filepaths[0], filetype='miriad')
-    nt.assert_true(isinstance(dlsts, (float, np.float)))
-    nt.assert_true(isinstance(dtimes, (float, np.float)))
-    nt.assert_equal(larrs.ndim, 1)
-    nt.assert_equal(tarrs.ndim, 1)
+    assert isinstance(dlsts, (float, np.float))
+    assert isinstance(dtimes, (float, np.float))
+    assert larrs.ndim == 1
+    assert tarrs.ndim == 1
 
     # test uvh5
     fp = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -51,12 +51,12 @@ class Test_HERACal(object):
         gains, flags, quals, total_qual = hc.read()
         uvc = UVCal()
         uvc.read_calfits(self.fname_both)
-        assert np.allclose(uvc.gain_array[0, 0, :, :, 0].T, gains[9, parse_jpolstr('jxx')])
-        assert np.allclose(uvc.flag_array[0, 0, :, :, 0].T, flags[9, parse_jpolstr('jxx')])
-        assert np.allclose(uvc.quality_array[0, 0, :, :, 0].T, quals[9, parse_jpolstr('jxx')])
-        assert np.allclose(uvc.total_quality_array[0, :, :, 0].T, total_qual[parse_jpolstr('jxx')])
-        assert np.allclose(np.unique(uvc.freq_array), hc.freqs)
-        assert np.allclose(np.unique(uvc.time_array), hc.times)
+        np.testing.assert_array_equal(uvc.gain_array[0, 0, :, :, 0].T, gains[9, parse_jpolstr('jxx')])
+        np.testing.assert_array_equal(uvc.flag_array[0, 0, :, :, 0].T, flags[9, parse_jpolstr('jxx')])
+        np.testing.assert_array_equal(uvc.quality_array[0, 0, :, :, 0].T, quals[9, parse_jpolstr('jxx')])
+        np.testing.assert_array_equal(uvc.total_quality_array[0, :, :, 0].T, total_qual[parse_jpolstr('jxx')])
+        np.testing.assert_array_equal(np.unique(uvc.freq_array), hc.freqs)
+        np.testing.assert_array_equal(np.unique(uvc.time_array), hc.times)
         assert hc.pols == [parse_jpolstr('jxx'), parse_jpolstr('jyy')]
         assert set([ant[0] for ant in hc.ants]) == set(uvc.ant_array)
 
@@ -86,11 +86,11 @@ class Test_HERACal(object):
         hc2 = HERACal('test.calfits')
         gains_out, flags_out, quals_out, total_qual_out = hc2.read()
         for key in gains_in.keys():
-            assert np.allclose(gains_in[key] * (2.0 + 1.0j), gains_out[key])
-            assert np.allclose(np.logical_not(flags_in[key]), flags_out[key])
-            assert np.allclose(quals_in[key] * (2.0), quals_out[key])
+            np.testing.assert_array_equal(gains_in[key] * (2.0 + 1.0j), gains_out[key])
+            np.testing.assert_array_equal(np.logical_not(flags_in[key]), flags_out[key])
+            np.testing.assert_array_equal(quals_in[key] * (2.0), quals_out[key])
         for key in total_qual.keys():
-            assert np.allclose(total_qual_in[key] * (2.0), total_qual_out[key])
+            np.testing.assert_array_equal(total_qual_in[key] * (2.0), total_qual_out[key])
 
         os.remove('test.calfits')
 
@@ -130,13 +130,13 @@ class Test_HERAData(object):
             assert getattr(hd, meta) is not None
         for f in files:
             assert len(hd.freqs[f]) == 1024
-            assert np.allclose(hd.freqs[f], individual_hds[f].freqs)
+            np.testing.assert_array_equal(hd.freqs[f], individual_hds[f].freqs)
             assert len(hd.bls[f]) == 3
-            assert np.all(hd.bls[f] == individual_hds[f].bls)
+            np.testing.assert_array_equal(hd.bls[f], individual_hds[f].bls)
             assert len(hd.times[f]) == 60
-            assert np.allclose(hd.times[f], individual_hds[f].times)
+            np.testing.assert_array_equal(hd.times[f], individual_hds[f].times)
             assert len(hd.lsts[f]) == 60
-            assert np.allclose(hd.lsts[f], individual_hds[f].lsts)
+            np.testing.assert_array_equal(hd.lsts[f], individual_hds[f].lsts)
         assert not hasattr(hd, '_writers')
 
         # miriad
@@ -183,10 +183,10 @@ class Test_HERAData(object):
         hd.select(bls=[(53, 54)])
         assert len(hd._blt_slices) == 1
         d2 = hd.get_data(53, 54, 'xx')
-        assert np.allclose(d1, d2)
+        np.testing.assert_array_almost_equal(d1, d2)
         hd.select(times=np.unique(hd.time_array)[-5:])
         d3 = hd.get_data(53, 54, 'xx')
-        assert np.allclose(d2[-5:], d3)
+        np.testing.assert_array_almost_equal(d2[-5:], d3)
 
         # pol select
         hd.select(polarizations=['yy'])
@@ -217,16 +217,16 @@ class Test_HERAData(object):
         assert len(metas['bls']) == 3
         assert len(metas['times']) == 60
         assert len(metas['lsts']) == 60
-        assert np.allclose(metas['times'], np.unique(list(metas['times_by_bl'].values())))
-        assert np.allclose(metas['lsts'], np.unique(list(metas['lsts_by_bl'].values())))
+        np.testing.assert_array_equal(metas['times'], np.unique(list(metas['times_by_bl'].values())))
+        np.testing.assert_array_equal(metas['lsts'], np.unique(list(metas['lsts_by_bl'].values())))
 
     def test_determine_blt_slicing(self):
         hd = HERAData(self.uvh5_1)
         for s in hd._blt_slices.values():
             assert isinstance(s, slice)
         for bl, s in hd._blt_slices.items():
-            assert np.allclose(np.arange(180)[np.logical_and(hd.ant_1_array == bl[0],
-                                                             hd.ant_2_array == bl[1])], np.arange(180)[s])
+            np.testing.assert_array_equal(np.arange(180)[np.logical_and(hd.ant_1_array == bl[0],
+                                                                        hd.ant_2_array == bl[1])], np.arange(180)[s])
         # test check for non-regular spacing
         hd.ant_1_array = hd.ant_2_array
         with pytest.raises(NotImplementedError):
@@ -243,23 +243,23 @@ class Test_HERAData(object):
         hd = HERAData(self.uvh5_1)
         hd.read()
         for bl in hd.bls:
-            assert np.allclose(hd._get_slice(hd.data_array, bl), hd.get_data(bl))
-        assert np.allclose(hd._get_slice(hd.data_array, (54, 53, 'XX')),
-                           hd.get_data((54, 53, 'XX')))
-        assert np.allclose(hd._get_slice(hd.data_array, (53, 54))[parse_polstr('XX')],
-                           hd.get_data((53, 54, 'XX')))
-        assert np.allclose(hd._get_slice(hd.data_array, 'XX')[(53, 54)],
-                           hd.get_data((53, 54, 'XX')))
+            np.testing.assert_array_equal(hd._get_slice(hd.data_array, bl), hd.get_data(bl))
+        np.testing.assert_array_equal(hd._get_slice(hd.data_array, (54, 53, 'XX')),
+                                      hd.get_data((54, 53, 'XX')))
+        np.testing.assert_array_equal(hd._get_slice(hd.data_array, (53, 54))[parse_polstr('XX')],
+                                      hd.get_data((53, 54, 'XX')))
+        np.testing.assert_array_equal(hd._get_slice(hd.data_array, 'XX')[(53, 54)],
+                                      hd.get_data((53, 54, 'XX')))
         with pytest.raises(KeyError):
             hd._get_slice(hd.data_array, (1, 2, 3, 4))
 
         hd = HERAData(self.four_pol, filetype='miriad')
         d, f, n = hd.read(bls=[(80, 81)])
         for p in d.pols():
-            assert np.allclose(hd._get_slice(hd.data_array, (80, 81, p)),
-                               hd.get_data((80, 81, p)))
-            assert np.allclose(hd._get_slice(hd.data_array, (81, 80, p)),
-                               hd.get_data((81, 80, p)))
+            np.testing.assert_array_almost_equal(hd._get_slice(hd.data_array, (80, 81, p)),
+                                                 hd.get_data((80, 81, p)))
+            np.testing.assert_array_almost_equal(hd._get_slice(hd.data_array, (81, 80, p)),
+                                                 hd.get_data((81, 80, p)))
 
     def test_set_slice(self):
         hd = HERAData(self.uvh5_1)
@@ -269,20 +269,20 @@ class Test_HERAData(object):
         for bl in hd.bls:
             new_vis = np.random.randn(60, 1024) + np.random.randn(60, 1024) * 1.0j
             hd._set_slice(hd.data_array, bl, new_vis)
-            assert np.allclose(new_vis, hd.get_data(bl))
+            np.testing.assert_array_almost_equal(new_vis, hd.get_data(bl))
 
         new_vis = np.random.randn(60, 1024) + np.random.randn(60, 1024) * 1.0j
         hd._set_slice(hd.data_array, (54, 53, 'xx'), new_vis)
-        assert np.allclose(np.conj(new_vis), hd.get_data((53, 54, 'xx')))
+        np.testing.assert_array_almost_equal(np.conj(new_vis), hd.get_data((53, 54, 'xx')))
 
         new_vis = np.random.randn(60, 1024) + np.random.randn(60, 1024) * 1.0j
         hd._set_slice(hd.data_array, (53, 54), {'xx': new_vis})
-        assert np.allclose(new_vis, hd.get_data((53, 54, 'xx')))
+        np.testing.assert_array_almost_equal(new_vis, hd.get_data((53, 54, 'xx')))
 
         new_vis = np.random.randn(60, 1024) + np.random.randn(60, 1024) * 1.0j
         to_set = {(53, 54): new_vis, (54, 54): 2 * new_vis, (53, 53): 3 * new_vis}
         hd._set_slice(hd.data_array, 'XX', to_set)
-        assert np.allclose(new_vis, hd.get_data((53, 54, 'xx')))
+        np.testing.assert_array_almost_equal(new_vis, hd.get_data((53, 54, 'xx')))
 
         with pytest.raises(KeyError):
             hd._set_slice(hd.data_array, (1, 2, 3, 4), None)
@@ -291,9 +291,9 @@ class Test_HERAData(object):
         hd = HERAData(self.uvh5_1)
         d, f, n = hd.read()
         for bl in hd.bls:
-            assert np.allclose(d[bl], hd.get_data(bl))
-            assert np.allclose(f[bl], hd.get_flags(bl))
-            assert np.allclose(n[bl], hd.get_nsamples(bl))
+            np.testing.assert_array_almost_equal(d[bl], hd.get_data(bl))
+            np.testing.assert_array_almost_equal(f[bl], hd.get_flags(bl))
+            np.testing.assert_array_almost_equal(n[bl], hd.get_nsamples(bl))
         for dc in [d, f, n]:
             assert isinstance(dc, DataContainer)
             for k in dc.antpos.keys():
@@ -360,7 +360,7 @@ class Test_HERAData(object):
         hd = HERAData(self.uvh5_1)
         hd.read()
         for bl in hd.bls:
-            assert np.allclose(hd[bl], hd.get_data(bl))
+            np.testing.assert_array_almost_equal(hd[bl], hd.get_data(bl))
 
     def test_update(self):
         hd = HERAData(self.uvh5_1)
@@ -372,9 +372,9 @@ class Test_HERAData(object):
         hd.update(data=d, flags=f, nsamples=n)
         d2, f2, n2 = hd.build_datacontainers()
         for bl in hd.bls:
-            assert np.allclose(d[bl], d2[bl])
-            assert np.all(f[bl] == f2[bl])
-            assert np.all(n[bl] == n2[bl])
+            np.testing.assert_array_almost_equal(d[bl], d2[bl])
+            np.testing.assert_array_equal(f[bl], f2[bl])
+            np.testing.assert_array_equal(n[bl], n2[bl])
 
     def test_partial_write(self):
         hd = HERAData(self.uvh5_1)
@@ -402,16 +402,16 @@ class Test_HERAData(object):
         d[(54, 54, 'XX')] *= (2.0 + 1.0j)
         hd.partial_write('out.h5', data=d, clobber=True, inplace=True)
         d_after, _, _ = hd.build_datacontainers()
-        assert np.allclose(d[(54, 54, 'XX')], d_after[(54, 54, 'XX')])
+        np.testing.assert_array_almost_equal(d[(54, 54, 'XX')], d_after[(54, 54, 'XX')])
 
         hd = HERAData(self.uvh5_1)
         d, f, n = hd.read()
         hd2 = HERAData('out.h5')
         d2, f2, n2 = hd2.read()
         for bl in hd.bls:
-            assert np.allclose(d[bl] * (2.0 + 1.0j), d2[bl])
-            assert np.all(f[bl] == f2[bl])
-            assert np.all(n[bl] == n2[bl])
+            np.testing.assert_array_almost_equal(d[bl] * (2.0 + 1.0j), d2[bl])
+            np.testing.assert_array_equal(f[bl], f2[bl])
+            np.testing.assert_array_equal(n[bl], n2[bl])
         os.remove('out.h5')
 
         # test errors
@@ -580,9 +580,9 @@ class Test_Visibility_IO_Legacy(object):
                 uvpol = list(uvd1.polarization_array).index(polstr2num(pol))
                 uvmask = np.all(
                     np.array(list(zip(uvd.ant_1_array, uvd.ant_2_array))) == [i, j], axis=1)
-                assert np.all(d[i, j][pol] == np.resize(
+                np.testing.assert_equal(d[i, j][pol], np.resize(
                     uvd.data_array[uvmask][:, 0, :, uvpol], d[i, j][pol].shape))
-                assert np.all(f[i, j][pol] == np.resize(
+                np.testing.assert_equal(f[i, j][pol], np.resize(
                     uvd.flag_array[uvmask][:, 0, :, uvpol], f[i, j][pol].shape))
 
         d, f = io.load_vis([filename1, filename2], nested_dict=True)
@@ -591,9 +591,9 @@ class Test_Visibility_IO_Legacy(object):
                 uvpol = list(uvd.polarization_array).index(polstr2num(pol))
                 uvmask = np.all(
                     np.array(list(zip(uvd.ant_1_array, uvd.ant_2_array))) == [i, j], axis=1)
-                assert np.all(d[i, j][pol] == np.resize(
+                np.testing.assert_equal(d[i, j][pol], np.resize(
                     uvd.data_array[uvmask][:, 0, :, uvpol], d[i, j][pol].shape))
-                assert np.all(f[i, j][pol] == np.resize(
+                np.testing.assert_equal(f[i, j][pol], np.resize(
                     uvd.flag_array[uvmask][:, 0, :, uvpol], f[i, j][pol].shape))
 
         uvd = UVData()
@@ -779,7 +779,7 @@ class Test_Calibration_IO_Legacy(object):
             gains[(k[0], 'Jyy')] = gains[k].conj()
         uvc = io.write_cal("ex.calfits", gains, freqs, times, return_uvc=True, outdir='./')
         assert uvc.gain_array.shape == (10, 1, 64, 100, 2)
-        assert np.allclose(uvc.gain_array[0, 0, :, :, 0], uvc.gain_array[0, 0, :, :, 1].conj())
+        np.testing.assert_array_almost_equal(uvc.gain_array[0, 0, :, :, 0], uvc.gain_array[0, 0, :, :, 1].conj())
         os.remove('ex.calfits')
 
         # test zero check
@@ -838,8 +838,8 @@ class Test_Flags_IO(object):
         assert (53, 54, parse_polstr('XX')) in flags
         for f in flags.values():
             assert f.shape == (60, 1024)
-            assert np.allclose(f[:, 0:50], True)
-            assert np.allclose(f[:, -50:], True)
+            np.testing.assert_array_equal(f[:, 0:50], True)
+            np.testing.assert_array_equal(f[:, -50:], True)
             assert not np.all(f)
 
         flags, meta = io.load_flags(npzfile, filetype='npz', return_meta=True)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -28,7 +28,7 @@ from hera_qm.data import DATA_PATH as QM_DATA_PATH
 
 
 class Test_HERACal(object):
-    def setup_method(self, method):
+    def setup_method(self):
         self.fname_xx = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.xx.HH.uvc.omni.calfits")
         self.fname_yy = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.yy.HH.uvc.omni.calfits")
         self.fname_both = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.HH.uvcA.omni.calfits")
@@ -100,7 +100,7 @@ class Test_HERACal(object):
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars")
 class Test_HERAData(object):
-    def setup_method(self, method):
+    def setup_method(self):
         self.uvh5_1 = os.path.join(DATA_PATH, "zen.2458116.61019.xx.HH.XRS_downselected.uvh5")
         self.uvh5_2 = os.path.join(DATA_PATH, "zen.2458116.61765.xx.HH.XRS_downselected.uvh5")
         self.miriad_1 = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -289,23 +289,23 @@ class Test_lstbin(object):
         x[10] = 4
         x[11] = -4
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert np.isclose(arr[10], True)
-        assert np.isclose(arr[11], True)
+        assert np.all(arr[10] == True)
+        assert np.all(arr[11] == True)
         # test array performance
         x = np.array(list(map(lambda s: stats.norm.rvs(0, s, 100), np.arange(1, 5.1, 1))))
         x[0, 50] = 100
         x[4, 50] = 5
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert np.isclose(arr[0, 50], True)
-        assert np.isclose(arr[4, 50], False)
+        assert np.all(arr[0, 50] == True)
+        assert np.all(arr[4, 50] == False)
         # test flags
         arr = stats.norm.rvs(0, 1, 10).reshape(2, 5)
         flg = np.zeros_like(arr, np.bool)
         flg[0, 3] = True
         out = lstbin.sigma_clip(arr, flags=flg, min_N=5)
-        assert np.isclose(out[0, 3], False)
+        assert np.all(out[0, 3] == False)
         out = lstbin.sigma_clip(arr, flags=flg, min_N=1)
-        assert np.isclose(out[0, 3], True)
+        assert np.all(out[0, 3] == True)
 
     def test_switch_bl(self):
         # test basic execution

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -65,11 +65,11 @@ class Test_lstbin(object):
         dlst = 0.0007830490163484
         # test basic execution
         output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=None,
-                                   median=True, lst_low=0, lst_hi=np.pi, verbose=False)
+                                median=True, lst_low=0, lst_hi=np.pi, verbose=False)
         output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
-                                   verbose=False)
+                                verbose=False)
         output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=dlst,
-                                   verbose=False)
+                                verbose=False)
         # check shape and dtype
         assert output[1][(24, 25, 'xx')].dtype == np.complex
         assert output[1][(24, 25, 'xx')].shape == (224, 64)
@@ -112,7 +112,7 @@ class Test_lstbin(object):
         assert len(output[0]) == 175
         # test appropriate data_count
         output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=dlst, lst_low=0.25, lst_hi=0.3,
-                                   verbose=False)
+                                verbose=False)
         assert np.allclose(output[4][(24, 25, 'xx')], 3.0)
 
     def test_lst_align(self):
@@ -289,23 +289,23 @@ class Test_lstbin(object):
         x[10] = 4
         x[11] = -4
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert arr[10] == True
-        assert arr[11] == True
+        assert np.isclose(arr[10], True)
+        assert np.isclose(arr[11], True)
         # test array performance
         x = np.array(list(map(lambda s: stats.norm.rvs(0, s, 100), np.arange(1, 5.1, 1))))
         x[0, 50] = 100
         x[4, 50] = 5
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert arr[0, 50] == True
-        assert arr[4, 50] == False
+        assert np.isclose(arr[0, 50], True)
+        assert np.isclose(arr[4, 50], False)
         # test flags
         arr = stats.norm.rvs(0, 1, 10).reshape(2, 5)
         flg = np.zeros_like(arr, np.bool)
         flg[0, 3] = True
         out = lstbin.sigma_clip(arr, flags=flg, min_N=5)
-        assert out[0, 3] == False
+        assert np.isclose(out[0, 3], False)
         out = lstbin.sigma_clip(arr, flags=flg, min_N=1)
-        assert out[0, 3] == True
+        assert np.isclose(out[0, 3], True)
 
     def test_switch_bl(self):
         # test basic execution

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -134,7 +134,7 @@ class Test_lstbin(object):
     @pytest.mark.filterwarnings("ignore:antenna_diameters is not set")
     def test_lst_bin_files(self):
         # basic execution
-        file_ext = "{pol}.{type}.{time:7.5f}.uv"
+        file_ext = "{pol}.{type}.{time:7.5f}.uvh5"
         lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
                              verbose=False, file_ext=file_ext, ignore_flags=True)
         output_lst_file = "./zen.xx.LST.0.20124.uvh5"
@@ -146,7 +146,7 @@ class Test_lstbin(object):
         # assert nsample w.r.t time follows 1-2-3-2-1 pattern
         nsamps = np.mean(uv1.get_nsamples(52, 52, 'xx'), axis=1)
         expectation = np.concatenate([np.ones(22), np.ones(22) * 2, np.ones(136) * 3, np.ones(22) * 2, np.ones(21)]).astype(np.float)
-        nt.assert_true(np.isclose(nsamps, expectation).all())
+        assert np.allclose(nsamps, expectation)
         os.remove(output_lst_file)
         os.remove(output_std_file)
 
@@ -164,8 +164,8 @@ class Test_lstbin(object):
         # test rephase
         lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
                              verbose=False, rephase=True, file_ext=file_ext)
-        output_lst_file = "./zen.xx.LST.0.20124.uv"
-        output_std_file = "./zen.xx.STD.0.20124.uv"
+        output_lst_file = "./zen.xx.LST.0.20124.uvh5"
+        output_std_file = "./zen.xx.STD.0.20124.uvh5"
         assert os.path.exists(output_lst_file)
         assert os.path.exists(output_std_file)
         os.remove(output_lst_file)
@@ -229,12 +229,16 @@ class Test_lstbin(object):
         # test fixed start
         lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
                              verbose=False, lst_start=0.18, fixed_lst_start=True, file_ext=file_ext)
-        output_lst_file = "./zen.xx.LST.0.17932.uv"
-        output_std_file = "./zen.xx.STD.0.17932.uv"
+        output_lst_file = "./zen.xx.LST.0.17932.uvh5"
+        output_std_file = "./zen.xx.STD.0.17932.uvh5"
         assert os.path.exists(output_lst_file)
         assert os.path.exists(output_std_file)
         os.remove(output_lst_file)
         os.remove(output_std_file)
+        extra_files = ["zen.xx.LST.0.37508.uvh5", "zen.xx.STD.0.37508.uvh5"]
+        for of in extra_files:
+            if os.path.exists(of):
+                os.remove(of)
 
         # test input_cal
         uvc = UVCal()
@@ -274,7 +278,7 @@ class Test_lstbin(object):
         os.remove(output_std_file)
 
     def test_lst_bin_arg_parser(self):
-        a = hc.lstbin.lst_bin_arg_parser()
+        a = lstbin.lst_bin_arg_parser()
         args = a.parse_args(["--dlst", "0.1", "--input_cals", "zen.2458043.12552.HH.uvA.omni.calfits", "zen.2458043.12552.xx.HH.uvORA.abs.calfits",
                              "--overwrite", "zen.2458042.12552.xx.HH.uvXA", "zen.2458043.12552.xx.HH.uvXA"])
 

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -289,23 +289,23 @@ class Test_lstbin(object):
         x[10] = 4
         x[11] = -4
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert np.all(arr[10] == True)
-        assert np.all(arr[11] == True)
+        assert np.all(arr[10])
+        assert np.all(arr[11])
         # test array performance
         x = np.array(list(map(lambda s: stats.norm.rvs(0, s, 100), np.arange(1, 5.1, 1))))
         x[0, 50] = 100
         x[4, 50] = 5
         arr = lstbin.sigma_clip(x, sigma=2.0)
-        assert np.all(arr[0, 50] == True)
-        assert np.all(arr[4, 50] == False)
+        assert np.all(arr[0, 50])
+        assert not np.any(arr[4, 50])
         # test flags
         arr = stats.norm.rvs(0, 1, 10).reshape(2, 5)
         flg = np.zeros_like(arr, np.bool)
         flg[0, 3] = True
         out = lstbin.sigma_clip(arr, flags=flg, min_N=5)
-        assert np.all(out[0, 3] == False)
+        assert not np.any(out[0, 3])
         out = lstbin.sigma_clip(arr, flags=flg, min_N=1)
-        assert np.all(out[0, 3] == True)
+        assert np.all(out[0, 3])
 
     def test_switch_bl(self):
         # test basic execution

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -31,7 +31,7 @@ from ..data import DATA_PATH
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in greater")
 class Test_lstbin(object):
-    def setup_method(self, method):
+    def setup_method(self):
         # load data
         np.random.seed(0)
         self.data_files = [sorted(glob.glob(DATA_PATH + '/zen.2458043.4*XRAA.uvh5')),

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-import nose.tools as nt
+import pytest
 import os
 import shutil
 import json
@@ -20,15 +20,18 @@ import scipy.stats as stats
 from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
 
-import hera_cal as hc
-from hera_cal import io
-from hera_cal.datacontainer import DataContainer
-from hera_cal.data import DATA_PATH
+from .. import io, lstbin
+from ..datacontainer import DataContainer
+from ..data import DATA_PATH
 
 
-class Test_lstbin:
-
-    def setUp(self):
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
+@pytest.mark.filterwarnings("ignore:Degrees of freedom <= 0 for slice")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in greater")
+class Test_lstbin(object):
+    def setup_method(self, method):
         # load data
         np.random.seed(0)
         self.data_files = [sorted(glob.glob(DATA_PATH + '/zen.2458043.4*XRAA.uvh5')),
@@ -36,47 +39,49 @@ class Test_lstbin:
                            sorted(glob.glob(DATA_PATH + '/zen.2458045.4*XRAA.uvh5'))]
 
         (self.data1, self.flgs1, self.ap1, a, self.freqs1, t, self.lsts1,
-         p) = hc.io.load_vis(self.data_files[0], return_meta=True, filetype='uvh5')
+         p) = io.load_vis(self.data_files[0], return_meta=True, filetype="uvh5")
         (self.data2, self.flgs2, ap, a, self.freqs2, t, self.lsts2,
-         p) = hc.io.load_vis(self.data_files[1], return_meta=True, filetype='uvh5')
+         p) = io.load_vis(self.data_files[1], return_meta=True, filetype="uvh5")
         (self.data3, self.flgs3, ap, a, self.freqs3, t, self.lsts3,
-         p) = hc.io.load_vis(self.data_files[2], return_meta=True, filetype='uvh5')
+         p) = io.load_vis(self.data_files[2], return_meta=True, filetype="uvh5")
         self.data_list = [self.data1, self.data2, self.data3]
         self.flgs_list = [self.flgs1, self.flgs2, self.flgs3]
         self.lst_list = [self.lsts1, self.lsts2, self.lsts3]
 
     def test_make_lst_grid(self):
-        lst_grid = hc.lstbin.make_lst_grid(0.01, begin_lst=None, verbose=False)
-        nt.assert_equal(len(lst_grid), 628)
-        nt.assert_almost_equal(lst_grid[0], 0.0050025360725952121)
-        lst_grid = hc.lstbin.make_lst_grid(0.01, begin_lst=np.pi, verbose=False)
-        nt.assert_equal(len(lst_grid), 628)
-        nt.assert_almost_equal(lst_grid[0], 3.1365901175171982)
-        lst_grid = hc.lstbin.make_lst_grid(0.01, begin_lst=-np.pi, verbose=False)
-        nt.assert_equal(len(lst_grid), 628)
-        nt.assert_almost_equal(lst_grid[0], 3.1365901175171982)
+        lst_grid = lstbin.make_lst_grid(0.01, begin_lst=None, verbose=False)
+        assert len(lst_grid) == 628
+        assert np.isclose(lst_grid[0], 0.0050025360725952121)
+        lst_grid = lstbin.make_lst_grid(0.01, begin_lst=np.pi, verbose=False)
+        assert len(lst_grid) == 628
+        assert np.isclose(lst_grid[0], 3.1365901175171982)
+        lst_grid = lstbin.make_lst_grid(0.01, begin_lst=-np.pi, verbose=False)
+        assert len(lst_grid) == 628
+        assert np.isclose(lst_grid[0], 3.1365901175171982)
 
+    @pytest.mark.filterwarnings("ignore:All-NaN slice encountered")
+    @pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
     def test_lstbin(self):
         dlst = 0.0007830490163484
         # test basic execution
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=None,
+        output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=None,
                                    median=True, lst_low=0, lst_hi=np.pi, verbose=False)
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
+        output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
                                    verbose=False)
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=dlst,
+        output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=self.flgs_list, dlst=dlst,
                                    verbose=False)
         # check shape and dtype
-        nt.assert_equal(output[1][(24, 25, 'xx')].dtype, np.complex)
-        nt.assert_equal(output[1][(24, 25, 'xx')].shape, (224, 64))
+        assert output[1][(24, 25, 'xx')].dtype == np.complex
+        assert output[1][(24, 25, 'xx')].shape == (224, 64)
         # check number of points in each bin
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[0, 30], 1)
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[30, 30], 2)
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[100, 30], 3)
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[190, 30], 2)
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[220, 30], 1)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[0, 30], 1)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[30, 30], 2)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[100, 30], 3)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[190, 30], 2)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[220, 30], 1)
         # check with large spacing lst_grid
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, dlst=.01, verbose=False)
-        nt.assert_almost_equal(output[-1][(24, 25, 'xx')].real[10, 30], 38)
+        output = lstbin.lst_bin(self.data_list, self.lst_list, dlst=.01, verbose=False)
+        assert np.allclose(output[-1][(24, 25, 'xx')].real[10, 30], 38)
         # check flgs are propagated
         flgs1 = copy.deepcopy(self.flgs1)
         flgs1[(24, 25, 'xx')][:, 32] = True
@@ -84,56 +89,58 @@ class Test_lstbin:
         flgs2[(24, 25, 'xx')][:, 32] = True
         flgs3 = copy.deepcopy(self.flgs3)
         flgs_list = [flgs1, flgs2, flgs3]
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, dlst=dlst, flags_list=flgs_list)
-        nt.assert_almost_equal(output[2][(24, 25, 'xx')][0, 32], True)
-        nt.assert_almost_equal(output[2][(24, 25, 'xx')][180, 32], False)
-        nt.assert_almost_equal(output[2][(24, 25, 'xx')][210, 32], False)
+        output = lstbin.lst_bin(self.data_list, self.lst_list, dlst=dlst, flags_list=flgs_list)
+        assert np.allclose(output[2][(24, 25, 'xx')][0, 32], True)
+        assert np.allclose(output[2][(24, 25, 'xx')][180, 32], False)
+        assert np.allclose(output[2][(24, 25, 'xx')][210, 32], False)
         # test return no avg
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, dlst=dlst, flags_list=self.flgs_list, return_no_avg=True)
-        nt.assert_equal(len(output[2][list(output[2].keys())[0]][100]), 3)
-        nt.assert_equal(len(output[2][list(output[2].keys())[0]][100][0]), 64)
+        output = lstbin.lst_bin(self.data_list, self.lst_list, dlst=dlst, flags_list=self.flgs_list, return_no_avg=True)
+        assert len(output[2][list(output[2].keys())[0]][100]) == 3
+        assert len(output[2][list(output[2].keys())[0]][100][0]) == 64
         # test switch bl
-        conj_data3 = DataContainer(odict(list(map(lambda k: (hc.lstbin.switch_bl(k), np.conj(self.data3[k])), self.data3.keys()))))
+        conj_data3 = DataContainer(odict(list(map(lambda k: (lstbin.switch_bl(k), np.conj(self.data3[k])), self.data3.keys()))))
         data_list = [self.data1, self.data2, conj_data3]
-        output = hc.lstbin.lst_bin(data_list, self.lst_list, dlst=dlst)
-        nt.assert_equal(output[1][(24, 25, 'xx')].shape, (224, 64))
+        output = lstbin.lst_bin(data_list, self.lst_list, dlst=dlst)
+        assert output[1][(24, 25, 'xx')].shape == (224, 64)
         # test sigma clip
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
-                                   verbose=False, sig_clip=True, min_N=5, sigma=2)
+        output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=0.01,
+                                verbose=False, sig_clip=True, min_N=5, sigma=2)
         # test wrapping
         lst_list = list(map(lambda l: (copy.deepcopy(l) + 6) % (2 * np.pi), self.lst_list))
-        output = hc.lstbin.lst_bin(self.data_list, lst_list, dlst=0.001, begin_lst=np.pi)
-        nt.assert_true(output[0][0] > output[0][-1])
-        nt.assert_equal(len(output[0]), 175)
+        output = lstbin.lst_bin(self.data_list, lst_list, dlst=0.001, begin_lst=np.pi)
+        assert output[0][0] > output[0][-1]
+        assert len(output[0]) == 175
         # test appropriate data_count
-        output = hc.lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=dlst, lst_low=0.25, lst_hi=0.3,
+        output = lstbin.lst_bin(self.data_list, self.lst_list, flags_list=None, dlst=dlst, lst_low=0.25, lst_hi=0.3,
                                    verbose=False)
-        nt.assert_true(np.isclose(output[4][(24, 25, 'xx')], 3.0).all())
+        assert np.allclose(output[4][(24, 25, 'xx')], 3.0)
 
     def test_lst_align(self):
         # test basic execution
-        output = hc.lstbin.lst_align(self.data1, self.lsts1, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
-        nt.assert_equal(output[0][(24, 25, 'xx')].shape, (180, 64))
-        nt.assert_equal(len(output[2]), 180)
-        nt.assert_almost_equal(output[2][0], 0.20163512170971379)
+        output = lstbin.lst_align(self.data1, self.lsts1, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
+        assert output[0][(24, 25, 'xx')].shape == (180, 64)
+        assert len(output[2]) == 180
+        assert np.allclose(output[2][0], 0.20163512170971379)
         # test flag extrapolate
-        nt.assert_true(output[1][(24, 25, 'xx')][-1].min())
+        assert np.all(output[1][(24, 25, 'xx')][-1])
         # test no dlst
-        output = hc.lstbin.lst_align(self.data1, self.lsts1, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
+        output = lstbin.lst_align(self.data1, self.lsts1, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
         # test wrapped lsts
         lsts = (self.lsts1 + 6) % (2 * np.pi)
-        output = hc.lstbin.lst_align(self.data1, lsts, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
-        nt.assert_almost_equal(output[2][150], 0.035628730243852047)
+        output = lstbin.lst_align(self.data1, lsts, dlst=None, flags=self.flgs1, flag_extrapolate=True, verbose=False)
+        assert np.allclose(output[2][150], 0.035628730243852047)
 
+    @pytest.mark.filterwarnings("ignore:The expected shape of the ENU array")
+    @pytest.mark.filterwarnings("ignore:antenna_diameters is not set")
     def test_lst_bin_files(self):
         # basic execution
-        file_ext = "{pol}.{type}.{time:7.5f}.uvh5"
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, file_ext=file_ext, ignore_flags=True)
+        file_ext = "{pol}.{type}.{time:7.5f}.uv"
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, file_ext=file_ext, ignore_flags=True)
         output_lst_file = "./zen.xx.LST.0.20124.uvh5"
         output_std_file = "./zen.xx.STD.0.20124.uvh5"
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
         uv1 = UVData()
         uv1.read(output_lst_file)
         # assert nsample w.r.t time follows 1-2-3-2-1 pattern
@@ -144,35 +151,35 @@ class Test_lstbin:
         os.remove(output_std_file)
 
         # test with multiple blgroups
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, file_ext=file_ext, Nblgroups=3, ignore_flags=True)
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, file_ext=file_ext, Nblgroups=3, ignore_flags=True)
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
         uv2 = UVData()
         uv2.read(output_lst_file)
-        nt.assert_equal(uv1, uv2)
+        assert uv1 == uv2
         os.remove(output_lst_file)
         os.remove(output_std_file)
 
         # test rephase
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, rephase=True, file_ext=file_ext)
-        output_lst_file = "./zen.xx.LST.0.20124.uvh5"
-        output_std_file = "./zen.xx.STD.0.20124.uvh5"
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, rephase=True, file_ext=file_ext)
+        output_lst_file = "./zen.xx.LST.0.20124.uv"
+        output_std_file = "./zen.xx.STD.0.20124.uv"
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
         os.remove(output_lst_file)
         os.remove(output_std_file)
 
         # test data_list is empty
         data_files = [[sorted(glob.glob(DATA_PATH + '/zen.2458043.*XRAA.uvh5'))[0]],
                       [sorted(glob.glob(DATA_PATH + '/zen.2458045.*XRAA.uvh5'))[-1]]]
-        hc.lstbin.lst_bin_files(data_files, ntimes_per_file=30, outdir="./", overwrite=True,
-                                verbose=False, file_ext=file_ext)
+        lstbin.lst_bin_files(data_files, ntimes_per_file=30, outdir="./", overwrite=True,
+                             verbose=False, file_ext=file_ext)
         output_lst_files = ['./zen.xx.LST.0.20124.uvh5', './zen.xx.LST.0.31870.uvh5', './zen.xx.LST.0.36568.uvh5']
-        nt.assert_true(os.path.exists(output_lst_files[0]))
-        nt.assert_true(os.path.exists(output_lst_files[1]))
-        nt.assert_true(os.path.exists(output_lst_files[2]))
+        assert os.path.exists(output_lst_files[0])
+        assert os.path.exists(output_lst_files[1])
+        assert os.path.exists(output_lst_files[2])
         output_files = np.concatenate([glob.glob("./zen.xx.LST*"),
                                        glob.glob("./zen.xx.STD*")])
         for of in output_files:
@@ -180,30 +187,30 @@ class Test_lstbin:
                 os.remove(of)
 
         # test smaller ntimes file output, sweeping through f_select
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True,
-                                verbose=False, vis_units='Jy', file_ext=file_ext)
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True,
+                             verbose=False, vis_units='Jy', file_ext=file_ext)
         output_files = sorted(glob.glob("./zen.xx.LST*") + glob.glob("./zen.xx.STD*"))
         # load a file
         uvd1 = UVData()
         uvd1.read(output_files[1])
-        nt.assert_equal(uvd1.vis_units, 'Jy')
-        nt.assert_true('Thisfilewasproducedbythefunction' in uvd1.history.replace('\n', '').replace(' ', ''))
-        nt.assert_equal(uvd1.Ntimes, 80)
-        nt.assert_almost_equal(uvd1.nsample_array.max(), 3.0)
+        assert uvd1.vis_units == 'Jy'
+        assert 'Thisfilewasproducedbythefunction' in uvd1.history.replace('\n', '').replace(' ', '')
+        assert uvd1.Ntimes == 80
+        assert np.isclose(uvd1.nsample_array.max(), 3.0)
         # remove files
         for of in output_files:
             if os.path.exists(of):
                 os.remove(of)
 
         # test output_file_select
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True, output_file_select=1,
-                                verbose=False, vis_units='Jy', file_ext=file_ext)
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True, output_file_select=1,
+                             verbose=False, vis_units='Jy', file_ext=file_ext)
         output_files = sorted(glob.glob("./zen.xx.LST*") + glob.glob("./zen.xx.STD*"))
         # load a file
         uvd2 = UVData()
         uvd2.read(output_files[0])
         # assert equivalence with previous run
-        nt.assert_equal(uvd1, uvd2)
+        assert uvd1 == uvd2
         # remove files
         for of in output_files:
             if os.path.exists(of):
@@ -214,18 +221,18 @@ class Test_lstbin:
         for of in output_files:
             if os.path.exists(of):
                 os.remove(of)
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True, output_file_select=100,
-                                verbose=False, file_ext=file_ext)
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=80, outdir="./", overwrite=True, output_file_select=100,
+                             verbose=False, file_ext=file_ext)
         output_files = sorted(glob.glob("./zen.xx.LST*") + glob.glob("./zen.xx.STD*"))
-        nt.assert_equal(len(output_files), 0)
+        assert len(output_files) == 0
 
         # test fixed start
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, lst_start=0.18, fixed_lst_start=True, file_ext=file_ext)
-        output_lst_file = "./zen.xx.LST.0.17932.uvh5"
-        output_std_file = "./zen.xx.STD.0.17932.uvh5"
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, lst_start=0.18, fixed_lst_start=True, file_ext=file_ext)
+        output_lst_file = "./zen.xx.LST.0.17932.uv"
+        output_std_file = "./zen.xx.STD.0.17932.uv"
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
         os.remove(output_lst_file)
         os.remove(output_std_file)
 
@@ -238,13 +245,13 @@ class Test_lstbin:
         for dfiles in self.data_files:
             input_cals.append([uvc for df in dfiles])
 
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, input_cals=input_cals, file_ext=file_ext)
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, input_cals=input_cals, file_ext=file_ext)
 
         output_lst_file = "./zen.xx.LST.0.20124.uvh5"
         output_std_file = "./zen.xx.STD.0.20124.uvh5"
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
         os.remove(output_lst_file)
         os.remove(output_std_file)
 
@@ -252,16 +259,16 @@ class Test_lstbin:
         input_cals = []
         for dfiles in self.data_files:
             input_cals.append([uvc.select(times=uvc.time_array[:1], inplace=False) for df in dfiles])
-        hc.lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
-                                verbose=False, input_cals=input_cals, file_ext=file_ext)
-        nt.assert_true(os.path.exists(output_lst_file))
-        nt.assert_true(os.path.exists(output_std_file))
+        lstbin.lst_bin_files(self.data_files, ntimes_per_file=250, outdir="./", overwrite=True,
+                             verbose=False, input_cals=input_cals, file_ext=file_ext)
+        assert os.path.exists(output_lst_file)
+        assert os.path.exists(output_std_file)
 
         # assert gains and flags were propagated
         lstb = UVData()
         lstb.read(output_lst_file)
-        nt.assert_true(np.isclose(np.abs(lstb.get_data(25, 37)[~lstb.get_flags(25, 37)]), 0.0).all())
-        nt.assert_true(lstb.get_flags(24, 25).all())
+        assert np.allclose(np.abs(lstb.get_data(25, 37)[~lstb.get_flags(25, 37)]), 0.0)
+        assert np.all(lstb.get_flags(24, 25))
 
         os.remove(output_lst_file)
         os.remove(output_std_file)
@@ -271,9 +278,9 @@ class Test_lstbin:
         args = a.parse_args(["--dlst", "0.1", "--input_cals", "zen.2458043.12552.HH.uvA.omni.calfits", "zen.2458043.12552.xx.HH.uvORA.abs.calfits",
                              "--overwrite", "zen.2458042.12552.xx.HH.uvXA", "zen.2458043.12552.xx.HH.uvXA"])
 
-        nt.assert_almost_equal(args.dlst, 0.1)
-        nt.assert_true(len(args.input_cals), 2)
-        nt.assert_true(len(args.data_files), 2)
+        assert np.isclose(args.dlst, 0.1)
+        assert len(args.input_cals) == 2
+        assert len(args.data_files) == 2
 
     def test_sigma_clip(self):
         # test basic execution
@@ -281,30 +288,30 @@ class Test_lstbin:
         x = stats.norm.rvs(0, 1, 1000)
         x[10] = 4
         x[11] = -4
-        arr = hc.lstbin.sigma_clip(x, sigma=2.0)
-        nt.assert_true(arr[10])
-        nt.assert_true(arr[11])
+        arr = lstbin.sigma_clip(x, sigma=2.0)
+        assert arr[10] == True
+        assert arr[11] == True
         # test array performance
         x = np.array(list(map(lambda s: stats.norm.rvs(0, s, 100), np.arange(1, 5.1, 1))))
         x[0, 50] = 100
         x[4, 50] = 5
-        arr = hc.lstbin.sigma_clip(x, sigma=2.0)
-        nt.assert_true(arr[0, 50])
-        nt.assert_false(arr[4, 50])
+        arr = lstbin.sigma_clip(x, sigma=2.0)
+        assert arr[0, 50] == True
+        assert arr[4, 50] == False
         # test flags
         arr = stats.norm.rvs(0, 1, 10).reshape(2, 5)
         flg = np.zeros_like(arr, np.bool)
         flg[0, 3] = True
-        out = hc.lstbin.sigma_clip(arr, flags=flg, min_N=5)
-        nt.assert_false(out[0, 3])
-        out = hc.lstbin.sigma_clip(arr, flags=flg, min_N=1)
-        nt.assert_true(out[0, 3])
+        out = lstbin.sigma_clip(arr, flags=flg, min_N=5)
+        assert out[0, 3] == False
+        out = lstbin.sigma_clip(arr, flags=flg, min_N=1)
+        assert out[0, 3] == True
 
     def test_switch_bl(self):
         # test basic execution
         key = (1, 2, 'xx')
-        sw_k = hc.lstbin.switch_bl(key)
-        nt.assert_equal(sw_k, (2, 1, 'xx'))
+        sw_k = lstbin.switch_bl(key)
+        assert sw_k == (2, 1, 'xx')
 
     def tearDown(self):
         output_files = sorted(glob.glob("./zen.xx.LST*") + glob.glob("./zen.xx.STD*"))

--- a/hera_cal/tests/test_noise.py
+++ b/hera_cal/tests/test_noise.py
@@ -24,11 +24,11 @@ class Test_Noise(object):
 
     def test_interleaved_noise_variance_estimate(self):
         const_test = noise.interleaved_noise_variance_estimate(np.ones((10, 10)))
-        assert np.all(const_test == 0)
+        np.testing.assert_array_equal(const_test, 0)
 
         np.random.seed(21)
         gauss_test = np.mean(noise.interleaved_noise_variance_estimate(np.random.randn(1000, 1000)))
-        assert np.allclose(gauss_test, 1, atol=1e-2)
+        np.testing.assert_almost_equal(gauss_test, 1, decimal=2)
 
         kernels = [('2x2 diff', [[1, -1], [-1, 1]]),
                    ('2D plus', [[0, 1, 0], [1, -4, 1], [0, 1, 0]]),
@@ -40,7 +40,7 @@ class Test_Noise(object):
                    ('1D 7-term', [[2, -9, 18, -22, 18, -9, 2]])]
         for kname, kernel in kernels:
             gauss_test = np.mean(noise.interleaved_noise_variance_estimate(np.random.randn(1000, 1000), kernel=kernel))
-            assert np.allclose(gauss_test, 1, atol=1e-2)
+            np.testing.assert_almost_equal(gauss_test, 1, decimal=2)
 
         with pytest.raises(AssertionError):
             noise.interleaved_noise_variance_estimate(np.random.randn(10, 10), kernel=[[.5, 1.0, .5]])
@@ -54,10 +54,10 @@ class Test_Noise(object):
             if k[0] != k[1]:
                 sigmasq = noise.predict_noise_variance_from_autos(k, data)
                 noise_var = noise.interleaved_noise_variance_estimate(data[k])
-                assert np.allclose(np.abs(np.mean(np.mean(noise_var, axis=0) / np.mean(sigmasq, axis=0)) - 1) <= .1, True)
+                np.testing.assert_array_equal(np.abs(np.mean(np.mean(noise_var, axis=0) / np.mean(sigmasq, axis=0)) - 1) <= .1, True)
                 times = hd.times_by_bl[k[:2]]
                 sigmasq2 = noise.predict_noise_variance_from_autos(k, data, df=(hd.freqs[1] - hd.freqs[0]), dt=((times[1] - times[0]) * 24. * 3600.))
-                assert np.allclose(sigmasq, sigmasq2)
+                np.testing.assert_array_equal(sigmasq, sigmasq2)
 
     def test_per_antenna_noise_std(self):
         infile = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')
@@ -68,7 +68,7 @@ class Test_Noise(object):
             if (bl[0] == bl[1]) and (split_pol(bl[2])[0] == split_pol(bl[2])[1]):
                 assert bl in n
                 assert n[bl].shape == data[bl].shape
-                assert np.allclose(n[bl].imag, 0.0)
+                np.testing.assert_array_equal(n[bl].imag, 0.0)
             else:
                 assert bl not in n
 
@@ -87,8 +87,8 @@ class Test_Noise(object):
         for bl in n.keys():
             assert bl[0] == bl[1]
             assert split_pol(bl[2])[0] == split_pol(bl[2])[1]
-            assert np.allclose(n[bl].imag, 0.0)
-            assert np.allclose(f[bl], gf[bl[0], split_pol(bl[2])[0]])
+            np.testing.assert_array_equal(n[bl].imag, 0.0)
+            np.testing.assert_array_equal(f[bl], gf[bl[0], split_pol(bl[2])[0]])
         os.remove(outfile)
 
     def test_noise_std_argparser(self):

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -108,7 +108,7 @@ class TestMethods(object):
             for bl in bls[1:]:
                 ai, aj, pol = bl
                 ans = data[bl] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jxx')].conj())
-                assert np.allclose(ans0, ans, atol=1e-7)
+                np.testing.assert_almost_equal(ans0, ans, decimal=7)
 
         reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yx'], pol_mode='4pol')
         gains, true_vis, data = om.sim_red_data(reds)
@@ -127,10 +127,10 @@ class TestMethods(object):
                 ans_xy = data[(ai, aj, 'xy',)] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jyy')].conj())
                 ans_yx = data[(ai, aj, 'yx',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jxx')].conj())
                 ans_yy = data[(ai, aj, 'yy',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jyy')].conj())
-                assert np.allclose(ans0xx, ans_xx, atol=1e-7)
-                assert np.allclose(ans0xy, ans_xy, atol=1e-7)
-                assert np.allclose(ans0yx, ans_yx, atol=1e-7)
-                assert np.allclose(ans0yy, ans_yy, atol=1e-7)
+                np.testing.assert_almost_equal(ans0xx, ans_xx, decimal=7)
+                np.testing.assert_almost_equal(ans0xy, ans_xy, decimal=7)
+                np.testing.assert_almost_equal(ans0yx, ans_yx, decimal=7)
+                np.testing.assert_almost_equal(ans0yy, ans_yy, decimal=7)
 
         reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yX'], pol_mode='4pol_minV')
         gains, true_vis, data = om.sim_red_data(reds)
@@ -143,17 +143,17 @@ class TestMethods(object):
             ans0xy = data[(ai, aj, 'xy',)] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jyy')].conj())
             ans0yx = data[(ai, aj, 'yx',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jxx')].conj())
             ans0yy = data[(ai, aj, 'yy',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jyy')].conj())
-            assert np.allclose(ans0xy, ans0yx, atol=1e-7)
+            np.testing.assert_almost_equal(ans0xy, ans0yx, decimal=7)
             for bl in bls[1:]:
                 ai, aj, pol = bl
                 ans_xx = data[(ai, aj, 'xx',)] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jxx')].conj())
                 ans_xy = data[(ai, aj, 'xy',)] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jyy')].conj())
                 ans_yx = data[(ai, aj, 'yx',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jxx')].conj())
                 ans_yy = data[(ai, aj, 'yy',)] / (gains[(ai, 'Jyy')] * gains[(aj, 'Jyy')].conj())
-                assert np.allclose(ans0xx, ans_xx, atol=1e-7)
-                assert np.allclose(ans0xy, ans_xy, atol=1e-7)
-                assert np.allclose(ans0yx, ans_yx, atol=1e-7)
-                assert np.allclose(ans0yy, ans_yy, atol=1e-7)
+                np.testing.assert_almost_equal(ans0xx, ans_xx, decimal=7)
+                np.testing.assert_almost_equal(ans0xy, ans_xy, decimal=7)
+                np.testing.assert_almost_equal(ans0yx, ans_yx, decimal=7)
+                np.testing.assert_almost_equal(ans0yy, ans_yy, decimal=7)
 
     def test_check_polLists_minV(self):
         polLists = [['xy']]
@@ -414,14 +414,14 @@ class TestRedundantCalibrator(object):
         w = dict([(k, 1.) for k in d.keys()])
 
         def solver(data, wgts, **kwargs):
-            assert np.allclose(data['g_0_Jxx * g_1_Jxx_ * u_0_xx'], d[0, 1, 'xx'])
-            assert np.allclose(data['g_1_Jxx * g_2_Jxx_ * u_0_xx'], d[1, 2, 'xx'])
-            assert np.allclose(data['g_0_Jxx * g_2_Jxx_ * u_1_xx'], d[0, 2, 'xx'])
+            np.testing.assert_equal(data['g_0_Jxx * g_1_Jxx_ * u_0_xx'], d[0, 1, 'xx'])
+            np.testing.assert_equal(data['g_1_Jxx * g_2_Jxx_ * u_0_xx'], d[1, 2, 'xx'])
+            np.testing.assert_equal(data['g_0_Jxx * g_2_Jxx_ * u_1_xx'], d[0, 2, 'xx'])
             if len(wgts) == 0:
                 return
-            assert np.allclose(wgts['g_0_Jxx * g_1_Jxx_ * u_0_xx'], w[0, 1, 'xx'])
-            assert np.allclose(wgts['g_1_Jxx * g_2_Jxx_ * u_0_xx'], w[1, 2, 'xx'])
-            assert np.allclose(wgts['g_0_Jxx * g_2_Jxx_ * u_1_xx'], w[0, 2, 'xx'])
+            np.testing.assert_equal(wgts['g_0_Jxx * g_1_Jxx_ * u_0_xx'], w[0, 1, 'xx'])
+            np.testing.assert_equal(wgts['g_1_Jxx * g_2_Jxx_ * u_0_xx'], w[1, 2, 'xx'])
+            np.testing.assert_equal(wgts['g_0_Jxx * g_2_Jxx_ * u_1_xx'], w[0, 2, 'xx'])
             return
         info._solver(solver, d)
         info._solver(solver, d, w)
@@ -469,7 +469,7 @@ class TestRedundantCalibrator(object):
         for ant in gains.keys():
             gains[ant] *= fc_gains[ant]
         g_fc = rc.firstcal(d, freqs, conv_crit=0)
-        assert np.allclose(np.linalg.norm([g_fc[ant] - gains[ant] for ant in g_fc]), 0, atol=1e-3)
+        np.testing.assert_array_almost_equal(np.linalg.norm([g_fc[ant] - gains[ant] for ant in g_fc]), 0, decimal=3)
 
         # test firstcal with only phases (no delays)
         gains, true_vis, d = om.sim_red_data(reds, gain_scatter=0, shape=(2, len(freqs)))
@@ -483,7 +483,7 @@ class TestRedundantCalibrator(object):
         for ant in gains.keys():
             gains[ant] *= fc_gains[ant]
         g_fc = rc.firstcal(d, freqs, conv_crit=0)
-        assert np.allclose(np.linalg.norm([g_fc[ant] - gains[ant] for ant in g_fc]), 0, atol=1e-10)  # much higher precision
+        np.testing.assert_array_almost_equal(np.linalg.norm([g_fc[ant] - gains[ant] for ant in g_fc]), 0, decimal=10)  # much higher precision
 
     def test_logcal(self):
         NANTS = 18
@@ -501,8 +501,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         for k in d.keys():
             d[k] = np.zeros_like(d[k])
@@ -511,9 +511,9 @@ class TestRedundantCalibrator(object):
             sol = info.logcal(d)
         om.make_sol_finite(sol)
         for red in reds:
-            assert np.allclose(sol[red[0]], 0.0)
+            np.testing.assert_array_equal(sol[red[0]], 0.0)
         for ant in gains.keys():
-            assert np.allclose(sol[ant], 1.0)
+            np.testing.assert_array_equal(sol[ant], 1.0)
 
     def test_omnical(self):
         NANTS = 18
@@ -533,8 +533,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
     def test_omnical64(self):
         NANTS = 18
@@ -554,8 +554,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-6)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-6)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=6)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=6)
 
     def test_omnical128(self):
         NANTS = 18
@@ -575,8 +575,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
     def test_lincal(self):
         NANTS = 18
@@ -617,8 +617,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-6)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-6)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=6)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=6)
 
     def test_lincal128(self):
         NANTS = 18
@@ -638,8 +638,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
     def test_svd_convergence(self):
         for hexnum in (2, 3, 4):
@@ -666,10 +666,10 @@ class TestRedundantCalibrator(object):
         true_dlys = {(i, split_pol(pol)[0]): np.array([[np.dot(xhat, antpos[i]) * dtau_dx]]) for i in range(len(antpos))}
         dlys = rc.remove_degen_gains(true_dlys, mode='phase')
         for k in dlys:
-            assert np.allclose(dlys[k], 0, atol=1e-10)
+            np.testing.assert_almost_equal(dlys[k], 0, decimal=10)
         dlys = rc.remove_degen_gains(true_dlys, degen_gains=true_dlys, mode='phase')
         for k in dlys:
-            assert np.allclose(dlys[k], true_dlys[k], atol=1e-10)
+            np.testing.assert_almost_equal(dlys[k], true_dlys[k], decimal=10)
 
     def test_remove_degen_firstcal_2D(self):
         pol = 'xx'
@@ -686,7 +686,7 @@ class TestRedundantCalibrator(object):
                      for i in range(len(antpos))}
         dlys = rc.remove_degen_gains(true_dlys, mode='phase')
         for k in dlys:
-            assert np.allclose(dlys[k], 0, atol=1e-10)
+            np.testing.assert_almost_equal(dlys[k], 0, decimal=10)
 
     def test_lincal_hex_end_to_end_1pol_with_remove_degen_and_firstcal(self):
         antpos = build_hex_array(3)
@@ -705,10 +705,10 @@ class TestRedundantCalibrator(object):
         sol0 = rc.logcal(d, sol0=fc_gains, wgts=w)
         meta, sol = rc.lincal(d, sol0, wgts=w)
 
-        assert np.all(meta['iter'] < 50 * np.ones_like(meta['iter']))
-        assert np.allclose(meta['chisq'], np.zeros_like(meta['chisq']), atol=1e-10)
+        np.testing.assert_array_less(meta['iter'], 50 * np.ones_like(meta['iter']))
+        np.testing.assert_almost_equal(meta['chisq'], np.zeros_like(meta['chisq']), decimal=10)
 
-        assert np.allclose(meta['chisq'], 0, atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], 0, decimal=10)
         for i in range(len(antpos)):
             assert sol[(i, 'Jxx')].shape == (1, len(freqs))
         for bls in reds:
@@ -717,8 +717,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol[(bl[0], 'Jxx')] * sol[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -726,7 +726,7 @@ class TestRedundantCalibrator(object):
         gainSols = np.array([sol_rd[ant] for ant in ants])
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
 
         for bls in reds:
             ubl = sol_rd[bls[0]]
@@ -734,8 +734,8 @@ class TestRedundantCalibrator(object):
             for bl in bls:
                 d_bl = d[bl]
                 mdl = sol_rd[(bl[0], 'Jxx')] * sol_rd[(bl[1], 'Jxx')].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -743,13 +743,13 @@ class TestRedundantCalibrator(object):
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
 
         for key, val in sol_rd.items():
             if len(key) == 2:
-                assert np.allclose(val, gains[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, gains[key], decimal=10)
             if len(key) == 3:
-                assert np.allclose(val, true_vis[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, true_vis[key], decimal=10)
 
         rc.pol_mode = 'unrecognized_pol_mode'
         with pytest.raises(AssertionError):
@@ -772,10 +772,10 @@ class TestRedundantCalibrator(object):
         sol0 = rc.logcal(d, sol0=fc_gains, wgts=w)
         meta, sol = rc.lincal(d, sol0, wgts=w)
 
-        assert np.all(meta['iter'] < 50 * np.ones_like(meta['iter']))
-        assert np.allclose(meta['chisq'], np.zeros_like(meta['chisq']), atol=1e-10)
+        np.testing.assert_array_less(meta['iter'], 50 * np.ones_like(meta['iter']))
+        np.testing.assert_almost_equal(meta['chisq'], np.zeros_like(meta['chisq']), decimal=10)
 
-        assert np.allclose(meta['chisq'], 0, atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], 0, decimal=10)
         for i in range(len(antpos)):
             assert sol[(i, 'Jxx')].shape == (1, len(freqs))
             assert sol[(i, 'Jyy')].shape == (1, len(freqs))
@@ -785,8 +785,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol[(bl[0], split_pol(bl[2])[0])] * sol[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol)
 
@@ -799,10 +799,10 @@ class TestRedundantCalibrator(object):
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
 
         for bls in reds:
             for bl in bls:
@@ -810,8 +810,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol_rd[(bl[0], split_pol(bl[2])[0])] * sol_rd[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -819,25 +819,25 @@ class TestRedundantCalibrator(object):
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
 
         gainSols = np.array([sol_rd[ant] for ant in ants])
         degenGains = np.array([gains[ant] for ant in ants])
-        assert np.allclose(np.mean(np.angle(gainSols[gainPols == 'Jxx']), axis=0),
-                           np.mean(np.angle(degenGains[gainPols == 'Jxx']), axis=0), atol=1e-10)
-        assert np.allclose(np.mean(np.angle(gainSols[gainPols == 'Jyy']), axis=0),
-                           np.mean(np.angle(degenGains[gainPols == 'Jyy']), axis=0), atol=1e-10)
+        np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols == 'Jxx']), axis=0),
+                                       np.mean(np.angle(degenGains[gainPols == 'Jxx']), axis=0), decimal=10)
+        np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols == 'Jyy']), axis=0),
+                                       np.mean(np.angle(degenGains[gainPols == 'Jyy']), axis=0), decimal=10)
 
         for key, val in sol_rd.items():
             if len(key) == 2:
-                assert np.allclose(val, gains[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, gains[key], decimal=10)
             if len(key) == 3:
-                assert np.allclose(val, true_vis[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, true_vis[key], decimal=10)
 
     def test_lincal_hex_end_to_end_4pol_minV_with_remove_degen_and_firstcal(self):
 
@@ -858,9 +858,9 @@ class TestRedundantCalibrator(object):
         meta, sol = rc.lincal(d, sol0, wgts=w)
 
         assert np.all(meta['iter'] < 50 * np.ones_like(meta['iter']))
-        assert np.allclose(meta['chisq'], np.zeros_like(meta['chisq']), atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], np.zeros_like(meta['chisq']), decimal=10)
 
-        assert np.allclose(meta['chisq'], 0, atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], 0, decimal=10)
         for i in range(len(antpos)):
             assert sol[(i, 'Jxx')].shape == (1, len(freqs))
             assert sol[(i, 'Jyy')].shape == (1, len(freqs))
@@ -870,8 +870,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol[(bl[0], split_pol(bl[2])[0])] * sol[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -884,10 +884,10 @@ class TestRedundantCalibrator(object):
         gainSols = np.array([sol_rd[ant] for ant in ants])
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
 
         for bls in reds:
             ubl = sol_rd[bls[0]]
@@ -895,8 +895,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol_rd[(bl[0], split_pol(bl[2])[0])] * sol_rd[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -907,35 +907,35 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol_rd[(bl[0], split_pol(bl[2])[0])] * sol_rd[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         gainSols = np.array([sol_rd[ant] for ant in ants])
         degenGains = np.array([gains[ant] for ant in ants])
-        assert np.allclose(np.mean(np.angle(gainSols), axis=0),
-                           np.mean(np.angle(degenGains), axis=0), atol=1e-10)
+        np.testing.assert_almost_equal(np.mean(np.angle(gainSols), axis=0),
+                                       np.mean(np.angle(degenGains), axis=0), decimal=10)
 
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
 
         visSols = np.array([sol_rd[bl] for bl in bl_pairs])
         degenVis = np.array([true_vis[bl] for bl in bl_pairs])
-        assert np.allclose(np.mean(np.angle(visSols), axis=0),
-                           np.mean(np.angle(degenVis), axis=0), atol=1e-10)
+        np.testing.assert_almost_equal(np.mean(np.angle(visSols), axis=0),
+                                       np.mean(np.angle(degenVis), axis=0), decimal=10)
 
         for key, val in sol_rd.items():
             if len(key) == 2:
-                assert np.allclose(val, gains[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, gains[key], decimal=10)
             if len(key) == 3:
-                assert np.allclose(val, true_vis[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, true_vis[key], decimal=10)
 
     def test_lincal_hex_end_to_end_2pol_with_remove_degen_and_firstcal(self):
 
@@ -956,9 +956,9 @@ class TestRedundantCalibrator(object):
         meta, sol = rc.lincal(d, sol0, wgts=w)
 
         assert np.all(meta['iter'] < 50 * np.ones_like(meta['iter']))
-        assert np.allclose(meta['chisq'], np.zeros_like(meta['chisq']), atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], np.zeros_like(meta['chisq']), decimal=10)
 
-        assert np.allclose(meta['chisq'], 0, atol=1e-10)
+        np.testing.assert_almost_equal(meta['chisq'], 0, decimal=10)
         for i in range(len(antpos)):
             assert sol[(i, 'Jxx')].shape == (1, len(freqs))
             assert sol[(i, 'Jyy')].shape == (1, len(freqs))
@@ -968,8 +968,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol[(bl[0], split_pol(bl[2])[0])] * sol[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol)
 
@@ -983,10 +983,10 @@ class TestRedundantCalibrator(object):
 
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, 1, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, 1, decimal=10)
 
         for bls in reds:
             for bl in bls:
@@ -994,8 +994,8 @@ class TestRedundantCalibrator(object):
                 assert ubl.shape == (1, len(freqs))
                 d_bl = d[bl]
                 mdl = sol_rd[(bl[0], split_pol(bl[2])[0])] * sol_rd[(bl[1], split_pol(bl[2])[1])].conj() * ubl
-                assert np.allclose(np.abs(d_bl), np.abs(mdl), atol=1e-10)
-                assert np.allclose(np.angle(d_bl * mdl.conj()), 0, atol=1e-10)
+                np.testing.assert_almost_equal(np.abs(d_bl), np.abs(mdl), decimal=10)
+                np.testing.assert_almost_equal(np.angle(d_bl * mdl.conj()), 0, decimal=10)
 
         sol_rd = rc.remove_degen(sol, degen_sol=gains)
         g, v = om.get_gains_and_vis_from_sol(sol_rd)
@@ -1006,23 +1006,23 @@ class TestRedundantCalibrator(object):
                                    for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jxx' and key2[1] == 'Jxx' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
         meanSqAmplitude = np.mean([np.abs(g[key1] * g[key2]) for key1 in g.keys()
                                    for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
         degenMeanSqAmplitude = np.mean([np.abs(gains[key1] * gains[key2]) for key1 in g.keys()
                                         for key2 in g.keys() if key1[1] == 'Jyy' and key2[1] == 'Jyy' and key1[0] != key2[0]], axis=0)
-        assert np.allclose(meanSqAmplitude, degenMeanSqAmplitude, atol=1e-10)
+        np.testing.assert_almost_equal(meanSqAmplitude, degenMeanSqAmplitude, decimal=10)
 
-        assert np.allclose(np.mean(np.angle(gainSols[gainPols == 'Jxx']), axis=0),
-                           np.mean(np.angle(degenGains[gainPols == 'Jxx']), axis=0), atol=1e-10)
-        assert np.allclose(np.mean(np.angle(gainSols[gainPols == 'Jyy']), axis=0),
-                           np.mean(np.angle(degenGains[gainPols == 'Jyy']), axis=0), atol=1e-10)
+        np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols == 'Jxx']), axis=0),
+                                       np.mean(np.angle(degenGains[gainPols == 'Jxx']), axis=0), decimal=10)
+        np.testing.assert_almost_equal(np.mean(np.angle(gainSols[gainPols == 'Jyy']), axis=0),
+                                       np.mean(np.angle(degenGains[gainPols == 'Jyy']), axis=0), decimal=10)
 
         for key, val in sol_rd.items():
             if len(key) == 2:
-                assert np.allclose(val, gains[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, gains[key], decimal=10)
             if len(key) == 3:
-                assert np.allclose(val, true_vis[key], atol=1e-10)
+                np.testing.assert_almost_equal(val, true_vis[key], decimal=10)
 
     def test_count_degen(self):
         # 1 phase slope
@@ -1126,7 +1126,7 @@ class TestRedcalAndAbscal(object):
         tgr = {ant: true_gains[ant] * np.abs(true_gains[refant[ant[1]]]) / true_gains[refant[ant[1]]] 
                for ant in true_gains.keys()}
         gain_errors = [agr[ant] - tgr[ant] for ant in tgr if ant[1] == 'Jxx']
-        assert np.allclose(np.abs(gain_errors), 0, atol=1e-10)
+        np.testing.assert_almost_equal(np.abs(gain_errors), 0, decimal=10)
 
 
 @pytest.mark.filterwarnings("ignore:It seems that the latitude and longitude are in radians")
@@ -1167,11 +1167,11 @@ class TestRunMethods(object):
                             assert val.dtype == bool
 
                 for flag in rv['gf_firstcal'].values():
-                    assert np.all(flag == 0)
+                    np.testing.assert_array_equal(flag, 0)
                 for k, flag in rv['gf_omnical'].items():
-                    assert np.all(rv['g_omnical'][k][flag] == 1.)
+                    np.testing.assert_array_equal(rv['g_omnical'][k][flag], 1.)
                 for k, flag in rv['vf_omnical'].items():
-                    assert np.all(rv['v_omnical'][k][flag] == 0)
+                    np.testing.assert_array_equal(rv['v_omnical'][k][flag], 0)
 
         if pol_mode == '4pol':
             assert rv['chisq'].shape == (nTimes, nFreqs)
@@ -1205,18 +1205,18 @@ class TestRunMethods(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             rv = om.redcal_iteration(hd, pol_mode='4pol')
-        assert np.allclose(rv['chisq']['Jxx'], rv['chisq']['Jyy'], equal_nan=True)
+        np.testing.assert_array_equal(rv['chisq']['Jxx'], rv['chisq']['Jyy'])
 
         hd.telescope_location_lat_lon_alt_degrees = (-30.7, 121.4, 1051.7)  # move array longitude
         rv = om.redcal_iteration(hd, solar_horizon=0.0)
         for flag in rv['gf_firstcal'].values():
-            assert np.all(flag)
+            np.testing.assert_array_equal(flag, True)
         for flag in rv['gf_omnical'].values():
-            assert np.all(flag)
+            np.testing.assert_array_equal(flag, True)
         for flag in rv['vf_omnical'].values():
-            assert np.all(flag)
+            np.testing.assert_array_equal(flag, True)
         for nsamples in rv['vns_omnical'].values():
-            assert np.all(nsamples == 0)
+            np.testing.assert_array_equal(nsamples, 0)
 
         hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))
         with warnings.catch_warnings():
@@ -1229,8 +1229,8 @@ class TestRunMethods(object):
                 # test that completely excluded baselines from redcal are still represented
                 assert (23, 27, pol) in rv[key].keys()
             # test redundant baseline counting
-            assert np.allclose(rv['vns_omnical'][(1, 12, pol)][~rv['vf_omnical'][(1, 12, pol)]], 4.0)
-            assert np.allclose(rv['vns_omnical'][(23, 27, pol)], 0.0)
+            np.testing.assert_array_equal(rv['vns_omnical'][(1, 12, pol)][~rv['vf_omnical'][(1, 12, pol)]], 4.0)
+            np.testing.assert_array_equal(rv['vns_omnical'][(23, 27, pol)], 0.0)
 
     def test_redcal_run(self):
         input_data = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')
@@ -1245,11 +1245,11 @@ class TestRunMethods(object):
         hc = io.HERACal(os.path.splitext(input_data)[0] + '.first.calfits')
         gains, flags, quals, total_qual = hc.read()
         for ant in gains.keys():
-            assert np.allclose(gains[ant], cal['g_firstcal'][ant])
-            assert np.allclose(flags[ant], cal['gf_firstcal'][ant])
+            np.testing.assert_almost_equal(gains[ant], cal['g_firstcal'][ant])
+            np.testing.assert_almost_equal(flags[ant], cal['gf_firstcal'][ant])
             if ant[0] in bad_ants:
-                assert np.all(gains[ant] == 1.0)
-                assert np.all(flags[ant])
+                np.testing.assert_array_equal(gains[ant], 1.0)
+                np.testing.assert_array_equal(flags[ant], True)
         assert 'testing' in hc.history.replace('\n', '').replace(' ', '')
         assert 'Thisfilewasproducedbythefunction' in hc.history.replace('\n', '').replace(' ', '')
 
@@ -1257,16 +1257,16 @@ class TestRunMethods(object):
         gains, flags, quals, total_qual = hc.read()
         for ant in gains.keys():
             zero_check = np.isclose(cal['g_omnical'][ant], 0, rtol=1e-10, atol=1e-10)
-            assert np.allclose(gains[ant][~zero_check], cal['g_omnical'][ant][~zero_check])
-            assert np.allclose(flags[ant][~zero_check], cal['gf_omnical'][ant][~zero_check])
+            np.testing.assert_array_almost_equal(gains[ant][~zero_check], cal['g_omnical'][ant][~zero_check])
+            np.testing.assert_array_almost_equal(flags[ant][~zero_check], cal['gf_omnical'][ant][~zero_check])
             if np.sum(zero_check) > 0:
-                assert np.all(flags[ant][zero_check])
-            assert np.allclose(quals[ant][~zero_check], cal['chisq_per_ant'][ant][~zero_check], equal_nan=True)
+                np.testing.assert_array_equal(flags[ant][zero_check], True)
+            np.testing.assert_array_almost_equal(quals[ant][~zero_check], cal['chisq_per_ant'][ant][~zero_check])
             if ant[0] in bad_ants:
-                assert np.all(gains[ant] == 1.0)
-                assert np.all(flags[ant])
+                np.testing.assert_array_equal(gains[ant], 1.0)
+                np.testing.assert_array_equal(flags[ant], True)
         for antpol in total_qual.keys():
-            assert np.allclose(total_qual[antpol], cal['chisq'][antpol], equal_nan=True)
+            np.testing.assert_array_almost_equal(total_qual[antpol], cal['chisq'][antpol])
         assert 'testing' in hc.history.replace('\n', '').replace(' ', '')
         assert 'Throwingoutantenna12' in hc.history.replace('\n', '').replace(' ', '')
         assert 'Thisfilewasproducedbythefunction' in hc.history.replace('\n', '').replace(' ', '')
@@ -1274,9 +1274,9 @@ class TestRunMethods(object):
         hd = io.HERAData(os.path.splitext(input_data)[0] + '.omni_vis.uvh5')
         data, flags, nsamples = hd.read()
         for bl in data.keys():
-            assert np.allclose(data[bl], cal['v_omnical'][bl], equal_nan=True)
-            assert np.allclose(flags[bl], cal['vf_omnical'][bl])
-            assert np.allclose(nsamples[bl], cal['vns_omnical'][bl])
+            np.testing.assert_array_almost_equal(data[bl], cal['v_omnical'][bl])
+            np.testing.assert_array_almost_equal(flags[bl], cal['vf_omnical'][bl])
+            np.testing.assert_array_almost_equal(nsamples[bl], cal['vns_omnical'][bl])
         assert 'testing' in hd.history.replace('\n', '').replace(' ', '')
         assert 'Thisfilewasproducedbythefunction' in hd.history.replace('\n', '').replace(' ', '')
         os.remove(os.path.splitext(input_data)[0] + '.first.calfits')

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1210,11 +1210,11 @@ class TestRunMethods(object):
         hd.telescope_location_lat_lon_alt_degrees = (-30.7, 121.4, 1051.7)  # move array longitude
         rv = om.redcal_iteration(hd, solar_horizon=0.0)
         for flag in rv['gf_firstcal'].values():
-            assert np.all(flag == True)
+            assert np.all(flag)
         for flag in rv['gf_omnical'].values():
-            assert np.all(flag == True)
+            assert np.all(flag)
         for flag in rv['vf_omnical'].values():
-            assert np.all(flag == True)
+            assert np.all(flag)
         for nsamples in rv['vns_omnical'].values():
             assert np.all(nsamples == 0)
 
@@ -1249,7 +1249,7 @@ class TestRunMethods(object):
             assert np.allclose(flags[ant], cal['gf_firstcal'][ant])
             if ant[0] in bad_ants:
                 assert np.all(gains[ant] == 1.0)
-                assert np.all(flags[ant] == True)
+                assert np.all(flags[ant])
         assert 'testing' in hc.history.replace('\n', '').replace(' ', '')
         assert 'Thisfilewasproducedbythefunction' in hc.history.replace('\n', '').replace(' ', '')
 
@@ -1260,11 +1260,11 @@ class TestRunMethods(object):
             assert np.allclose(gains[ant][~zero_check], cal['g_omnical'][ant][~zero_check])
             assert np.allclose(flags[ant][~zero_check], cal['gf_omnical'][ant][~zero_check])
             if np.sum(zero_check) > 0:
-                assert np.all(flags[ant][zero_check] == True)
+                assert np.all(flags[ant][zero_check])
             assert np.allclose(quals[ant][~zero_check], cal['chisq_per_ant'][ant][~zero_check], equal_nan=True)
             if ant[0] in bad_ants:
                 assert np.all(gains[ant] == 1.0)
-                assert np.all(flags[ant] == True)
+                assert np.all(flags[ant])
         for antpol in total_qual.keys():
             assert np.allclose(total_qual[antpol], cal['chisq'][antpol], equal_nan=True)
         assert 'testing' in hc.history.replace('\n', '').replace(' ', '')

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -395,15 +395,15 @@ class Test_ReflectionFitter_XTalk(object):
         pcomp2 = RF.pcomp_model[bl]
         # assert pcomp model with projected vmode has less noise in it for a delay with no systematic
         ind = np.argmin(np.abs(RF.delays - 400))  # no systematic at this delay, only noise
-        nt.assert_true(np.mean(np.abs(pcomp1[:, ind])) > np.mean(np.abs(pcomp2[:, ind])))
+        assert np.mean(np.abs(pcomp1[:, ind])) > np.mean(np.abs(pcomp2[:, ind]))
 
         # test projection of other SVD matrices
         _svals = RF.project_svd_modes(RF.dfft * svd_wgts, umodes=RF.umodes, vmodes=RF.vmodes)
         _umodes = RF.project_svd_modes(RF.dfft * svd_wgts, vmodes=RF.vmodes, svals=RF.svals)
 
         # assert original is nearly the same as projected
-        nt.assert_true(np.all(np.isclose(_svals[bl], RF.svals[bl], atol=1e-10)))  
-        nt.assert_true(np.all(np.isclose(_umodes[bl][:, 0], RF.umodes[bl][:, 0], atol=1e-10)))  
+        assert np.allclose(_svals[bl], RF.svals[bl], atol=1e-10)
+        assert np.allclose(_umodes[bl][:, 0], RF.umodes[bl][:, 0], atol=1e-10)
 
         # try with and without Nmirror
         RF.interp_u(RF.umodes, RF.times, overwrite=True, gp_frate=gp_frate, gp_nl=1e-10, optimizer=None, Ninterp=10, Nmirror=0)
@@ -412,11 +412,11 @@ class Test_ReflectionFitter_XTalk(object):
         uinterp2 = copy.deepcopy(RF.umode_interp)
         # assert higher order umodes don't diverge as much at time boundaries with Nmirror > 0
         for i in range(3, 10):
-            nt.assert_true(np.mean(np.abs(uinterp1[bl][:2, i]) / np.abs(uinterp2[bl][:2, i])) > 1.0)
-            nt.assert_true(np.mean(np.abs(uinterp1[bl][-2:, i]) / np.abs(uinterp2[bl][-2:, i])) > 1.0)
+            assert np.mean(np.abs(uinterp1[bl][:2, i]) / np.abs(uinterp2[bl][:2, i])) > 1.0
+            assert np.mean(np.abs(uinterp1[bl][-2:, i]) / np.abs(uinterp2[bl][-2:, i])) > 1.0
 
         # test too large Nmirror
-        nt.assert_raises(AssertionError, RF.interp_u, RF.umodes, RF.times, overwrite=True, gp_frate=gp_frate, gp_nl=1e-10, optimizer=None, Ninterp=10, Nmirror=100)
+        pytest.raises(AssertionError, RF.interp_u, RF.umodes, RF.times, overwrite=True, gp_frate=gp_frate, gp_nl=1e-10, optimizer=None, Ninterp=10, Nmirror=100)
 
         # assert custom kernel works
         gp_len = 1.0 / (0.4 * 1e-3) / (24.0 * 3600.0)

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -45,7 +45,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         wgts[3, 5] = 0
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 10, endpoint=False)
         tf = smooth_cal.time_filter(gains, wgts, times, filter_scale=1800.0, nMirrors=1)
-        assert np.allclose(tf, np.ones((10, 10), dtype=complex))
+        np.testing.assert_array_almost_equal(tf, np.ones((10, 10), dtype=complex))
 
     def test_freq_filter(self):
         gains = np.ones((10, 10), dtype=complex)
@@ -54,7 +54,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         wgts[3, 5] = 0
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs)
-        assert np.allclose(ff, np.ones((10, 10), dtype=complex))
+        np.testing.assert_array_almost_equal(ff, np.ones((10, 10), dtype=complex))
 
         # test rephasing
         gains = np.ones((2, 1000), dtype=complex)
@@ -62,7 +62,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
         gains *= np.exp(2.0j * np.pi * np.outer(150e-9 * np.ones(2), freqs))
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs)
-        assert np.allclose(ff, gains)
+        np.testing.assert_array_almost_equal(ff, gains)
 
         # test skip_wgt
         gains = np.random.randn(10, 10) + 1.0j * np.random.randn(10, 10)
@@ -70,7 +70,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         wgts[0, 0:8] = 0
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs, skip_wgt=.5)
-        assert np.allclose(ff[0, :], gains[0, :])
+        np.testing.assert_array_almost_equal(ff[0, :], gains[0, :])
         assert np.all(info[0]['skipped'] == True)
 
     def test_time_freq_2D_filter(self):
@@ -81,16 +81,16 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freqs = np.linspace(100., 200., 100, endpoint=False) * 1e6
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 100, endpoint=False)
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times, filter_mode='rect')
-        assert np.allclose(ff, np.ones((100, 100), dtype=complex))
+        np.testing.assert_array_almost_equal(ff, np.ones((100, 100), dtype=complex))
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times, filter_mode='plus')
-        assert np.allclose(ff, np.ones((100, 100), dtype=complex))
+        np.testing.assert_array_almost_equal(ff, np.ones((100, 100), dtype=complex))
 
         # test rephasing
         gains = np.ones((100, 100), dtype=complex)
         wgts = np.ones((100, 100), dtype=float)
         gains *= np.exp(2.0j * np.pi * np.outer(-151e-9 * np.ones(100), freqs))
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times)
-        assert np.allclose(ff, gains, 4)
+        np.testing.assert_array_almost_equal(ff, gains, 4)
 
         # test errors
         with pytest.raises(ValueError):
@@ -127,7 +127,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         gains = {(0, 'Jxx'): np.array([1. + 1.0j, 1. - 1.0j]),
                  (1, 'Jxx'): np.array([-1. + 1.0j, -1. - 1.0j])}
         smooth_cal.rephase_to_refant(gains, (0, 'Jxx'))
-        assert np.allclose(np.imag(gains[(0, 'Jxx')]), np.zeros_like(np.imag(gains[(0, 'Jxx')])))
+        np.testing.assert_array_almost_equal(np.imag(gains[(0, 'Jxx')]), np.zeros_like(np.imag(gains[(0, 'Jxx')])))
         flags = {(0, 'Jxx'): np.array([False, True]),
                  (1, 'Jxx'): np.array([True, False])}
         with pytest.raises(ValueError):
@@ -149,8 +149,8 @@ class Test_Calibration_Smoother(object):
         assert cs.refant['Jxx'] == (54, 'Jxx')
         cs.time_freq_2D_filter(window='tukey', alpha=.45)
         cs.rephase_to_refant()
-        assert np.allclose(np.imag(cs.gain_grids[54, 'Jxx']),
-                           np.zeros_like(np.imag(cs.gain_grids[54, 'Jxx'])))
+        np.testing.assert_array_almost_equal(np.imag(cs.gain_grids[54, 'Jxx']),
+                                             np.zeros_like(np.imag(cs.gain_grids[54, 'Jxx'])))
 
     def test_check_consistency(self):
         temp_time = self.cs.cal_times[self.cs.cals[0]][0]
@@ -187,7 +187,7 @@ class Test_Calibration_Smoother(object):
         assert (54, 'Jxx') in self.cs.flag_grids
         assert self.cs.gain_grids[54, 'Jxx'].shape == (180, 1024)
         assert self.cs.flag_grids[54, 'Jxx'].shape == (180, 1024)
-        assert np.allclose(self.cs.flag_grids[54, 'Jxx'][60:120, :], True)
+        np.testing.assert_array_equal(self.cs.flag_grids[54, 'Jxx'][60:120, :], True)
 
     def test_1D_filtering(self):
         g = deepcopy(self.cs.gain_grids[54, 'Jxx'])
@@ -219,12 +219,12 @@ class Test_Calibration_Smoother(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.cs.freq_filter()
-            assert np.allclose(self.cs.gain_grids[(54, 'Jxx')], g)
+            np.testing.assert_array_equal(self.cs.gain_grids[(54, 'Jxx')], g)
             self.cs.time_filter()
-            assert np.allclose(self.cs.gain_grids[(54, 'Jxx')], g)
+            np.testing.assert_array_equal(self.cs.gain_grids[(54, 'Jxx')], g)
             # test skip_wgt propagation to flags
-            assert np.allclose(self.cs.flag_grids[(54, 'Jxx')],
-                               np.ones_like(self.cs.flag_grids[(54, 'Jxx')]))
+            np.testing.assert_array_equal(self.cs.flag_grids[(54, 'Jxx')],
+                                          np.ones_like(self.cs.flag_grids[(54, 'Jxx')]))
         self.setup_method()
         self.cs.gain_grids[54, 'Jxx'] = g
 
@@ -248,5 +248,5 @@ class Test_Calibration_Smoother(object):
             assert 'helloworld' in new_cal.history.replace('\n', '').replace(' ', '')
             assert 'Thisfilewasproducedbythefunction' in new_cal.history.replace('\n', '').replace(' ', '')
             assert new_cal.telescope_name == 'PAPER'
-            assert np.allclose(gains[54, 'Jxx'], g[self.cs.time_indices[cal], :])
+            np.testing.assert_array_equal(gains[54, 'Jxx'], g[self.cs.time_indices[cal], :])
             os.remove(cal.replace('test_input/', 'test_output/smoothed_'))

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -142,6 +142,8 @@ class Test_Calibration_Smoother(object):
         self.cs = smooth_cal.CalibrationSmoother(calfits_list, flag_file_list=flag_file_list, flag_filetype='npz')
 
     @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
+    @pytest.mark.filterwarnings("ignore:overflow encountered in square")
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in reduce")
     def test_ref_ant(self):
         calfits_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.abs.calfits_54x_only')))[0::2]
         flag_file_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.uvOCR_53x_54x_only.flags.applied.npz')))[0::2]

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -71,7 +71,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs, skip_wgt=.5)
         assert np.allclose(ff[0, :], gains[0, :])
-        assert np.isclose(info[0]['skipped'], True)
+        assert np.all(info[0]['skipped'] == True)
 
     def test_time_freq_2D_filter(self):
         gains = np.ones((100, 100), dtype=complex)

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -71,7 +71,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs, skip_wgt=.5)
         np.testing.assert_array_almost_equal(ff[0, :], gains[0, :])
-        assert np.all(info[0]['skipped'] == True)
+        assert np.all(info[0]['skipped'])
 
     def test_time_freq_2D_filter(self):
         gains = np.ones((100, 100), dtype=complex)

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import unittest
+import pytest
 import numpy as np
 from copy import deepcopy
 import os
@@ -16,28 +16,27 @@ import warnings
 from pyuvdata.utils import check_histories
 from pyuvdata import UVCal, UVData
 
-from hera_cal import io
-from hera_cal import smooth_cal
-from hera_cal.datacontainer import DataContainer
-from hera_cal.data import DATA_PATH
+from .. import io, smooth_cal
+from ..datacontainer import DataContainer
+from ..data import DATA_PATH
 
 
-class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
+class Test_Smooth_Cal_Helper_Functions(object):
 
-    def setUp(self):
+    def setup_method(self):
         np.random.seed(21)
 
     def test_time_kernel(self):
         kernel = smooth_cal.time_kernel(100, 10.0, filter_scale=1.0)
-        self.assertAlmostEqual(np.sum(kernel), 1.0)
-        self.assertEqual(np.max(kernel), kernel[100])
-        self.assertEqual(len(kernel), 201)
+        assert np.allclose(np.sum(kernel), 1.0)
+        assert np.max(kernel) == kernel[100]
+        assert len(kernel) == 201
 
     def test_smooth_cal_argparser(self):
         sys.argv = [sys.argv[0], 'a', 'b', '--flag_file_list', 'c']
         a = smooth_cal.smooth_cal_argparser()
-        self.assertEqual(a.calfits_list, ['a', 'b'])
-        self.assertEqual(a.flag_file_list, ['c'])
+        assert a.calfits_list == ['a', 'b']
+        assert a.flag_file_list == ['c']
 
     def test_time_filter(self):
         gains = np.ones((10, 10), dtype=complex)
@@ -46,7 +45,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         wgts[3, 5] = 0
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 10, endpoint=False)
         tf = smooth_cal.time_filter(gains, wgts, times, filter_scale=1800.0, nMirrors=1)
-        np.testing.assert_array_almost_equal(tf, np.ones((10, 10), dtype=complex))
+        assert np.allclose(tf, np.ones((10, 10), dtype=complex))
 
     def test_freq_filter(self):
         gains = np.ones((10, 10), dtype=complex)
@@ -55,7 +54,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         wgts[3, 5] = 0
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs)
-        np.testing.assert_array_almost_equal(ff, np.ones((10, 10), dtype=complex))
+        assert np.allclose(ff, np.ones((10, 10), dtype=complex))
 
         # test rephasing
         gains = np.ones((2, 1000), dtype=complex)
@@ -63,7 +62,7 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
         gains *= np.exp(2.0j * np.pi * np.outer(150e-9 * np.ones(2), freqs))
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs)
-        np.testing.assert_array_almost_equal(ff, gains)
+        assert np.allclose(ff, gains)
 
         # test skip_wgt
         gains = np.random.randn(10, 10) + 1.0j * np.random.randn(10, 10)
@@ -71,8 +70,8 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         wgts[0, 0:8] = 0
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs, skip_wgt=.5)
-        np.testing.assert_array_equal(ff[0, :], gains[0, :])
-        self.assertTrue(info[0]['skipped'])
+        assert np.allclose(ff[0, :], gains[0, :])
+        assert info[0]['skipped'] == True
 
     def test_time_freq_2D_filter(self):
         gains = np.ones((100, 100), dtype=complex)
@@ -82,19 +81,19 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
         freqs = np.linspace(100., 200., 100, endpoint=False) * 1e6
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 100, endpoint=False)
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times, filter_mode='rect')
-        np.testing.assert_array_almost_equal(ff, np.ones((100, 100), dtype=complex))
+        assert np.allclose(ff, np.ones((100, 100), dtype=complex))
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times, filter_mode='plus')
-        np.testing.assert_array_almost_equal(ff, np.ones((100, 100), dtype=complex))
+        assert np.allclose(ff, np.ones((100, 100), dtype=complex))
 
         # test rephasing
         gains = np.ones((100, 100), dtype=complex)
         wgts = np.ones((100, 100), dtype=float)
         gains *= np.exp(2.0j * np.pi * np.outer(-151e-9 * np.ones(100), freqs))
         ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times)
-        np.testing.assert_array_almost_equal(ff, gains, 4)
+        assert np.allclose(ff, gains, 4)
 
         # test errors
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ff, info = smooth_cal.time_freq_2D_filter(gains, wgts, freqs, times, filter_mode='blah')
 
     def flag_threshold_and_broadcast(self):
@@ -104,14 +103,14 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
             flags[ant][0:4, 4] = True
         flag_threshold_and_broadcast(flags, freq_threshold=0.35, time_threshold=0.5, ant_threshold=1.0)
         for ant in flags.keys():
-            self.assertTrue(np.all(flags[ant][4, :]))
-            self.assertTrue(np.all(flags[ant][:, 4]))
+            assert np.all(flags[ant][4, :])
+            assert np.all(flags[ant][:, 4])
 
-        self.assertFalse(np.all(flags[(0, 'Jxx')]))
+        assert not np.all(flags[(0, 'Jxx')])
         flags[(0, 'Jxx')][0:8, :] = True
         flag_threshold_and_broadcast(flags, freq_threshold=1.0, time_threshold=1.0, ant_threshold=0.5)
-        self.assertTrue(np.all(flags[0, 'Jxx']))
-        self.assertFalse(np.all(flags[1, 'Jxx']))
+        assert np.all(flags[0, 'Jxx'])
+        assert not np.all(flags[1, 'Jxx'])
 
     def test_pick_reference_antenna(self):
         gains = {(n, 'Jxx'): np.ones((10, 10), dtype=complex) for n in range(10)}
@@ -121,73 +120,74 @@ class Test_Smooth_Cal_Helper_Functions(unittest.TestCase):
             flags[(n, 'Jxx')][:, 4] = True
         for n in range(6, 9):  # add phase noise to disqualify antennas 6, 7, 8
             gains[(n, 'Jxx')] *= np.exp(.1j * np.pi * np.random.rand(10, 10))  # want this to be << 2pi to avoid phase wraps
-        self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs, per_pol=False), (9, 'Jxx'))
-        self.assertEqual(smooth_cal.pick_reference_antenna(gains, flags, freqs), {'Jxx': (9, 'Jxx')})
+        assert smooth_cal.pick_reference_antenna(gains, flags, freqs, per_pol=False) == (9, 'Jxx')
+        assert smooth_cal.pick_reference_antenna(gains, flags, freqs) == {'Jxx': (9, 'Jxx')}
 
     def test_rephase_to_refant(self):
         gains = {(0, 'Jxx'): np.array([1. + 1.0j, 1. - 1.0j]),
                  (1, 'Jxx'): np.array([-1. + 1.0j, -1. - 1.0j])}
         smooth_cal.rephase_to_refant(gains, (0, 'Jxx'))
-        np.testing.assert_almost_equal(np.imag(gains[(0, 'Jxx')]), np.zeros_like(np.imag(gains[(0, 'Jxx')])))
+        assert np.allclose(np.imag(gains[(0, 'Jxx')]), np.zeros_like(np.imag(gains[(0, 'Jxx')])))
         flags = {(0, 'Jxx'): np.array([False, True]),
                  (1, 'Jxx'): np.array([True, False])}
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             smooth_cal.rephase_to_refant(gains, (0, 'Jxx'), flags=flags)
 
 
-class Test_Calibration_Smoother(unittest.TestCase):
+class Test_Calibration_Smoother(object):
 
-    def setUp(self):
+    def setup_method(self):
         calfits_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.abs.calfits_54x_only')))[0::2]
         flag_file_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.uvOCR_53x_54x_only.flags.applied.npz')))[0::2]
         self.cs = smooth_cal.CalibrationSmoother(calfits_list, flag_file_list=flag_file_list, flag_filetype='npz')
 
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
     def test_ref_ant(self):
         calfits_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.abs.calfits_54x_only')))[0::2]
         flag_file_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.uvOCR_53x_54x_only.flags.applied.npz')))[0::2]
         cs = smooth_cal.CalibrationSmoother(calfits_list, flag_file_list=flag_file_list, flag_filetype='npz', pick_refant=True)
-        self.assertEqual(cs.refant['Jxx'], (54, 'Jxx'))
+        assert cs.refant['Jxx'] == (54, 'Jxx')
         cs.time_freq_2D_filter(window='tukey', alpha=.45)
         cs.rephase_to_refant()
-        np.testing.assert_array_almost_equal(np.imag(cs.gain_grids[54, 'Jxx']),
-                                             np.zeros_like(np.imag(cs.gain_grids[54, 'Jxx'])))
+        assert np.allclose(np.imag(cs.gain_grids[54, 'Jxx']),
+                           np.zeros_like(np.imag(cs.gain_grids[54, 'Jxx'])))
 
     def test_check_consistency(self):
         temp_time = self.cs.cal_times[self.cs.cals[0]][0]
         self.cs.cal_times[self.cs.cals[0]][0] = self.cs.cal_times[self.cs.cals[0]][1]
         self.cs.time_indices = {cal: np.searchsorted(self.cs.time_grid, times) for cal, times in self.cs.cal_times.items()}
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.cs.check_consistency()
         self.cs.cal_times[self.cs.cals[0]][0] = temp_time
         self.cs.time_indices = {cal: np.searchsorted(self.cs.time_grid, times) for cal, times in self.cs.cal_times.items()}
 
         self.cs.cal_freqs[self.cs.cals[0]] += 1
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.cs.check_consistency()
         self.cs.cal_freqs[self.cs.cals[0]] -= 1
 
         self.cs.flag_freqs[self.cs.flag_files[0]] += 1
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.cs.check_consistency()
         self.cs.flag_freqs[self.cs.flag_files[0]] -= 1
 
         temp_time = self.cs.flag_times[self.cs.flag_files[0]][0]
         self.cs.flag_times[self.cs.flag_files[0]][0] = self.cs.flag_times[self.cs.flag_files[0]][1]
         self.cs.flag_time_indices = {ff: np.searchsorted(self.cs.time_grid, times) for ff, times in self.cs.flag_times.items()}
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             self.cs.check_consistency()
         self.cs.flag_times[self.cs.flag_files[0]][0] = temp_time
         self.cs.flag_time_indices = {ff: np.searchsorted(self.cs.time_grid, times) for ff, times in self.cs.flag_times.items()}
 
     def test_load_cal_and_flags(self):
-        self.assertEqual(len(self.cs.freqs), 1024)
-        self.assertEqual(len(self.cs.time_grid), 180)
-        self.assertAlmostEqual(self.cs.dt, 10.737419128417969 / 24 / 60 / 60)
-        self.assertTrue((54, 'Jxx') in self.cs.gain_grids)
-        self.assertTrue((54, 'Jxx') in self.cs.flag_grids)
-        self.assertEqual(self.cs.gain_grids[54, 'Jxx'].shape, (180, 1024))
-        self.assertEqual(self.cs.flag_grids[54, 'Jxx'].shape, (180, 1024))
-        np.testing.assert_array_equal(self.cs.flag_grids[54, 'Jxx'][60:120, :], True)
+        assert len(self.cs.freqs) == 1024
+        assert len(self.cs.time_grid) == 180
+        assert np.allclose(self.cs.dt, 10.737419128417969 / 24 / 60 / 60)
+        assert (54, 'Jxx') in self.cs.gain_grids
+        assert (54, 'Jxx') in self.cs.flag_grids
+        assert self.cs.gain_grids[54, 'Jxx'].shape == (180, 1024)
+        assert self.cs.flag_grids[54, 'Jxx'].shape == (180, 1024)
+        assert np.allclose(self.cs.flag_grids[54, 'Jxx'][60:120, :], True)
 
     def test_1D_filtering(self):
         g = deepcopy(self.cs.gain_grids[54, 'Jxx'])
@@ -195,37 +195,37 @@ class Test_Calibration_Smoother(unittest.TestCase):
             warnings.simplefilter("ignore")
             self.cs.freq_filter(window='tukey', alpha=.45)
         g2 = deepcopy(self.cs.gain_grids[54, 'Jxx'])
-        self.assertFalse(np.all(g == g2))
-        self.assertEqual(g2.shape, g.shape)
+        assert not np.all(g == g2)
+        assert g2.shape == g.shape
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.cs.time_filter()
         g3 = deepcopy(self.cs.gain_grids[54, 'Jxx'])
-        self.assertFalse(np.all(g == g3))
-        self.assertEqual(g3.shape, g.shape)
+        assert not np.all(g == g3)
+        assert g3.shape == g.shape
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.cs.time_filter()
         g4 = deepcopy(self.cs.gain_grids[54, 'Jxx'])
-        self.assertFalse(np.all(g3 == g4))
-        self.assertEqual(g4.shape, g.shape)
+        assert not np.all(g3 == g4)
+        assert g4.shape == g.shape
 
-        self.setUp()
-        self.assertFalse(np.all(self.cs.flag_grids[(54, 'Jxx')] == np.ones_like(self.cs.flag_grids[(54, 'Jxx')])))
+        self.setup_method()
+        assert not np.all(self.cs.flag_grids[(54, 'Jxx')] == np.ones_like(self.cs.flag_grids[(54, 'Jxx')]))
         self.cs.flag_grids[(54, 'Jxx')] = np.zeros_like(self.cs.flag_grids[(54, 'Jxx')])
         self.cs.flag_grids[(54, 'Jxx')][:, 0:1000] = True
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.cs.freq_filter()
-            np.testing.assert_array_equal(self.cs.gain_grids[(54, 'Jxx')], g)
+            assert np.allclose(self.cs.gain_grids[(54, 'Jxx')], g)
             self.cs.time_filter()
-            np.testing.assert_array_equal(self.cs.gain_grids[(54, 'Jxx')], g)
+            assert np.allclose(self.cs.gain_grids[(54, 'Jxx')], g)
             # test skip_wgt propagation to flags
-            np.testing.assert_array_equal(self.cs.flag_grids[(54, 'Jxx')],
-                                          np.ones_like(self.cs.flag_grids[(54, 'Jxx')]))
-        self.setUp()
+            assert np.allclose(self.cs.flag_grids[(54, 'Jxx')],
+                               np.ones_like(self.cs.flag_grids[(54, 'Jxx')]))
+        self.setup_method()
         self.cs.gain_grids[54, 'Jxx'] = g
 
     def test_2D_filtering(self):
@@ -234,8 +234,8 @@ class Test_Calibration_Smoother(unittest.TestCase):
             warnings.simplefilter("ignore")
             self.cs.time_freq_2D_filter(window='tukey', alpha=.45)
         g2 = deepcopy(self.cs.gain_grids[54, 'Jxx'])
-        self.assertFalse(np.all(g == g2))
-        self.assertEqual(g2.shape, g.shape)
+        assert not np.all(g == g2)
+        assert g2.shape == g.shape
 
     def test_write(self):
         outfilename = os.path.join(DATA_PATH, 'test_output/smooth_test.calfits')
@@ -245,12 +245,8 @@ class Test_Calibration_Smoother(unittest.TestCase):
         for cal in self.cs.cals:
             new_cal = io.HERACal(cal.replace('test_input/', 'test_output/smoothed_'))
             gains, flags, _, _ = new_cal.read()
-            self.assertTrue('helloworld' in new_cal.history.replace('\n', '').replace(' ', ''))
-            self.assertTrue('Thisfilewasproducedbythefunction' in new_cal.history.replace('\n', '').replace(' ', ''))
-            self.assertEqual(new_cal.telescope_name, 'PAPER')
-            np.testing.assert_array_equal(gains[54, 'Jxx'], g[self.cs.time_indices[cal], :])
+            assert 'helloworld' in new_cal.history.replace('\n', '').replace(' ', '')
+            assert 'Thisfilewasproducedbythefunction' in new_cal.history.replace('\n', '').replace(' ', '')
+            assert new_cal.telescope_name == 'PAPER'
+            assert np.allclose(gains[54, 'Jxx'], g[self.cs.time_indices[cal], :])
             os.remove(cal.replace('test_input/', 'test_output/smoothed_'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -71,7 +71,7 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freqs = np.linspace(100., 200., 10, endpoint=False) * 1e6
         ff, info = smooth_cal.freq_filter(gains, wgts, freqs, skip_wgt=.5)
         assert np.allclose(ff[0, :], gains[0, :])
-        assert info[0]['skipped'] == True
+        assert np.isclose(info[0]['skipped'], True)
 
     def test_time_freq_2D_filter(self):
         gains = np.ones((100, 100), dtype=complex)

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-import nose.tools as nt
+import pytest
 import numpy as np
 import sys
 import os
@@ -19,75 +19,62 @@ from pyuvdata import UVData
 from pyuvdata import UVCal
 import pyuvdata.tests as uvtest
 
-from hera_cal import utils, abscal, datacontainer, io
-from hera_cal.redcal import noise
-from hera_cal.calibrations import CAL_PATH
-from hera_cal.data import DATA_PATH
-
-
-# define a context manager for checking stdout
-# from https://stackoverflow.com/questions/4219717/how-to-assert-output-with-nosetest-unittest-in-python
-@contextmanager
-def captured_output():
-    new_out, new_err = six.StringIO(), six.StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = new_out, new_err
-        yield sys.stdout, sys.stderr
-    finally:
-        sys.stdout, sys.stderr = old_out, old_err
+from .. import utils, abscal, datacontainer, io
+from ..redcal import noise
+from ..calibrations import CAL_PATH
+from ..data import DATA_PATH
 
 
 class Test_Pol_Ops(object):
     def test_split_pol(self):
-        nt.assert_equal(utils.split_pol('xx'), ('Jxx', 'Jxx'))
-        nt.assert_equal(utils.split_pol('xy'), ('Jxx', 'Jyy'))
-        nt.assert_equal(utils.split_pol('XY'), ('Jxx', 'Jyy'))
-        nt.assert_raises(KeyError, utils.split_pol, 'I')
-        nt.assert_raises(KeyError, utils.split_pol, 'pV')
+        assert utils.split_pol('xx') == ('Jxx', 'Jxx')
+        assert utils.split_pol('xy') == ('Jxx', 'Jyy')
+        assert utils.split_pol('XY') == ('Jxx', 'Jyy')
+        pytest.raises(KeyError, utils.split_pol, 'I')
+        pytest.raises(KeyError, utils.split_pol, 'pV')
 
     def test_join_pol(self):
-        nt.assert_equal(utils.join_pol('Jxx', 'Jxx'), 'xx')
-        nt.assert_equal(utils.join_pol('Jxx', 'Jyy'), 'xy')
+        assert utils.join_pol('Jxx', 'Jxx') == 'xx'
+        assert utils.join_pol('Jxx', 'Jyy') == 'xy'
 
     def test_split_bl(self):
-        nt.assert_equal(utils.split_bl((1, 2, 'xx')), ((1, 'Jxx'), (2, 'Jxx')))
-        nt.assert_equal(utils.split_bl((1, 2, 'xy')), ((1, 'Jxx'), (2, 'Jyy')))
-        nt.assert_equal(utils.split_bl((1, 2, 'XX')), ((1, 'Jxx'), (2, 'Jxx')))
-        nt.assert_raises(KeyError, utils.split_bl, (1, 2, 'pQ'))
-        nt.assert_raises(KeyError, utils.split_bl, (1, 2, 'U'))
+        assert utils.split_bl((1, 2, 'xx')) == ((1, 'Jxx'), (2, 'Jxx'))
+        assert utils.split_bl((1, 2, 'xy')) == ((1, 'Jxx'), (2, 'Jyy'))
+        assert utils.split_bl((1, 2, 'XX')) == ((1, 'Jxx'), (2, 'Jxx'))
+        pytest.raises(KeyError, utils.split_bl, (1, 2, 'pQ'))
+        pytest.raises(KeyError, utils.split_bl, (1, 2, 'U'))
 
     def test_join_bl(self):
-        nt.assert_equal(utils.join_bl((1, 'Jxx'), (2, 'Jxx')), (1, 2, 'xx'))
-        nt.assert_equal(utils.join_bl((1, 'Jxx'), (2, 'Jyy')), (1, 2, 'xy'))
+        assert utils.join_bl((1, 'Jxx'), (2, 'Jxx')) == (1, 2, 'xx')
+        assert utils.join_bl((1, 'Jxx'), (2, 'Jyy')) == (1, 2, 'xy')
 
     def test_reverse_bl(self):
-        nt.assert_equal(utils.reverse_bl((1, 2, 'xx')), (2, 1, 'xx'))
-        nt.assert_equal(utils.reverse_bl((1, 2, 'xy')), (2, 1, 'yx'))
-        nt.assert_equal(utils.reverse_bl((1, 2, 'XX')), (2, 1, 'xx'))
-        nt.assert_equal(utils.reverse_bl((1, 2, 'pI')), (2, 1, 'pI'))
-        nt.assert_equal(utils.reverse_bl((1, 2)), (2, 1))
+        assert utils.reverse_bl((1, 2, 'xx')) == (2, 1, 'xx')
+        assert utils.reverse_bl((1, 2, 'xy')) == (2, 1, 'yx')
+        assert utils.reverse_bl((1, 2, 'XX')) == (2, 1, 'xx')
+        assert utils.reverse_bl((1, 2, 'pI')) == (2, 1, 'pI')
+        assert utils.reverse_bl((1, 2)) == (2, 1)
 
     def test_comply_bl(self):
-        nt.assert_equal(utils.comply_bl((1, 2, 'xx')), (1, 2, 'xx'))
-        nt.assert_equal(utils.comply_bl((1, 2, 'xy')), (1, 2, 'xy'))
-        nt.assert_equal(utils.comply_bl((1, 2, 'XX')), (1, 2, 'xx'))
-        nt.assert_equal(utils.comply_bl((1, 2, 'pI')), (1, 2, 'pI'))
+        assert utils.comply_bl((1, 2, 'xx')) == (1, 2, 'xx')
+        assert utils.comply_bl((1, 2, 'xy')) == (1, 2, 'xy')
+        assert utils.comply_bl((1, 2, 'XX')) == (1, 2, 'xx')
+        assert utils.comply_bl((1, 2, 'pI')) == (1, 2, 'pI')
 
     def test_make_bl(self):
-        nt.assert_equal(utils.make_bl((1, 2, 'xx')), (1, 2, 'xx'))
-        nt.assert_equal(utils.make_bl((1, 2), 'xx'), (1, 2, 'xx'))
-        nt.assert_equal(utils.make_bl((1, 2, 'xy')), (1, 2, 'xy'))
-        nt.assert_equal(utils.make_bl((1, 2), 'xy'), (1, 2, 'xy'))
-        nt.assert_equal(utils.make_bl((1, 2, 'XX')), (1, 2, 'xx'))
-        nt.assert_equal(utils.make_bl((1, 2), 'XX'), (1, 2, 'xx'))
-        nt.assert_equal(utils.make_bl((1, 2, 'pI')), (1, 2, 'pI'))
-        nt.assert_equal(utils.make_bl((1, 2), 'pI'), (1, 2, 'pI'))
+        assert utils.make_bl((1, 2, 'xx')) == (1, 2, 'xx')
+        assert utils.make_bl((1, 2), 'xx') == (1, 2, 'xx')
+        assert utils.make_bl((1, 2, 'xy')) == (1, 2, 'xy')
+        assert utils.make_bl((1, 2), 'xy') == (1, 2, 'xy')
+        assert utils.make_bl((1, 2, 'XX')) == (1, 2, 'xx')
+        assert utils.make_bl((1, 2), 'XX') == (1, 2, 'xx')
+        assert utils.make_bl((1, 2, 'pI')) == (1, 2, 'pI')
+        assert utils.make_bl((1, 2), 'pI') == (1, 2, 'pI')
 
 
 class TestFftDly(object):
 
-    def setUp(self):
+    def setup_method(self):
         np.random.seed(0)
         self.freqs = np.linspace(.1, .2, 1024)
 
@@ -97,10 +84,10 @@ class TestFftDly(object):
         data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys)
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df, f0=self.freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-5)  # median accuracy of 10 fs
-        np.testing.assert_almost_equal(offs, 0, 4)
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-5  # median accuracy of 10 fs
+        assert np.allclose(offs, 0, atol=1e-4)
         dlys, offs = utils.fft_dly(data, df, medfilt=True, f0=self.freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-2)  # median accuracy of 10 ps
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-2  # median accuracy of 10 ps
 
     def test_ideal_offset(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
@@ -108,16 +95,16 @@ class TestFftDly(object):
         data = np.exp(2j * np.pi * self.freqs * true_dlys + 1j * 0.123)
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df, f0=self.freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-5)  # median accuracy of 10 fs
-        np.testing.assert_almost_equal(offs, 0.123, 4)
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-5  # median accuracy of 10 fs
+        assert np.allclose(offs, 0.123, atol=1e-4)
         mdl = np.exp(2j * np.pi * self.freqs * dlys + 1j * offs)
-        np.testing.assert_almost_equal(np.angle(data * mdl.conj()), 0, 5)
+        assert np.allclose(np.angle(data * mdl.conj()), 0, atol=1e-5)
         dlys, offs = utils.fft_dly(data, df, edge_cut=100, f0=self.freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-4)  # median accuracy of 100 fs
-        np.testing.assert_almost_equal(offs, 0.123, 4)
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-4  # median accuracy of 100 fs
+        assert np.allclose(offs, 0.123, atol=1e-4)
         dlys, offs = utils.fft_dly(data, df, medfilt=True, f0=self.freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-2)  # median accuracy of 10 ps
-        np.testing.assert_almost_equal(offs, 0.123, 1)
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-2  # median accuracy of 10 ps
+        assert np.allclose(offs, 0.123, atol=1e-1)
 
     def test_noisy(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
@@ -125,9 +112,9 @@ class TestFftDly(object):
         data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys) + 5 * noise((60, 1024))
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df)
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1)  # median accuracy of 1 ns
+        assert np.median(np.abs(dlys - true_dlys)) < 1  # median accuracy of 1 ns
         dlys, offs = utils.fft_dly(data, df, medfilt=True)
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1)  # median accuracy of 1 ns
+        assert np.median(np.abs(dlys - true_dlys)) < 1  # median accuracy of 1 ns
 
     def test_rfi(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
@@ -136,7 +123,7 @@ class TestFftDly(object):
         data[:, ::16] = 1000.
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df, medfilt=True)
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-2)  # median accuracy of 10 ps
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-2  # median accuracy of 10 ps
 
     def test_nan(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
@@ -145,8 +132,9 @@ class TestFftDly(object):
         data[:, ::16] = np.nan
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df)
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 1e-3)  # median accuracy of 1 ps
+        assert np.median(np.abs(dlys - true_dlys)) < 1e-3  # median accuracy of 1 ps
 
+    @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
     def test_realistic(self):
         # load into pyuvdata object
         data_fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
@@ -161,19 +149,19 @@ class TestFftDly(object):
         df = np.median(np.diff(freqs))
         # basic execution
         dlys, offs = utils.fft_dly(flat_phs, df, medfilt=True, f0=freqs[0])  # dlys in ns
-        nt.assert_equal(dlys.shape, (60, 1))
-        nt.assert_true(np.all(np.abs(dlys) < 1))  # all delays near zero
+        assert dlys.shape == (60, 1)
+        assert np.all(np.abs(dlys) < 1)  # all delays near zero
         true_dlys = np.random.uniform(-20, 20, size=60)
         true_dlys.shape = (60, 1)
         phs = np.exp(2j * np.pi * freqs.reshape((1, -1)) * (true_dlys + dlys))
         dlys, offs = utils.fft_dly(flat_phs * phs, df, medfilt=True, f0=freqs[0])
-        nt.assert_true(np.median(np.abs(dlys - true_dlys)) < 2)  # median accuracy better than 2 ns
+        assert np.median(np.abs(dlys - true_dlys)) < 2  # median accuracy better than 2 ns
 
     def test_error(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
         true_dlys.shape = (60, 1)
         data = np.exp(2j * np.pi * self.freqs.reshape((1, -1)) * true_dlys)
-        nt.assert_raises(ValueError, utils.interp_peak, np.fft.fft(data), method='blah')
+        pytest.raises(ValueError, utils.interp_peak, np.fft.fft(data), method='blah')
 
     def test_interp_peak(self):
         # code testing is done in TestFftDly, so just check optional parameters here
@@ -182,22 +170,22 @@ class TestFftDly(object):
         y = (x - 5)**2 + np.isclose(x, 5.0).astype(np.float)
         # check peak is zeroth bin
         inds, bs, peaks, p = utils.interp_peak(y[None, :], method='quadratic', reject_edges=False)
-        nt.assert_equal(inds[0], 0)
+        assert inds[0] == 0
         # check peak is middle bin with reject_edges
         inds, bs, peaks, p = utils.interp_peak(y[None, :], method='quadratic', reject_edges=True)
-        nt.assert_equal(inds[0], np.argmax(y - (x - 5)**2))
+        assert inds[0] == np.argmax(y - (x - 5)**2)
         # check peak is last bin even w/ reject_edges
         y = x * 1.0
         inds, bs, peaks, p = utils.interp_peak(y[None, :], method='quadratic', reject_edges=True)
-        nt.assert_equal(inds[0], np.argmax(y))
+        assert inds[0] == np.argmax(y)
         # check peak is zero bin even w/ reject_edges
         y = np.abs(-x * 1.0 + 10)
         inds, bs, peaks, p = utils.interp_peak(y[None, :], method='quadratic', reject_edges=True)
-        nt.assert_equal(inds[0], np.argmax(y))
+        assert inds[0] == np.argmax(y)
 
 
 class TestAAFromUV(object):
-    def setUp(self):
+    def setup_method(self):
         # define test file that is compatible with get_aa_from_uv
         self.test_file = "zen.2457999.76839.xx.HH.uvA"
 
@@ -208,11 +196,11 @@ class TestAAFromUV(object):
         aa = utils.get_aa_from_uv(uvd)
         # like miriad, aipy will pad the aa with non-existent antennas,
         #   because there is no concept of antenna names
-        nt.assert_equal(len(aa), 88)
+        assert len(aa) == 88
 
 
 class TestAA(object):
-    def setUp(self):
+    def setup_method(self):
         # define test file that is compatible with get_aa_from_uv
         self.test_file = "zen.2457999.76839.xx.HH.uvA"
 
@@ -232,47 +220,47 @@ class TestAA(object):
         new_params = aa.get_params()
         new_top = [new_params['0'][key] for key in antpos.keys()]
         old_top = [antpos[key] for key in antpos.keys()]
-        nt.assert_true(np.allclose(old_top, new_top))
+        assert np.allclose(old_top, new_top)
 
 
 def test_JD2LST():
     # test float execution
     jd = 2458042.
-    nt.assert_almost_equal(utils.JD2LST(jd, longitude=21.), 3.930652307266274)
+    assert np.allclose(utils.JD2LST(jd, longitude=21.), 3.930652307266274)
     # test array execution
     jd = np.arange(2458042, 2458046.1, .5)
     lst = utils.JD2LST(jd, longitude=21.)
-    nt.assert_equal(len(lst), 9)
-    nt.assert_almost_equal(lst[3], 0.81486300218170715)
+    assert len(lst) == 9
+    assert np.allclose(lst[3], 0.81486300218170715)
 
 
 def test_LST2JD():
     # test basic execution
     lst = np.pi
     jd = utils.LST2JD(lst, start_jd=2458042)
-    nt.assert_almost_equal(jd, 2458042.8708433118)
+    assert np.allclose(jd, 2458042.8708433118)
     # test array execution
     lst = np.arange(np.pi, np.pi + 1.1, 0.2)
     jd = utils.LST2JD(lst, start_jd=2458042)
-    nt.assert_equal(len(jd), 6)
-    nt.assert_almost_equal(jd[3], 2458042.9660755517)
+    assert len(jd) == 6
+    assert np.allclose(jd[3], 2458042.9660755517)
 
 
 def test_JD2RA():
     # test basic execution
     jd = 2458042.5
     ra = utils.JD2RA(jd)
-    nt.assert_almost_equal(ra, 46.130897831277629)
+    assert np.allclose(ra, 46.130897831277629)
     # test array
     jd = np.arange(2458042, 2458043.01, .2)
     ra = utils.JD2RA(jd)
-    nt.assert_equal(len(ra), 6)
-    nt.assert_almost_equal(ra[3], 82.229459674026003)
+    assert len(ra) == 6
+    assert np.allclose(ra[3], 82.229459674026003)
     # test exception
-    nt.assert_raises(ValueError, utils.JD2RA, jd, epoch='foo')
+    pytest.raises(ValueError, utils.JD2RA, jd, epoch='foo')
     # test J2000 epoch
     ra = utils.JD2RA(jd, epoch='J2000')
-    nt.assert_almost_equal(ra[0], 225.37671446615548)
+    assert np.allclose(ra[0], 225.37671446615548)
 
 
 def test_combine_calfits():
@@ -283,23 +271,23 @@ def test_combine_calfits():
         os.remove('ex.calfits')
     utils.combine_calfits([test_file1, test_file2], 'ex.calfits', outdir='./', overwrite=True, broadcast_flags=True)
     # test it exists
-    nt.assert_true(os.path.exists('ex.calfits'))
+    assert os.path.exists('ex.calfits')
     # test antenna number
     uvc = UVCal()
     uvc.read_calfits('ex.calfits')
-    nt.assert_equal(len(uvc.antenna_numbers), 7)
+    assert len(uvc.antenna_numbers) == 7
     # test time number
-    nt.assert_equal(uvc.Ntimes, 60)
+    assert uvc.Ntimes == 60
     # test gain value got properly multiplied
     uvc_dly = UVCal()
     uvc_dly.read_calfits(test_file1)
     uvc_abs = UVCal()
     uvc_abs.read_calfits(test_file2)
-    nt.assert_almost_equal(uvc_dly.gain_array[0, 0, 10, 10, 0] * uvc_abs.gain_array[0, 0, 10, 10, 0], uvc.gain_array[0, 0, 10, 10, 0])
+    assert np.allclose(uvc_dly.gain_array[0, 0, 10, 10, 0] * uvc_abs.gain_array[0, 0, 10, 10, 0], uvc.gain_array[0, 0, 10, 10, 0])
     if os.path.exists('ex.calfits'):
         os.remove('ex.calfits')
     utils.combine_calfits([test_file1, test_file2], 'ex.calfits', outdir='./', overwrite=True, broadcast_flags=False)
-    nt.assert_true(os.path.exists('ex.calfits'))
+    assert os.path.exists('ex.calfits')
     if os.path.exists('ex.calfits'):
         os.remove('ex.calfits')
 
@@ -323,10 +311,10 @@ def test_lst_rephase():
     k = (0, 1, 'xx')
     # check error at transit
     phs_err = np.angle(data[k][transit_integration, 4] / data_drift[k][transit_integration + 1, 4])
-    nt.assert_true(np.isclose(phs_err, 0, atol=1e-7))
+    assert np.isclose(phs_err, 0, atol=1e-7)
     # check error across file
     phs_err = np.angle(data[k][:-1, 4] / data_drift[k][1:, 4])
-    nt.assert_true(np.abs(phs_err).max() < 1e-4)
+    assert np.abs(phs_err).max() < 1e-4
 
     # multiple phase term test: dlst per integration
     dlst = np.array([np.median(np.diff(lsts))] * data[k].shape[0])
@@ -334,10 +322,10 @@ def test_lst_rephase():
     utils.lst_rephase(data, bls, freqs, dlst, lat=0.0)
     # check error at transit
     phs_err = np.angle(data[k][transit_integration, 4] / data_drift[k][transit_integration + 1, 4])
-    nt.assert_true(np.isclose(phs_err, 0, atol=1e-7))
+    assert np.isclose(phs_err, 0, atol=1e-7)
     # check err across file
     phs_err = np.angle(data[k][:-1, 4] / data_drift[k][1:, 4])
-    nt.assert_true(np.abs(phs_err).max() < 1e-4)
+    assert np.abs(phs_err).max() < 1e-4
 
     # phase all integrations to a single integration
     dlst = lsts[50] - lsts
@@ -345,16 +333,16 @@ def test_lst_rephase():
     utils.lst_rephase(data, bls, freqs, dlst, lat=0.0)
     # check error at transit
     phs_err = np.angle(data[k][transit_integration, 4] / data_drift[k][transit_integration, 4])
-    nt.assert_true(np.isclose(phs_err, 0, atol=1e-7))
+    assert np.isclose(phs_err, 0, atol=1e-7)
     # check error across file
     phs_err = np.angle(data[k][:, 4] / data_drift[k][50, 4])
-    nt.assert_true(np.abs(phs_err).max() < 1e-4)
+    assert np.abs(phs_err).max() < 1e-4
 
     # test operation on array
     k = (0, 1, 'xx')
     d = data_drift[k].copy()
     d_phs = utils.lst_rephase(d, bls[k], freqs, dlst, lat=0.0, array=True)
-    nt.assert_almost_equal(np.abs(np.angle(d_phs[50] / data[k][50])).max(), 0.0)
+    assert np.allclose(np.abs(np.angle(d_phs[50] / data[k][50])).max(), 0.0)
 
 
 def test_chisq():
@@ -362,25 +350,25 @@ def test_chisq():
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xx'): 3 * np.ones((5, 10), dtype=complex)})
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model)
-    nt.assert_true(chisq.shape == (5, 10))
-    nt.assert_true(nObs.shape == (5, 10))
-    nt.assert_true(chisq.dtype == float)
-    nt.assert_true(nObs.dtype == int)
-    np.testing.assert_array_equal(chisq, 4.0)
-    np.testing.assert_array_equal(nObs, 1)
-    np.testing.assert_array_equal(chisq_per_ant[0, 'Jxx'], 4.0)
-    np.testing.assert_array_equal(chisq_per_ant[1, 'Jxx'], 4.0)
-    np.testing.assert_array_equal(nObs_per_ant[0, 'Jxx'], 1)
-    np.testing.assert_array_equal(nObs_per_ant[1, 'Jxx'], 1)
+    assert chisq.shape == (5, 10)
+    assert nObs.shape == (5, 10)
+    assert chisq.dtype == float
+    assert nObs.dtype == int
+    assert np.allclose(chisq, 4.0)
+    assert np.allclose(nObs, 1)
+    assert np.allclose(chisq_per_ant[0, 'Jxx'], 4.0)
+    assert np.allclose(chisq_per_ant[1, 'Jxx'], 4.0)
+    assert np.allclose(nObs_per_ant[0, 'Jxx'], 1)
+    assert np.allclose(nObs_per_ant[1, 'Jxx'], 1)
 
     # test with reds
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex),
                                         (1, 2, 'xx'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xx'): 2 * np.ones((5, 10), dtype=complex)})
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, reds=[[(0, 1, 'xx'), (1, 2, 'xx')]])
-    np.testing.assert_array_equal(chisq, 2.0)
-    np.testing.assert_array_equal(nObs, 2)
-    nt.assert_false((1, 2, 'xx') in model)
+    assert np.allclose(chisq, 2.0)
+    assert np.allclose(nObs, 2)
+    assert (1, 2, 'xx') not in model
 
     # test with weights
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex)})
@@ -388,8 +376,8 @@ def test_chisq():
     data_wgts = datacontainer.DataContainer({(0, 1, 'xx'): np.zeros((5, 10), dtype=float)})
     data_wgts[(0, 1, 'xx')][:, 0] = 1.0
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts)
-    nt.assert_equal(np.sum(chisq), 5.0)
-    nt.assert_equal(np.sum(nObs), 5)
+    assert np.sum(chisq) == 5.0
+    assert np.sum(nObs) == 5
 
     # test update case
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex)})
@@ -398,12 +386,12 @@ def test_chisq():
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts)
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, chisq=chisq, nObs=nObs,
                                                            chisq_per_ant=chisq_per_ant, nObs_per_ant=nObs_per_ant)
-    np.testing.assert_array_equal(chisq, 2.0)
-    np.testing.assert_array_equal(nObs, 2)
-    np.testing.assert_array_equal(chisq_per_ant[0, 'Jxx'], 2.0)
-    np.testing.assert_array_equal(chisq_per_ant[1, 'Jxx'], 2.0)
-    np.testing.assert_array_equal(nObs_per_ant[0, 'Jxx'], 2)
-    np.testing.assert_array_equal(nObs_per_ant[1, 'Jxx'], 2)
+    assert np.allclose(chisq, 2.0)
+    assert np.allclose(nObs, 2)
+    assert np.allclose(chisq_per_ant[0, 'Jxx'], 2.0)
+    assert np.allclose(chisq_per_ant[1, 'Jxx'], 2.0)
+    assert np.allclose(nObs_per_ant[0, 'Jxx'], 2)
+    assert np.allclose(nObs_per_ant[1, 'Jxx'], 2)
 
     # test with gains and gain flags
     gains = {(0, 'Jxx'): .5**.5 * np.ones((5, 10), dtype=complex),
@@ -412,57 +400,54 @@ def test_chisq():
                   (1, 'Jxx'): np.zeros((5, 10), dtype=bool)}
     gain_flags[0, 'Jxx'][:, 0] = True
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, gains=gains, gain_flags=gain_flags)
-    nt.assert_almost_equal(np.sum(chisq), 0.0)
-    nt.assert_equal(np.sum(nObs), 45)
-    nt.assert_almost_equal(np.sum(chisq_per_ant[0, 'Jxx']), 0.0)
-    nt.assert_almost_equal(np.sum(chisq_per_ant[1, 'Jxx']), 0.0)
-    nt.assert_equal(np.sum(nObs_per_ant[1, 'Jxx']), 45)
-    nt.assert_equal(np.sum(nObs_per_ant[1, 'Jxx']), 45)
+    assert np.allclose(np.sum(chisq), 0.0)
+    assert np.sum(nObs) == 45
+    assert np.allclose(np.sum(chisq_per_ant[0, 'Jxx']), 0.0)
+    assert np.allclose(np.sum(chisq_per_ant[1, 'Jxx']), 0.0)
+    assert np.sum(nObs_per_ant[1, 'Jxx']) == 45
+    assert np.sum(nObs_per_ant[1, 'Jxx']) == 45
 
     # test errors
-    nt.assert_raises(ValueError, utils.chisq, data, model, data_wgts, chisq=chisq)
-    nt.assert_raises(ValueError, utils.chisq, data, model, data_wgts, nObs=nObs)
-    nt.assert_raises(AssertionError, utils.chisq, data, model, data_wgts, split_by_antpol=True, chisq={'Jxx': 1}, nObs={})
-    nt.assert_raises(AssertionError, utils.chisq, data, model, data_wgts, split_by_antpol=True, nObs={'Jxx': 1}, chisq={})
-    nt.assert_raises(ValueError, utils.chisq, data, model, data_wgts, chisq_per_ant=chisq_per_ant)
-    nt.assert_raises(ValueError, utils.chisq, data, model, data_wgts, nObs_per_ant=nObs_per_ant)
-    nt.assert_raises(AssertionError, utils.chisq, data, model, data_wgts, chisq_per_ant=chisq_per_ant, nObs_per_ant={})
-    nt.assert_raises(AssertionError, utils.chisq, data, model, data_wgts, chisq_per_ant={}, nObs_per_ant=nObs_per_ant)
-    nt.assert_raises(KeyError, utils.chisq, data, model, data_wgts, gains={(0, 'x'): np.ones((5, 10), dtype=complex)})
+    pytest.raises(ValueError, utils.chisq, data, model, data_wgts, chisq=chisq)
+    pytest.raises(ValueError, utils.chisq, data, model, data_wgts, nObs=nObs)
+    pytest.raises(AssertionError, utils.chisq, data, model, data_wgts, split_by_antpol=True, chisq={'Jxx': 1}, nObs={})
+    pytest.raises(AssertionError, utils.chisq, data, model, data_wgts, split_by_antpol=True, nObs={'Jxx': 1}, chisq={})
+    pytest.raises(ValueError, utils.chisq, data, model, data_wgts, chisq_per_ant=chisq_per_ant)
+    pytest.raises(ValueError, utils.chisq, data, model, data_wgts, nObs_per_ant=nObs_per_ant)
+    pytest.raises(AssertionError, utils.chisq, data, model, data_wgts, chisq_per_ant=chisq_per_ant, nObs_per_ant={})
+    pytest.raises(AssertionError, utils.chisq, data, model, data_wgts, chisq_per_ant={}, nObs_per_ant=nObs_per_ant)
+    pytest.raises(KeyError, utils.chisq, data, model, data_wgts, gains={(0, 'x'): np.ones((5, 10), dtype=complex)})
     data_wgts = datacontainer.DataContainer({(0, 1, 'xx'): 1.0j * np.ones((5, 10), dtype=float)})
-    nt.assert_raises(AssertionError, utils.chisq, data, model, data_wgts)
+    pytest.raises(AssertionError, utils.chisq, data, model, data_wgts)
 
     # test by_pol option
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xx'): 2 * np.ones((5, 10), dtype=complex)})
     data_wgts = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=float)})
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, split_by_antpol=True)
-    nt.assert_true('Jxx' in chisq)
-    nt.assert_true('Jxx' in nObs)
-    nt.assert_true(chisq['Jxx'].shape, (5, 10))
-    nt.assert_true(nObs['Jxx'].shape, (5, 10))
-    np.testing.assert_array_equal(chisq['Jxx'], 1.0)
-    np.testing.assert_array_equal(nObs['Jxx'], 1)
+    assert 'Jxx' in chisq
+    assert 'Jxx' in nObs
+    assert chisq['Jxx'].shape == (5, 10)
+    assert nObs['Jxx'].shape == (5, 10)
+    assert np.allclose(chisq['Jxx'], 1.0)
+    assert np.allclose(nObs['Jxx'], 1)
     data = datacontainer.DataContainer({(0, 1, 'xy'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xy'): 2 * np.ones((5, 10), dtype=complex)})
     data_wgts = datacontainer.DataContainer({(0, 1, 'xy'): np.ones((5, 10), dtype=float)})
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, split_by_antpol=True)
-    nt.assert_true(len(chisq) == 0)
-    nt.assert_true(len(nObs) == 0)
-    nt.assert_true(len(chisq_per_ant) == 0)
-    nt.assert_true(len(chisq_per_ant) == 0)
+    assert len(chisq) == 0
+    assert len(nObs) == 0
+    assert len(chisq_per_ant) == 0
+    assert len(chisq_per_ant) == 0
 
 
-def test_echo():
-    with captured_output() as (out, err):
-        utils.echo('hi', verbose=True)
-    output = out.getvalue().strip()
-    nt.assert_equal(output, 'hi')
+def test_echo(capsys):
+    utils.echo('hi', verbose=True)
+    output = capsys.readouterr().out
+    assert output.strip() == 'hi'
 
-    with captured_output() as (out, err):
-        utils.echo('hi', type=1, verbose=True)
-    output = out.getvalue()
-    print("output: ", output)
-    nt.assert_equal(output[0], '\n')
-    nt.assert_equal(output[1:4], 'hi\n')
-    nt.assert_equal(output[4:], '-' * 40 + '\n')
+    utils.echo('hi', type=1, verbose=True)
+    output = capsys.readouterr().out
+    assert output[0] == '\n'
+    assert output[1:4] == 'hi\n'
+    assert output[4:] == '-' * 40 + '\n'

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -85,7 +85,7 @@ class TestFftDly(object):
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df, f0=self.freqs[0])
         assert np.median(np.abs(dlys - true_dlys)) < 1e-5  # median accuracy of 10 fs
-        assert np.allclose(offs, 0, atol=1e-4)
+        np.testing.assert_almost_equal(offs, 0, decimal=4)
         dlys, offs = utils.fft_dly(data, df, medfilt=True, f0=self.freqs[0])
         assert np.median(np.abs(dlys - true_dlys)) < 1e-2  # median accuracy of 10 ps
 
@@ -96,15 +96,15 @@ class TestFftDly(object):
         df = np.median(np.diff(self.freqs))
         dlys, offs = utils.fft_dly(data, df, f0=self.freqs[0])
         assert np.median(np.abs(dlys - true_dlys)) < 1e-5  # median accuracy of 10 fs
-        assert np.allclose(offs, 0.123, atol=1e-4)
+        np.testing.assert_almost_equal(offs, 0.123, decimal=4)
         mdl = np.exp(2j * np.pi * self.freqs * dlys + 1j * offs)
-        assert np.allclose(np.angle(data * mdl.conj()), 0, atol=1e-5)
+        np.testing.assert_almost_equal(np.angle(data * mdl.conj()), 0, decimal=5)
         dlys, offs = utils.fft_dly(data, df, edge_cut=100, f0=self.freqs[0])
         assert np.median(np.abs(dlys - true_dlys)) < 1e-4  # median accuracy of 100 fs
-        assert np.allclose(offs, 0.123, atol=1e-4)
+        np.testing.assert_almost_equal(offs, 0.123, decimal=4)
         dlys, offs = utils.fft_dly(data, df, medfilt=True, f0=self.freqs[0])
         assert np.median(np.abs(dlys - true_dlys)) < 1e-2  # median accuracy of 10 ps
-        assert np.allclose(offs, 0.123, atol=1e-1)
+        np.testing.assert_almost_equal(offs, 0.123, decimal=1)
 
     def test_noisy(self):
         true_dlys = np.random.uniform(-200, 200, size=60)
@@ -354,20 +354,20 @@ def test_chisq():
     assert nObs.shape == (5, 10)
     assert chisq.dtype == float
     assert nObs.dtype == int
-    assert np.allclose(chisq, 4.0)
-    assert np.allclose(nObs, 1)
-    assert np.allclose(chisq_per_ant[0, 'Jxx'], 4.0)
-    assert np.allclose(chisq_per_ant[1, 'Jxx'], 4.0)
-    assert np.allclose(nObs_per_ant[0, 'Jxx'], 1)
-    assert np.allclose(nObs_per_ant[1, 'Jxx'], 1)
+    np.testing.assert_array_equal(chisq, 4.0)
+    np.testing.assert_array_equal(nObs, 1)
+    np.testing.assert_array_equal(chisq_per_ant[0, 'Jxx'], 4.0)
+    np.testing.assert_array_equal(chisq_per_ant[1, 'Jxx'], 4.0)
+    np.testing.assert_array_equal(nObs_per_ant[0, 'Jxx'], 1)
+    np.testing.assert_array_equal(nObs_per_ant[1, 'Jxx'], 1)
 
     # test with reds
     data = datacontainer.DataContainer({(0, 1, 'xx'): np.ones((5, 10), dtype=complex),
                                         (1, 2, 'xx'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xx'): 2 * np.ones((5, 10), dtype=complex)})
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, reds=[[(0, 1, 'xx'), (1, 2, 'xx')]])
-    assert np.allclose(chisq, 2.0)
-    assert np.allclose(nObs, 2)
+    np.testing.assert_array_equal(chisq, 2.0)
+    np.testing.assert_array_equal(nObs, 2)
     assert (1, 2, 'xx') not in model
 
     # test with weights
@@ -386,12 +386,12 @@ def test_chisq():
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts)
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, chisq=chisq, nObs=nObs,
                                                            chisq_per_ant=chisq_per_ant, nObs_per_ant=nObs_per_ant)
-    assert np.allclose(chisq, 2.0)
-    assert np.allclose(nObs, 2)
-    assert np.allclose(chisq_per_ant[0, 'Jxx'], 2.0)
-    assert np.allclose(chisq_per_ant[1, 'Jxx'], 2.0)
-    assert np.allclose(nObs_per_ant[0, 'Jxx'], 2)
-    assert np.allclose(nObs_per_ant[1, 'Jxx'], 2)
+    np.testing.assert_array_equal(chisq, 2.0)
+    np.testing.assert_array_equal(nObs, 2)
+    np.testing.assert_array_equal(chisq_per_ant[0, 'Jxx'], 2.0)
+    np.testing.assert_array_equal(chisq_per_ant[1, 'Jxx'], 2.0)
+    np.testing.assert_array_equal(nObs_per_ant[0, 'Jxx'], 2)
+    np.testing.assert_array_equal(nObs_per_ant[1, 'Jxx'], 2)
 
     # test with gains and gain flags
     gains = {(0, 'Jxx'): .5**.5 * np.ones((5, 10), dtype=complex),
@@ -400,10 +400,10 @@ def test_chisq():
                   (1, 'Jxx'): np.zeros((5, 10), dtype=bool)}
     gain_flags[0, 'Jxx'][:, 0] = True
     chisq, nObs, chisq_per_ant, nObs_per_ant = utils.chisq(data, model, data_wgts, gains=gains, gain_flags=gain_flags)
-    assert np.allclose(np.sum(chisq), 0.0)
+    assert np.isclose(np.sum(chisq), 0.0)
     assert np.sum(nObs) == 45
-    assert np.allclose(np.sum(chisq_per_ant[0, 'Jxx']), 0.0)
-    assert np.allclose(np.sum(chisq_per_ant[1, 'Jxx']), 0.0)
+    assert np.isclose(np.sum(chisq_per_ant[0, 'Jxx']), 0.0)
+    assert np.isclose(np.sum(chisq_per_ant[1, 'Jxx']), 0.0)
     assert np.sum(nObs_per_ant[1, 'Jxx']) == 45
     assert np.sum(nObs_per_ant[1, 'Jxx']) == 45
 
@@ -429,8 +429,8 @@ def test_chisq():
     assert 'Jxx' in nObs
     assert chisq['Jxx'].shape == (5, 10)
     assert nObs['Jxx'].shape == (5, 10)
-    assert np.allclose(chisq['Jxx'], 1.0)
-    assert np.allclose(nObs['Jxx'], 1)
+    np.testing.assert_array_equal(chisq['Jxx'], 1.0)
+    np.testing.assert_array_equal(nObs['Jxx'], 1)
     data = datacontainer.DataContainer({(0, 1, 'xy'): np.ones((5, 10), dtype=complex)})
     model = datacontainer.DataContainer({(0, 1, 'xy'): 2 * np.ones((5, 10), dtype=complex)})
     data_wgts = datacontainer.DataContainer({(0, 1, 'xy'): np.ones((5, 10), dtype=float)})

--- a/hera_cal/tests/test_version.py
+++ b/hera_cal/tests/test_version.py
@@ -6,15 +6,15 @@
 
 from __future__ import print_function, division, absolute_import
 
-import nose.tools as nt
+import pytest
 import sys
 import os
 import six
 import subprocess
 import json
 
-import hera_cal
-from hera_cal.data import DATA_PATH
+from .. import version, __version__
+from ..data import DATA_PATH
 
 
 def test_get_gitinfo_file():
@@ -24,7 +24,7 @@ def test_get_gitinfo_file():
     if not os.path.exists(git_file):
         # write a file to read in
         temp_git_file = os.path.join(DATA_PATH, 'test_output/GIT_INFO')
-        version_info = hera_cal.version.construct_version_info()
+        version_info = version.construct_version_info()
         data = [version_info['git_origin'], version_info['git_origin'],
                 version_info['git_origin'], version_info['git_origin']]
         with open(temp_git_file, 'w') as outfile:
@@ -32,7 +32,7 @@ def test_get_gitinfo_file():
         git_file = temp_git_file
 
     with open(git_file) as data_file:
-        data = [hera_cal.version._unicode_to_str(x) for x in json.loads(data_file.read().strip())]
+        data = [version._unicode_to_str(x) for x in json.loads(data_file.read().strip())]
         git_origin = data[0]
         git_hash = data[1]
         git_description = data[2]
@@ -42,12 +42,12 @@ def test_get_gitinfo_file():
                       'git_description': git_description, 'git_branch': git_branch}
 
     if 'temp_git_file' in locals():
-        file_info = hera_cal.version._get_gitinfo_file(git_file=temp_git_file)
+        file_info = version._get_gitinfo_file(git_file=temp_git_file)
         os.remove(temp_git_file)
     else:
-        file_info = hera_cal.version._get_gitinfo_file()
+        file_info = version._get_gitinfo_file()
 
-    nt.assert_equal(file_info, test_file_info)
+    assert file_info == test_file_info
 
 
 def test_construct_version_info():
@@ -102,39 +102,39 @@ def test_construct_version_info():
             git_description = ''
             git_branch = ''
 
-    test_version_info = {'version': hera_cal.__version__, 'git_origin': git_origin,
+    test_version_info = {'version': __version__, 'git_origin': git_origin,
                          'git_hash': git_hash, 'git_description': git_description,
                          'git_branch': git_branch}
 
-    nt.assert_equal(hera_cal.version.construct_version_info(), test_version_info)
+    assert version.construct_version_info() == test_version_info
 
 
 def test_history_string():
-    hs = hera_cal.version.history_string()
-    nt.assert_true('function test_history_string() in test_version.py' in hs)
-    version_info = hera_cal.version.construct_version_info()
+    hs = version.history_string()
+    assert 'function test_history_string() in test_version.py' in hs
+    version_info = version.construct_version_info()
     for k, v in version_info.items():
-        nt.assert_true(k in hs)
-        nt.assert_true(v in hs)
-    hs = hera_cal.version.history_string('stuff')
-    nt.assert_true('stuff' in hs)
-    nt.assert_true('Notes' in hs)
+        assert k in hs
+        assert v in hs
+    hs = version.history_string('stuff')
+    assert 'stuff' in hs
+    assert 'Notes' in hs
 
 
 def test_main():
-    version_info = hera_cal.version.construct_version_info()
+    version_info = version.construct_version_info()
 
     saved_stdout = sys.stdout
     try:
         out = six.StringIO()
         sys.stdout = out
-        hera_cal.version.main()
+        version.main()
         output = out.getvalue()
-        nt.assert_equal(output, 'Version = {v}\ngit origin = {o}\n'
-                        'git branch = {b}\ngit description = {d}\n'
-                        .format(v=version_info['version'],
-                                o=version_info['git_origin'],
-                                b=version_info['git_branch'],
-                                d=version_info['git_description']))
+        assert output == ('Version = {v}\ngit origin = {o}\n'
+                          'git branch = {b}\ngit description = {d}\n'
+                          .format(v=version_info['version'],
+                                  o=version_info['git_origin'],
+                                  b=version_info['git_branch'],
+                                  d=version_info['git_description']))
     finally:
         sys.stdout = saved_stdout

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -152,7 +152,7 @@ class Test_VisClean(object):
         delays = V.delays
         assert hasattr(V, 'foo')
         V.fft_data(keys=[(24, 25, 'xx')], assign='foo', overwrite=True, ifft=False, fftshift=False)
-        assert np.allclose(delays, np.fft.fftshift(V.delays))
+        np.testing.assert_array_almost_equal(delays, np.fft.fftshift(V.delays))
 
         # test flag factorization
         flags = V.factorize_flags(inplace=False, time_thresh=0.05)

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-import unittest
+import pytest
 import numpy as np
 from copy import deepcopy
 import os
@@ -12,7 +12,6 @@ import sys
 import shutil
 from scipy import constants
 from pyuvdata import UVCal, UVData
-import nose.tools as nt
 
 from hera_cal import io, datacontainer
 from hera_cal import vis_clean
@@ -20,27 +19,29 @@ from hera_cal.vis_clean import VisClean
 from hera_cal.data import DATA_PATH
 
 
-class Test_VisClean(unittest.TestCase):
+@pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
+@pytest.mark.filterwarnings("ignore:It seems that the latitude and longitude are in radians")
+class Test_VisClean(object):
 
     def test_init(self):
         # test basic init
         fname = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
         V = VisClean(fname, filetype='uvh5')
-        nt.assert_false(hasattr(V, 'data'))
+        assert not hasattr(V, 'data')
         V.read(bls=[(24, 25, 'xx')])
-        nt.assert_true(hasattr(V, 'data'))
-        nt.assert_true(hasattr(V, 'antpos'))
-        nt.assert_true(isinstance(V.hd, io.HERAData))
-        nt.assert_true(isinstance(V.hd.data_array, np.ndarray))
+        assert hasattr(V, 'data')
+        assert hasattr(V, 'antpos')
+        assert isinstance(V.hd, io.HERAData)
+        assert isinstance(V.hd.data_array, np.ndarray)
 
         # test basic init w/ uvh5
         fname = os.path.join(DATA_PATH, 'zen.2458098.43124.subband.uvh5')
         V = VisClean(fname, filetype='uvh5')
-        nt.assert_false(hasattr(V, 'data'))
+        assert not hasattr(V, 'data')
         V.read(bls=[(13, 14, 'xx')])
-        nt.assert_equal(set(V.hd.ant_1_array), set([13]))
-        nt.assert_true(isinstance(V.hd, io.HERAData))
-        nt.assert_true(isinstance(V.hd.data_array, np.ndarray))
+        assert set(V.hd.ant_1_array) == set([13])
+        assert isinstance(V.hd, io.HERAData)
+        assert isinstance(V.hd.data_array, np.ndarray)
 
         # test input cal
         fname = os.path.join(DATA_PATH, 'zen.2458043.12552.xx.HH.uvORA')
@@ -52,55 +53,57 @@ class Test_VisClean(unittest.TestCase):
         V2 = VisClean(fname, filetype='miriad', input_cal=uvc)
         V2.read(bls=[bl])
         g = gains[(bl[0], 'Jxx')] * gains[(bl[1], 'Jxx')].conj()
-        nt.assert_almost_equal((V1.data[bl] / g)[30, 30], V2.data[bl][30, 30])
+        assert np.allclose((V1.data[bl] / g)[30, 30], V2.data[bl][30, 30])
         V2.apply_calibration(V2.hc, unapply=True)
-        nt.assert_almost_equal(V1.data[bl][30, 30], V2.data[bl][30, 30], places=5)
+        assert np.allclose(V1.data[bl][30, 30], V2.data[bl][30, 30], atol=1e-5)
 
         # test soft copy
         V1.hello = 'hi'
         V1.hello_there = 'bye'
         V1.foo = 'bar'
         V3 = V1.soft_copy(references=["hello*"])
-        nt.assert_equal(hex(id(V1.data[(52, 53, 'xx')])), hex(id(V3.data[(52, 53, 'xx')])))
-        nt.assert_true(hasattr(V3, 'hello'))
-        nt.assert_true(hasattr(V3, 'hello_there'))
-        nt.assert_false(hasattr(V3, 'foo'))
-        nt.assert_equal(V3.__class__, VisClean)
+        assert hex(id(V1.data[(52, 53, 'xx')])) == hex(id(V3.data[(52, 53, 'xx')]))
+        assert hasattr(V3, 'hello')
+        assert hasattr(V3, 'hello_there')
+        assert not hasattr(V3, 'foo')
+        assert V3.__class__ == VisClean
 
         # test clear
         V1.clear_containers()
-        nt.assert_true(np.all([len(getattr(V1, c)) == 0 for c in ['data', 'flags', 'nsamples']]))
+        assert np.all([len(getattr(V1, c)) == 0 for c in ['data', 'flags', 'nsamples']])
         V2.clear_calibration()
-        nt.assert_false(hasattr(V2, 'hc'))
+        assert not hasattr(V2, 'hc')
 
+    @pytest.mark.filterwarnings("ignore:Selected polarization values are not evenly spaced")
     def test_read_write(self):
         # test read data can be turned off for uvh5
         fname = os.path.join(DATA_PATH, 'zen.2458098.43124.subband.uvh5')
         V = VisClean(fname, filetype='uvh5')
         V.read(read_data=False)
-        nt.assert_equal(set(V.hd.ant_1_array), set([1, 11, 12, 13, 14]))
+        assert set(V.hd.ant_1_array) == set([1, 11, 12, 13, 14])
 
         # test read-write-read
         V.read()
         V.write_data(V.data, "./ex.uvh5", overwrite=True, filetype='uvh5', vis_units='Jy')
         V2 = VisClean("./ex.uvh5", filetype='uvh5')
         V2.read()
-        nt.assert_equal(V2.hd.vis_units, 'Jy')
-        nt.assert_true('Thisfilewasproducedbythefunction' in V2.hd.history.replace('\n', '').replace(' ', ''))
+        assert V2.hd.vis_units == 'Jy'
+        assert 'Thisfilewasproducedbythefunction' in V2.hd.history.replace('\n', '').replace(' ', '')
         V.hd.history, V2.hd.history, V2.hd.vis_units = '', '', V.hd.vis_units
-        nt.assert_equal(V.hd, V2.hd)
+        assert V.hd == V2.hd
         os.remove("./ex.uvh5")
 
         # exceptions
-        nt.assert_raises(ValueError, V.write_data, V.data, 'foo', filetype='what')
+        pytest.raises(ValueError, V.write_data, V.data, 'foo', filetype='what')
 
         # test write on subset of data
         V.read(read_data=True)
         data = datacontainer.DataContainer(dict([(k, V.data[k]) for k in list(V.data.keys())[:2]]))
         V.write_data(data, "ex.uvh5", overwrite=True, filetype='uvh5')
-        nt.assert_true(os.path.exists("ex.uvh5"))
+        assert os.path.exists("ex.uvh5")
         os.remove('ex.uvh5')
 
+    @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
         V = VisClean(fname, filetype='uvh5')
@@ -111,21 +114,21 @@ class Test_VisClean(unittest.TestCase):
 
         # basic freq clean
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='freq', overwrite=True)
-        nt.assert_true(np.all([i['success'] for i in V.clean_info[(24, 25, 'xx')]]))
+        assert np.all([i['success'] for i in V.clean_info[(24, 25, 'xx')]])
 
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='time', max_frate=10., overwrite=True)
-        nt.assert_true('skipped' in V.clean_info[(24, 25, 'xx')][0])
-        nt.assert_true('success' in V.clean_info[(24, 25, 'xx')][3])
+        assert 'skipped' in V.clean_info[(24, 25, 'xx')][0]
+        assert 'success' in V.clean_info[(24, 25, 'xx')][3]
 
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='both', max_frate=10., overwrite=True,
                     filt2d_mode='plus')
-        nt.assert_true('success' in V.clean_info[(24, 25, 'xx')])
+        'success' in V.clean_info[(24, 25, 'xx')]
 
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')
-        nt.assert_true('skipped' in V.clean_info[(24, 25, 'xx')])
+        assert 'skipped' in V.clean_info[(24, 25, 'xx')]
 
         # test fft data
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='both', max_frate=10., overwrite=True,
@@ -133,28 +136,28 @@ class Test_VisClean(unittest.TestCase):
 
         # assert foreground peak is at 0 delay bin
         V.fft_data(data=V.clean_model, keys=[(24, 25, 'xx')], ax='freq', window='hann', edgecut_low=10, edgecut_hi=10, overwrite=True)
-        nt.assert_equal(np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=0)), 32)
+        assert np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=0)) == 32
 
         # assert foreground peak is at 0 FR bin (just due to FR resolution)
         V.fft_data(data=V.clean_model, keys=[(24, 25, 'xx')], ax='time', window='hann', edgecut_low=10, edgecut_hi=10, overwrite=True)
-        nt.assert_equal(np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=1)), 30)
+        assert np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=1)) == 30
 
         # assert foreground peak is at both 0 FR and 0 delay bin
         V.fft_data(data=V.clean_model, keys=[(24, 25, 'xx')], ax='both', window='tukey', alpha=0.5, edgecut_low=10, edgecut_hi=10, overwrite=True)
-        nt.assert_equal(np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=0)), 32)
-        nt.assert_equal(np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=1)), 30)
+        assert np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=0)) == 32
+        assert np.argmax(np.mean(np.abs(V.dfft[(24, 25, 'xx')]), axis=1)) == 30
 
         # check various kwargs
         V.fft_data(keys=[(24, 25, 'xx')], assign='foo', ifft=True, fftshift=True)
         delays = V.delays
-        nt.assert_true(hasattr(V, 'foo'))
+        assert hasattr(V, 'foo')
         V.fft_data(keys=[(24, 25, 'xx')], assign='foo', overwrite=True, ifft=False, fftshift=False)
-        np.testing.assert_array_almost_equal(delays, np.fft.fftshift(V.delays))
+        assert np.allclose(delays, np.fft.fftshift(V.delays))
 
         # test flag factorization
         flags = V.factorize_flags(inplace=False, time_thresh=0.05)
-        nt.assert_true(flags[(24, 25, 'xx')][45, :].all())
-        nt.assert_true(flags[(24, 25, 'xx')][:, 5].all())
+        assert np.all(flags[(24, 25, 'xx')][45, :])
+        assert np.all(flags[(24, 25, 'xx')][:, 5])
 
     def test_fft_data(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
@@ -163,12 +166,12 @@ class Test_VisClean(unittest.TestCase):
 
         # fft
         V.fft_data(zeropad=30, ifft=False)
-        nt.assert_equal(V.dfft[(24, 25, 'xx')].shape, (60, 124))
+        assert V.dfft[(24, 25, 'xx')].shape == (60, 124)
 
         # exceptions
-        nt.assert_raises(ValueError, V.fft_data, ax='foo')
-        nt.assert_raises(ValueError, V.fft_data, keys=[])
-        nt.assert_raises(ValueError, V.fft_data, keys=[('foo')])
+        pytest.raises(ValueError, V.fft_data, ax='foo')
+        pytest.raises(ValueError, V.fft_data, keys=[])
+        pytest.raises(ValueError, V.fft_data, keys=[('foo')])
 
     def test_zeropad(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
@@ -177,38 +180,38 @@ class Test_VisClean(unittest.TestCase):
 
         # test basic zeropad
         d, _ = vis_clean.zeropad_array(V.data[(24, 25, 'xx')], zeropad=30, axis=-1, undo=False)
-        nt.assert_equal(d.shape, (60, 124))
-        nt.assert_true(np.isclose(d[:, :30], 0.0).all())
-        nt.assert_true(np.isclose(d[:, -30:], 0.0).all())        
+        assert d.shape == (60, 124)
+        assert np.allclose(d[:, :30], 0.0)
+        assert np.allclose(d[:, -30:], 0.0)
         d, _ = vis_clean.zeropad_array(d, zeropad=30, axis=-1, undo=True)
-        nt.assert_equal(d.shape, (60, 64))
+        assert d.shape == (60, 64)
 
         # test zeropad with bool
         f, _ = vis_clean.zeropad_array(V.flags[(24, 25, 'xx')], zeropad=30, axis=-1, undo=False)
-        nt.assert_equal(f.shape, (60, 124))
-        nt.assert_true(np.all(f[:, :30]))
-        nt.assert_true(np.all(f[:, -30:]))
+        assert f.shape == (60, 124)
+        assert np.all(f[:, :30])
+        assert np.all(f[:, -30:])
 
         # zeropad with binvals
         d, bval = vis_clean.zeropad_array(V.data[(24, 25, 'xx')], zeropad=30, axis=0, binvals=V.times)
-        nt.assert_almost_equal(np.median(np.diff(V.times)), np.median(np.diff(bval)))
-        nt.assert_equal(len(bval), 120)
+        assert np.allclose(np.median(np.diff(V.times)), np.median(np.diff(bval)))
+        assert len(bval) == 120
 
         # 2d zeropad
         d, bval = vis_clean.zeropad_array(V.data[(24, 25, 'xx')], zeropad=(30, 10), axis=(0, 1), binvals=[V.times, V.freqs])
-        nt.assert_equal(d.shape, (120, 84))
-        nt.assert_equal((bval[0].size, bval[1].size), (120, 84))
+        assert d.shape == (120, 84)
+        assert (bval[0].size, bval[1].size) == (120, 84)
 
         # un-pad with bval
         d, bval = vis_clean.zeropad_array(d, zeropad=(30, 10), axis=(0, 1), binvals=bval, undo=True)
-        nt.assert_equal(d.shape, (60, 64))
-        nt.assert_equal((bval[0].size, bval[1].size), (60, 64))
+        assert d.shape == (60, 64)
+        assert (bval[0].size, bval[1].size) == (60, 64)
 
         # test VisClean method
         V.zeropad_data(V.data, binvals=V.times, zeropad=10, axis=0, undo=False)
-        nt.assert_equal(V.data[(24, 25, 'xx')].shape, (80, 64))
-        nt.assert_equal(V.data.binvals.size, 80)
+        assert V.data[(24, 25, 'xx')].shape == (80, 64)
+        assert V.data.binvals.size == 80
 
         # exceptions
-        nt.assert_raises(ValueError, vis_clean.zeropad_array, V.data[(24, 25, 'xx')], axis=(0, 1), zeropad=0)
-        nt.assert_raises(ValueError, vis_clean.zeropad_array, V.data[(24, 25, 'xx')], axis=(0, 1), zeropad=(0,))
+        pytest.raises(ValueError, vis_clean.zeropad_array, V.data[(24, 25, 'xx')], axis=(0, 1), zeropad=0)
+        pytest.raises(ValueError, vis_clean.zeropad_array, V.data[(24, 25, 'xx')], axis=(0, 1), zeropad=(0,))

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -124,7 +124,7 @@ class Test_VisClean(object):
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='both', max_frate=10., overwrite=True,
                     filt2d_mode='plus')
-        'success' in V.clean_info[(24, 25, 'xx')]
+        assert 'success' in V.clean_info[(24, 25, 'xx')]
 
         V.vis_clean(keys=[(24, 25, 'xx'), (24, 24, 'xx')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -828,6 +828,7 @@ def zeropad_array(data, binvals=None, zeropad=0, axis=-1, undo=False):
             if undo:
                 s = [slice(None) for j in range(data.ndim)]
                 s[ax] = slice(zeropad[i], -zeropad[i])
+                s = tuple(s)
                 data = data[s]
                 if binvals[i] is not None:
                     binvals[i] = binvals[i][s[i]]


### PR DESCRIPTION
This PR converts the testing framework of hera_cal from nose (which is deprecated and may go away in the future) to pytest, which is more fully featured and has much broader support. The docs are [here](https://docs.pytest.org/en/latest/contents.html), but the tl;dr is:
- Tests use bare `assert` statements rather than `nt.assert_true` or `nt.assert_equal`-type statements.
- Raising of errors is testing by calling `pytest.raises`, with similar syntax to nose's `nt.assert_raises` or unittest's `self.assertRaises`.
- Specific warnings (such as floating point exceptions) can be easily filtered using function decorators (some examples of which are [here](https://github.com/HERA-Team/hera_cal/blob/940f882ca9e15ccc5d45fe93e3285db3444b8534/hera_cal/tests/test_abscal.py#L31) and [here](https://github.com/HERA-Team/hera_cal/blob/940f882ca9e15ccc5d45fe93e3285db3444b8534/hera_cal/tests/test_delay_filter.py#L22)).
- Tests can be invoked from anywhere inside of the repo, by calling `pytest` to run all tests or, e.g., `pytest test_delay_filter.py::Test_DelayFilter::test_run_filter`.

The PR updates the travis script accordingly, and also fixes a few small warnings that were being hidden behind the large number of (relatively) benign warnings triggered by the tests.

@jsdillon there isn't a huge time pressure on this, so feel free to wait until after IDR2.2 is done before reviewing/merging. Just wanted to have your eyes on it so we can make sure new tests use this framework going forward.