### PR TITLE
fixed XX / YY 2pol mixup in AbsCal.custom_*

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2438,7 +2438,7 @@ class AbsCal(object):
         if hasattr(self, '_dly_slope'):
             # form dict of delay slopes for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            dly_slope_dict = {ants[0][1]: self.dly_slope[k[0]] for ants in self._gain_keys}
+            dly_slope_dict = {ants[0][1]: self.dly_slope[ants[0]] for ants in self._gain_keys}
 
             # turn delay slope into per-antenna complex gains, while iterating over input gain_keys
             dly_slope_gain = odict()
@@ -2503,7 +2503,7 @@ class AbsCal(object):
         if hasattr(self, '_phs_slope'):
             # form dict of phs slopes for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            phs_slope_dict = {ants[0][1]: self.phs_slope[k[0]] for ants in self._gain_keys}
+            phs_slope_dict = {ants[0][1]: self.phs_slope[ants[0]] for ants in self._gain_keys}
 
             # turn phs slope into per-antenna complex gains, while iterating over input gain_keys
             phs_slope_gain = odict()
@@ -2565,7 +2565,7 @@ class AbsCal(object):
         if hasattr(self, '_abs_eta'):
             # form dict of abs eta for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            abs_eta_dict = {ants[0][1]: self.abs_eta[k[0]] for ants in self._gain_keys}
+            abs_eta_dict = {ants[0][1]: self.abs_eta[ants[0]] for ants in self._gain_keys}
 
             # turn abs eta into per-antenna complex gains, while iterating over input gain_keys
             abs_eta_gain = odict()
@@ -2619,7 +2619,7 @@ class AbsCal(object):
         if hasattr(self, '_abs_psi'):
             # form dict of abs psi for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            abs_psi_dict = {ants[0][1]: self.abs_psi[k[0]] for ants in self._gain_keys}
+            abs_psi_dict = {ants[0][1]: self.abs_psi[ants[0]] for ants in self._gain_keys}
 
             # turn abs psi into per-antenna complex gains, while iterating over input gain_keys
             abs_psi_gain = odict()
@@ -2672,7 +2672,7 @@ class AbsCal(object):
         if hasattr(self, '_TT_Phi'):
             # form dict of TT_Phi for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            TT_Phi_dict = {ants[0][1]: self.TT_Phi[k[0]] for ants in self._gain_keys}
+            TT_Phi_dict = {ants[0][1]: self.TT_Phi[ants[0]] for ants in self._gain_keys}
 
             # turn TT_Phi into per-antenna complex gains, while iterating over input gain_keys
             TT_Phi_gain = odict()

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2423,6 +2423,7 @@ class AbsCal(object):
             # get dly_slope dictionary
             dly_slope = self.dly_slope
             # turn delay slope into per-antenna complex gains, while iterating over self._gain_keys
+            # einsum sums over antenna position
             return odict(list(map(lambda k: (k, np.exp(2j * np.pi * self.freqs.reshape(1, -1) * np.einsum("i...,i->...", dly_slope[k], self.antpos[k[0]][:2]))),
                                   flatten(self._gain_keys))))
         else:
@@ -2443,6 +2444,7 @@ class AbsCal(object):
             # turn delay slope into per-antenna complex gains, while iterating over input gain_keys
             dly_slope_gain = odict()
             for gk in gain_keys:
+                # einsum sums over antenna position
                 dly_slope_gain[gk] = np.exp(2j * np.pi * self.freqs.reshape(1, -1) * np.einsum("i...,i->...", dly_slope_dict[gk[1]], antpos[gk[0]][:2]))
             return dly_slope_gain
         else:
@@ -2460,6 +2462,7 @@ class AbsCal(object):
     def dly_slope_gain_arr(self):
         """ form complex gain from _dly_slope_arr array """
         if hasattr(self, '_dly_slope_arr'):
+            # einsum sums over antenna position
             return np.exp(2j * np.pi * self.freqs.reshape(-1, 1) * np.einsum("hi...,hi->h...", self._dly_slope_arr, self.antpos_arr[:, :2]))
         else:
             return None
@@ -2468,6 +2471,7 @@ class AbsCal(object):
     def dly_slope_ant_dly_arr(self):
         """ form antenna delays from _dly_slope_arr array """
         if hasattr(self, '_dly_slope_arr'):
+            # einsum sums over antenna position
             return np.einsum("hi...,hi->h...", self._dly_slope_arr, self.antpos_arr[:, :2])
         else:
             return None
@@ -2488,6 +2492,7 @@ class AbsCal(object):
             # get phs_slope dictionary
             phs_slope = self.phs_slope
             # turn phs slope into per-antenna complex gains, while iterating over self._gain_keys
+            # einsum sums over antenna position
             return odict(list(map(lambda k: (k, np.exp(1.0j * np.ones_like(self.freqs).reshape(1, -1) * np.einsum("i...,i->...", phs_slope[k], self.antpos[k[0]][:2]))),
                                   flatten(self._gain_keys))))
         else:
@@ -2508,6 +2513,7 @@ class AbsCal(object):
             # turn phs slope into per-antenna complex gains, while iterating over input gain_keys
             phs_slope_gain = odict()
             for gk in gain_keys:
+                # einsum sums over antenna position
                 phs_slope_gain[gk] = np.exp(1.0j * np.ones_like(self.freqs).reshape(1, -1) * np.einsum("i...,i->...", phs_slope_dict[gk[1]], antpos[gk[0]][:2]))
             return phs_slope_gain
 
