### PR TITLE
Fix datacontainers to not conjugate non-complex numbers

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -115,7 +115,13 @@ class DataContainer:
             try:
                 return self._data[comply_bl(key)]
             except(KeyError):
-                return np.conj(self._data[reverse_bl(key)])
+                try:
+                    if np.iscomplexobj(self._data[reverse_bl(key)]): 
+                        return np.conj(self._data[reverse_bl(key)])
+                    else:
+                        return self._data[reverse_bl(key)]
+                except(KeyError):
+                    raise KeyError('Cannot find either {} or {} in this DataContainer.'.format(key, reverse_bl(key)))
 
     def __setitem__(self, key, value):
         '''Sets the data corresponding to the key. Only supports the form (0,1,'xx').
@@ -129,7 +135,10 @@ class DataContainer:
                 if key in self.keys():
                     self._data[key] = value
                 else:
-                    self._data[reverse_bl(key)] = np.conj(value)
+                    if np.iscomplexobj(value):
+                        self._data[reverse_bl(key)] = np.conj(value)
+                    else:
+                        self._data[reverse_bl(key)] = value
             else:
                 self._data[key] = value
                 self._antpairs.update({tuple(key[:2])})

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -37,7 +37,6 @@ class TestDataContainer(object):
             for bl in self.antpairs:
                 self.bools[bl + (pol,)] = np.array([True])
 
-
     def test_init(self):
         dc = datacontainer.DataContainer(self.blpol)
         for k in dc._data.keys():

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -32,6 +32,11 @@ class TestDataContainer(object):
         for pol in self.pols:
             for bl in self.antpairs:
                 self.both[bl + (pol,)] = 1j
+        self.bools = {}
+        for pol in self.pols:
+            for bl in self.antpairs:
+                self.bools[bl + (pol,)] = np.array([True])
+
 
     def test_init(self):
         dc = datacontainer.DataContainer(self.blpol)
@@ -185,6 +190,12 @@ class TestDataContainer(object):
         assert dc[(2, 1, 'XX')] == -1j
         assert dc[(2, 1, 'XX')] == dc.get_data(2, 1, 'XX')
         assert dc[(2, 1, 'XX')] == dc.get_data(2, 1, 'xx')
+        dc = datacontainer.DataContainer(self.bools)
+        assert dc[(1, 2, 'xx')] == np.array([True])
+        assert dc[(2, 1, 'xx')] == np.array([True])
+        assert dc[(2, 1, 'xx')].dtype == bool
+        with pytest.raises(KeyError, match=r".*(10, 1, 'xx').*(1, 10, 'xx).*"):
+            dc[(10, 1, 'xx')]
 
     def test_has_key(self):
         dc = datacontainer.DataContainer(self.blpol)
@@ -277,6 +288,12 @@ class TestDataContainer(object):
         assert 'xy' in dc._pols
         # test error
         pytest.raises(ValueError, dc.__setitem__, *((100, 101), 100j))
+
+        dc = datacontainer.DataContainer(self.bools)
+        dc[2, 1, 'xx'] = np.array([True])
+        assert dc[(1, 2, 'xx')] == np.array([True])
+        assert dc[(2, 1, 'xx')] == np.array([True])
+        assert dc[(2, 1, 'xx')].dtype == bool
 
     def test_adder(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")


### PR DESCRIPTION
This fixes an issue where arrays of booleans get converted into arrays of ints. I don't believe this affects the pipeline, I just noticed it in a notebook.

This closes #505 