### PR TITLE
Make predict_noise_variance_from_autos nsamples-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ hera_cal/data/test_output/*
 # Test notebooks
 hera_cal/notebooks
 *.ipynb_checkpoints*
+.pytest_cache*

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy pip matplotlib coverage pandas scikit-learn h5py six pytest-cov coveralls cached-property
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy pycodestyle attrs h5py healpy pyyaml
+  - conda install -c conda-forge healpy aipy pycodestyle attrs h5py healpy pyyaml mpi4py
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/hera_qm.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy pip matplotlib coverage pandas scikit-learn h5py six pytest-cov coveralls cached-property
   - source activate test-environment
-  - conda install -c conda-forge healpy aipy pycodestyle
+  - conda install -c conda-forge healpy aipy pycodestyle attrs h5py healpy pyyaml
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
   - pip install git+https://github.com/HERA-Team/hera_qm.git

--- a/hera_cal/tests/test_noise.py
+++ b/hera_cal/tests/test_noise.py
@@ -62,8 +62,7 @@ class Test_Noise(object):
 
                 nsamples[k] *= 2
                 sigmasq3 = noise.predict_noise_variance_from_autos(k, data, nsamples=nsamples)
-                np.testing.assert_array_equal(sigmasq/2.0, sigmasq3)
-
+                np.testing.assert_array_equal(sigmasq / 2.0, sigmasq3)
 
     def test_per_antenna_noise_std(self):
         infile = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')

--- a/hera_cal/tests/test_noise.py
+++ b/hera_cal/tests/test_noise.py
@@ -55,9 +55,15 @@ class Test_Noise(object):
                 sigmasq = noise.predict_noise_variance_from_autos(k, data)
                 noise_var = noise.interleaved_noise_variance_estimate(data[k])
                 np.testing.assert_array_equal(np.abs(np.mean(np.mean(noise_var, axis=0) / np.mean(sigmasq, axis=0)) - 1) <= .1, True)
+                
                 times = hd.times_by_bl[k[:2]]
                 sigmasq2 = noise.predict_noise_variance_from_autos(k, data, df=(hd.freqs[1] - hd.freqs[0]), dt=((times[1] - times[0]) * 24. * 3600.))
                 np.testing.assert_array_equal(sigmasq, sigmasq2)
+
+                nsamples[k] *= 2
+                sigmasq3 = noise.predict_noise_variance_from_autos(k, data, nsamples=nsamples)
+                np.testing.assert_array_equal(sigmasq/2.0, sigmasq3)
+
 
     def test_per_antenna_noise_std(self):
         infile = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')


### PR DESCRIPTION
As I showed in the note attached to #490, this PR satisfies your request on Tuesday's pspec telecon for a metric of the thermal noise on LST-binned data, @acliu

However, I do not think it makes sense to add this step to the pipeline that produces a separate data product. Unlikely in the case when nsamples = 1, the noise on a given baseline is not given by the product of two-antenna based quantities. If we want to write down this noise, it would be the same size as the because each baseline could have a unique nsamples array. However, if you have the lst-binned autocorrelations and the nsample array for a given baseline in memory, this function will serve to do what we want.

As a side note, it remains to be shown that calibrated autocorrelations don't vary substantially from day to day (as assumed here, see #490).

This PR closes #412.