@@ -2526,6 +2532,7 @@ class AbsCal(object):
     def phs_slope_gain_arr(self):
         """ form complex gain from _phs_slope_arr array """
         if hasattr(self, '_phs_slope_arr'):
+            # einsum sums over antenna position
             return np.exp(1.0j * np.ones_like(self.freqs).reshape(-1, 1) * np.einsum("hi...,hi->h...", self._phs_slope_arr, self.antpos_arr[:, :2]))
         else:
             return None
@@ -2534,6 +2541,7 @@ class AbsCal(object):
     def phs_slope_ant_phs_arr(self):
         """ form antenna delays from _phs_slope_arr array """
         if hasattr(self, '_phs_slope_arr'):
+            # einsum sums over antenna position
             return np.einsum("hi...,hi->h...", self._phs_slope_arr, self.antpos_arr[:, :2])
         else:
             return None
@@ -2658,6 +2666,7 @@ class AbsCal(object):
         """ form complex gain from _TT_Phi array """
         if hasattr(self, '_TT_Phi'):
             TT_Phi = self.TT_Phi
+            # einsum sums over antenna position
             return odict(list(map(lambda k: (k, np.exp(1j * np.einsum("i...,i->...", TT_Phi[k], self.antpos[k[0]][:2]))), flatten(self._gain_keys))))
         else:
             return None
@@ -2677,6 +2686,7 @@ class AbsCal(object):
             # turn TT_Phi into per-antenna complex gains, while iterating over input gain_keys
             TT_Phi_gain = odict()
             for gk in gain_keys:
+                # einsum sums over antenna position
                 TT_Phi_gain[gk] = np.exp(1j * np.einsum("i...,i->...", TT_Phi_dict[gk[1]], antpos[gk[0]][:2]))
             return TT_Phi_gain
         else:
@@ -2694,6 +2704,7 @@ class AbsCal(object):
     def TT_Phi_gain_arr(self):
         """ form complex gain from _TT_Phi_arr array """
         if hasattr(self, '_TT_Phi_arr'):
+            # einsum sums over antenna position
             return np.exp(1j * np.einsum("hi...,hi->h...", self._TT_Phi_arr, self.antpos_arr[:, :2]))
         else:
             return None

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2438,7 +2438,7 @@ class AbsCal(object):
         if hasattr(self, '_dly_slope'):
             # form dict of delay slopes for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            dly_slope_dict = {k[0][1]: self.dly_slope[k[0]] for k in self._gain_keys}
+            dly_slope_dict = {ants[0][1]: self.dly_slope[k[0]] for ants in self._gain_keys}
 
             # turn delay slope into per-antenna complex gains, while iterating over input gain_keys
             dly_slope_gain = odict()
@@ -2503,7 +2503,7 @@ class AbsCal(object):
         if hasattr(self, '_phs_slope'):
             # form dict of phs slopes for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            phs_slope_dict = {k[0][1]: self.phs_slope[k[0]] for k in self._gain_keys}
+            phs_slope_dict = {ants[0][1]: self.phs_slope[k[0]] for ants in self._gain_keys}
 
             # turn phs slope into per-antenna complex gains, while iterating over input gain_keys
             phs_slope_gain = odict()
@@ -2565,7 +2565,7 @@ class AbsCal(object):
         if hasattr(self, '_abs_eta'):
             # form dict of abs eta for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            abs_eta_dict = {k[0][1]: self.abs_eta[k[0]] for k in self._gain_keys}
+            abs_eta_dict = {ants[0][1]: self.abs_eta[k[0]] for ants in self._gain_keys}
 
             # turn abs eta into per-antenna complex gains, while iterating over input gain_keys
             abs_eta_gain = odict()
@@ -2619,7 +2619,7 @@ class AbsCal(object):
         if hasattr(self, '_abs_psi'):
             # form dict of abs psi for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            abs_psi_dict = {k[0][1]: self.abs_psi[k[0]] for k in self._gain_keys}
+            abs_psi_dict = {ants[0][1]: self.abs_psi[k[0]] for ants in self._gain_keys}
 
             # turn abs psi into per-antenna complex gains, while iterating over input gain_keys
             abs_psi_gain = odict()
@@ -2672,7 +2672,7 @@ class AbsCal(object):
         if hasattr(self, '_TT_Phi'):
             # form dict of TT_Phi for each polarization in self._gain_keys
             # b/c they are identical for all antennas of the same polarization
-            TT_Phi_dict = {k[0][1]: self.TT_Phi[k[0]] for k in self._gain_keys}
+            TT_Phi_dict = {ants[0][1]: self.TT_Phi[k[0]] for ants in self._gain_keys}
 
             # turn TT_Phi into per-antenna complex gains, while iterating over input gain_keys
             TT_Phi_gain = odict()


### PR DESCRIPTION
Resolves issue #515 where in abscal 2pol calibration, the custom_* funcs assigned XX solutions to requested YY keys. This is relevant for `abscal.post_redcal_abscal_run` which uses these functions. Tests have been added to catch this.

If IDR2.2 ran XX and YY pol abscal simultaneously, then it will need to be re-run :(. If XX and YY pol were ran independently (different tasks) then this bug won't affect the results.

[Update:] I just checked and it looks like the partial abs component of the gain for IDR2.2 is different for XX and YY, meaning that this bug did not affect the most recent run of IDR2.2 (dated 7/30/2019), which is probably due to the fact that the `post_redcal_abscal_run` function performs partial IO analysis across polarization groups. So seems like no need to re-run the pipeline.