### PR TITLE
fix basic installation order issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pytest-cov coveralls
-  - conda activate test-environment
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest-cov coveralls
+  - source activate test-environment
   - conda env update -n test-environment -f environment.yml
   - pip install .
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,11 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy pip matplotlib coverage pandas scikit-learn h5py six pytest-cov coveralls cached-property psutil
-  - source activate test-environment
-  - conda install -c conda-forge healpy aipy pycodestyle attrs h5py healpy pyyaml mpi4py
-  - pip install git+https://github.com/HERA-Team/pyuvdata.git
-  - pip install git+https://github.com/HERA-Team/pyuvsim.git
-  - pip install git+https://github.com/HERA-Team/linsolve.git
-  - pip install git+https://github.com/HERA-Team/hera_qm.git
-  - pip install git+https://github.com/HERA-Team/uvtools.git
-  - pip install git+https://github.com/HERA-Team/hera_sim.git
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pytest-cov coveralls
+  - conda activate test-environment
+  - conda env update -n test-environment -f environment.yml
+  - pip install .
   - conda list
-  - python --version
 script:
   - pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
   - pycodestyle . --ignore=E501,W291,W293,W503,W601

--- a/README.md
+++ b/README.md
@@ -7,47 +7,67 @@ The hera_cal package includes modules and scripts for calibration of HERA as par
 
 Full documentation available on [Read the Docs.](http://hera_cal.readthedocs.io/en/latest/)
 
-# Package Details
+## Package Details
 
-## Modules
+### Modules
 
-* hera_cal.firstcal: module includes the FirstCalRedundantInfo class, FirstCal class that solves for delays, and other helper functions.
+* `hera_cal.firstcal`: module includes the `FirstCalRedundantInfo` class, `FirstCal` 
+  class that solves for delays, and other helper functions.
 
-* hera_cal.omni: includes functions and classes for interfacing with and running omnical.
+* `hera_cal.omni`: includes functions and classes for interfacing with and running 
+  `omnical`.
 
-* hera_cal.abscal: includes AbsCal class for phasing and scaling visibility data to an absolute reference. See scripts/notebook/running_abscal.ipynb for a quick tutorial. Functionalities include:
+* `hera_cal.abscal`: includes `AbsCal` class for phasing and scaling visibility data to 
+  an absolute reference. See `scripts/notebook/running_abscal.ipynb` for a quick 
+  tutorial. Functionalities include:
     1. scaling raw data to an absolute (visibility) reference
     2. scaling omnicalibrated data to an absolute (visibility) reference
-    3. scaling omnical unique-baseline visibility solutions to an absolute reference (still beta testing this capability)
+    3. scaling omnical unique-baseline visibility solutions to an absolute reference 
+       (still beta testing this capability)
 
-* hera_cal.lstbin: includes functions for LST-aligning visibility data, and LST binning files overlapping in LST. See scripts/notebooks/running_lstbin.ipynb for a brief tutorial.
+* `hera_cal.lstbin`: includes functions for LST-aligning visibility data, and LST-binning 
+  files overlapping in LST. See `scripts/notebooks/running_lstbin.ipynb` for a brief 
+  tutorial.
 
-## Scripts
+### Scripts
 
-* firstcal\_run.py: runs firstcal on a per file basis.
-* omni\_run.py: runs omnical on a per file basis.
-* omni\_apply.py: apply calibration solutions to miriad files.
-* abscal\_run.py: run absolute calibration given a data file and model file(s)
-* lstbin\_run.py: run LST binning on series of files overlapping in LST.
+* `firstcal\_run.py`: runs firstcal on a per file basis.
+* `omni\_run.py`: runs omnical on a per file basis.
+* `omni\_apply.py`: apply calibration solutions to miriad files.
+* `abscal\_run.py`: run absolute calibration given a data file and model file(s)
+* `lstbin\_run.py`: run LST binning on series of files overlapping in LST.
 
-# Installation
-## Dependencies
-First install dependencies. 
+## Installation
+Preferred installation method is `pip install .` in top-level directory. Alternatively,
+one can use `python setup.py install`. This will attempt to install all dependencies.
+If you prefer to explicitly manage dependencies, see below.
 
-* numpy >= 1.10
-* scipy
-* astropy >=1.2
+### Dependencies
+Those who use `conda` (preferred) may wish to install the following manually before 
+installing `hera_cal`:
+
+`conda install -c conda-forge "numpy>=1.10" scipy scikit-learn h5py astropy pyuvdata "aipy>=3.0rc2"`
+
+(note that `h5py` is a dependency of `hera_qm`, not `hera_cal`).
+
+Other dependencies that will be installed from PyPI on-the-fly are:
 * pyephem
 * [uvtools](https://github.com/HERA-Team/uvtools)
-* [aipy](https://github.com/HERA-Team/aipy/)
-* [pyuvdata](https://github.com/HERA-Team/pyuvdata/)
 * [linsolve](https://github.com/HERA-Team/linsolve)
 * [hera_qm](https://github.com/HERA-Team/hera_qm)
-* [hera_sim](https://github.com/HERA-Team/hera_sim) (Only required for unit tests.)
 
-## Install hera_cal
-Install with ```python setup.py install```
+### Development Environment
+To install a full development environment for `hera_cal`, it is preferred to work with
+a fresh `conda` environment. These steps will get you up and running::
 
-## Running tests
+    $ conda create -n hera_cal python=3
+    $ conda activate hera_cal
+    $ conda env update -n hera_cal -f environment.yml
+    $ pip install -e . 
+
+This installs extra packages than those required to use `hera_cal`, including `hera_sim`
+and `pytest`.
+
+### Running tests
 Tests use the `pytest` framework. To run all tests, call `pytest` or
 `python -m pytest` from the base directory of the repo.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: hera_cal
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pip
+  - aipy>=3.0.0rc2
+  - astropy
+  - h5py
+  - numpy>=1.10
+  - pytest
+  - pyuvdata
+  - scipy
+  - scikit-learn
+  - mpi4py
+  - pyyaml
+  - pip:
+    - git+https://github.com/HERA-Team/hera_qm
+    - git+https://github.com/HERA-Team/linsolve
+    - pyephem
+    - pyuvsim
+    - git+https://github.com/HERA-Team/uvtools
+    - git+https://github.com/HERA-Team/hera_sim

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - scikit-learn
   - mpi4py
   - pyyaml
+  - pycodestyle
   - pip:
     - git+https://github.com/HERA-Team/hera_qm
     - git+https://github.com/HERA-Team/linsolve

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - mpi4py
   - pyyaml
   - pycodestyle
+  - psutil
   - pip:
     - git+https://github.com/HERA-Team/hera_qm
     - git+https://github.com/HERA-Team/linsolve

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup
-import glob
+
 import os
 import sys
-from hera_cal import version
 import json
+
+sys.path.append("hera_cal")
+import version
 
 data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]
 with open(os.path.join('hera_cal', 'GIT_INFO'), 'w') as outfile:
@@ -40,6 +42,18 @@ setup_args = {
                 'scripts/auto_reflection_run.py', 'scripts/noise_from_autos.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
+    'install_requires':[
+        'numpy>=1.10',
+        'scipy',
+        'astropy',
+        'pyuvdata',
+        'aipy>=3.0rc2',
+        'pyephem',
+        'uvtools @ git+git://github.com/HERA-Team/uvtools',
+        'linsolve @ git+git://github.com/HERA-Team/linsolve',
+        'hera_qm @ git+git://github.com/HERA-Team/hera_qm',
+        'scikit-learn'
+    ],
     'zip_safe': False,
 }
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import json
 
 sys.path.append("hera_cal")
-import version
+import version # noqa
 
 data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]
 with open(os.path.join('hera_cal', 'GIT_INFO'), 'w') as outfile:
@@ -42,7 +42,7 @@ setup_args = {
                 'scripts/auto_reflection_run.py', 'scripts/noise_from_autos.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
-    'install_requires':[
+    'install_requires': [
         'numpy>=1.10',
         'scipy',
         'astropy',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import json
 
 sys.path.append("hera_cal")
-import version # noqa
+import version  # noqa
 
 data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]
 with open(os.path.join('hera_cal', 'GIT_INFO'), 'w') as outfile:


### PR DESCRIPTION
This PR tries to fix the installation-order issue, similar to the way it was implemented in `pyuvdata` recently.

Along with this, I've amended the README installation instructions, and added a `conda` `environment.yml` file for simple development setup. There's a bit of debate whether this file should have absolutely pinned versions or not, but I've left them as free as the `install_requires` section in the `setup.py`. 

I've tested on a fresh environment, and everything seems to work.