### PR TITLE
Fix issue with get_reds branchcut

### DIFF
--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -83,6 +83,13 @@ class TestMethods(object):
         pos = {0: np.array([0, 0, 0]), 1: np.array([20, 0, 0]), 2: np.array([10, 0, 0])}
         assert om.get_pos_reds(pos) == [[(0, 2), (2, 1)], [(0, 1)]]
 
+        # test branch cut
+        pos = {0: np.array([-.03, 1., 0.]),
+               1: np.array([1., 1., 0.]),
+               2: np.array([0.03, 0.0, 0.]),
+               3: np.array([1., 0., 0.])}
+        assert len(om.get_pos_reds(pos, bl_error_tol=.1)) == 4
+
     def test_filter_reds(self):
         antpos = linear_array(7)
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')


### PR DESCRIPTION
It is technically possible, though likely very rare, for baselines to not be identified as redundant because one was conjugated and the other wasn't (because both are just on opposite sides of the axis/branch cut). @zacharymartinot thought this was an issue with his simulations. 

This revision to `get_pos_reds` first checks whether either the baseline or its conjugate is already in the list of unique baselines, then only if it's not already, it decides whether to include take the baseline or its conjugate. It adds a test to expose the issue.

This should not affect anything done in the IDR 2.2 pipeline.