### PR TITLE
Fix smooth_cal delay Issues by implementing a single per-night, per-antenna delay.

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -272,13 +272,12 @@ def pick_reference_antenna(gains, flags, freqs, per_pol=True):
             if per_pol: dictionary mapping gain polarizations string to ant-pol tuples
             else: ant-pol tuple e.g. (0, 'Jxx')
     '''
-    # compute delay and phase for all gains to flatten them as well as possible. Average over times.
-    df = np.median(np.diff(freqs))
+    # compute delay for all gains to flatten them as well as possible. Average over times.
     rephasors = {}
     for ant in gains.keys():
         wgts = np.array(~(flags[ant]), dtype=float)
-        (dlys, phis) = utils.fft_dly(gains[ant], df, wgts, medfilt=False, f0=freqs[0])
-        rephasors[ant] = np.exp(-2.0j * np.pi * np.mean(dlys), freqs - 1.0j * np.mean(phis))
+        dly = single_iterative_fft_dly(gains[ant], wgts, freqs)
+        rephasors[ant] = np.exp(-2.0j * np.pi * dly * freqs)
 
     def narrow_refant_candidates(candidates):
         '''Helper function for comparing refant candidates to another another looking for the one with the 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -35,6 +35,9 @@ def single_iterative_fft_dly(gains, wgts, freqs, conv_crit=1e-5, maxiter=100):
     Returns:
         tau: float, single best fit delay in s
     '''
+    if np.sum(wgts) == 0:  # if all flagged, return 0 delay
+        return 0.0
+
     df = np.median(np.diff(freqs))
     gains = deepcopy(gains)
     gains[wgts <= 0] = np.nan

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -60,8 +60,8 @@ class Test_Smooth_Cal_Helper_Functions(object):
         # try with flags
         gains = np.ones((2, 1000), dtype=complex)
         wgts = np.ones((2, 1000), dtype=float)
-        wgts[:,0:40] = 0.0
-        wgts[:,900:] = 0.0
+        wgts[:, 0:40] = 0.0
+        wgts[:, 900:] = 0.0
         freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
         gains *= np.exp(2.0j * np.pi * np.outer(-151e-9 * np.ones(2), freqs))
         dly = smooth_cal.single_iterative_fft_dly(gains, wgts, freqs)

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -47,6 +47,26 @@ class Test_Smooth_Cal_Helper_Functions(object):
         tf = smooth_cal.time_filter(gains, wgts, times, filter_scale=1800.0, nMirrors=1)
         np.testing.assert_array_almost_equal(tf, np.ones((10, 10), dtype=complex))
 
+    @pytest.mark.filterwarnings("ignore: Mean of empty slice")
+    def test_single_iterative_fft_dly(self):
+        # try without flags
+        gains = np.ones((2, 1000), dtype=complex)
+        wgts = np.ones((2, 1000), dtype=float)
+        freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
+        gains *= np.exp(2.0j * np.pi * np.outer(151e-9 * np.ones(2), freqs))
+        dly = smooth_cal.single_iterative_fft_dly(gains, wgts, freqs)
+        np.testing.assert_array_almost_equal(dly, 151e-9)
+
+        # try with flags
+        gains = np.ones((2, 1000), dtype=complex)
+        wgts = np.ones((2, 1000), dtype=float)
+        wgts[:,0:40] = 0.0
+        wgts[:,900:] = 0.0
+        freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
+        gains *= np.exp(2.0j * np.pi * np.outer(-151e-9 * np.ones(2), freqs))
+        dly = smooth_cal.single_iterative_fft_dly(gains, wgts, freqs)
+        np.testing.assert_array_almost_equal(dly, -151e-9)
+
     def test_freq_filter(self):
         gains = np.ones((10, 10), dtype=complex)
         gains[3, 5] = 10.0

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -67,6 +67,13 @@ class Test_Smooth_Cal_Helper_Functions(object):
         dly = smooth_cal.single_iterative_fft_dly(gains, wgts, freqs)
         np.testing.assert_array_almost_equal(dly, -151e-9)
 
+        # try all flagged
+        gains = np.ones((2, 1000), dtype=complex)
+        wgts = np.zeros((2, 1000), dtype=float)
+        freqs = np.linspace(100., 200., 1000, endpoint=False) * 1e6
+        gains *= np.exp(2.0j * np.pi * np.outer(-151e-9 * np.ones(2), freqs))
+        assert smooth_cal.single_iterative_fft_dly(gains, wgts, freqs) == 0
+
     def test_freq_filter(self):
         gains = np.ones((10, 10), dtype=complex)
         gains[3, 5] = 10.0

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -123,6 +123,7 @@ def fft_dly(data, df, wgts=None, f0=0.0, medfilt=False, kernel=(1, 11), edge_cut
 
     # smooth via median filter
     if medfilt:
+        data = deepcopy(data)  # this prevents filtering of the original input data
         data.real = signal.medfilt(data.real, kernel_size=kernel)
         data.imag = signal.medfilt(data.imag, kernel_size=kernel)
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -123,7 +123,7 @@ def fft_dly(data, df, wgts=None, f0=0.0, medfilt=False, kernel=(1, 11), edge_cut
 
     # smooth via median filter
     if medfilt:
-        data = deepcopy(data)  # this prevents filtering of the original input data
+        data = copy.deepcopy(data)  # this prevents filtering of the original input data
         data.real = signal.medfilt(data.real, kernel_size=kernel)
         data.imag = signal.medfilt(data.imag, kernel_size=kernel)
 


### PR DESCRIPTION
This closes #493 by finding a single per-night, per-antenna delay and using that to recenter the gain in delay space before smoothing.

In my initial test on the most problematic gain I found from the current smooth_cal results (the one I showed in #493 and in the analysis Slack), this seems to have fixed the problem:

![image](https://user-images.githubusercontent.com/5281139/59724156-bd39ea00-91dd-11e9-8494-2c42bbdb41c6.png)

where the axes are channel number vs. integration number.
