### PR TITLE
Sparse SVD in reflections and xthinning in gp_interp1d

### DIFF
--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -788,7 +788,8 @@ class ReflectionFitter(FRFilter):
             self.data_pcmodel_resid[k] = data[k] - model_fft
 
     def interp_u(self, umodes, times, full_times=None, uflags=None, keys=None, overwrite=False, Ninterp=None,
-                 gp_frate=1.0, gp_frate_degrade=0.0, gp_nl=1e-12, kernels=None, optimizer=None, Nmirror=0, verbose=True):
+                 gp_frate=1.0, gp_frate_degrade=0.0, gp_nl=1e-12, kernels=None, optimizer=None, Nmirror=0, 
+                 xthin=None, verbose=True):
         """
         Interpolate u modes along time with a Gaussian Process.
 
@@ -827,6 +828,8 @@ class ReflectionFitter(FRFilter):
                 See sklearn.gaussian_process.GaussianProcessRegressor for details.
             Nmirror : int
                 Number of time bins to mirror at ends of input time axis. Default is no mirroring.
+            xthin : int
+                Factor by which to thin time-axis before GP interpolation. Default is no thinning.
             verbose : bool
                 If True, report feedback to stdout.
 
@@ -883,7 +886,7 @@ class ReflectionFitter(FRFilter):
             yflag = np.repeat(uflags[k], y.shape[1], axis=1)
             self.umode_interp[k] = gp_interp1d(Xtrain, y, x_eval=Xpredict,
                                                flags=yflag, kernel=kernel, Nmirror=Nmirror,
-                                               optimizer=optimizer)
+                                               optimizer=optimizer, xthin=xthin)
 
 
 def form_gains(epsilon):

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -900,7 +900,7 @@ def gp_interp1d(x, y, x_eval=None, flags=None, length_scale=1.0, nl=1e-10,
         kernel = 1**2 * gp.kernels.RBF(length_scale=length_scale) + gp.kernels.WhiteKernel(noise_level=nl)
 
     # initialize GP
-    GP = gp.GaussianProcessRegressor(kernel=kernel, optimizer=optimizer, normalize_y=False)
+    GP = gp.GaussianProcessRegressor(kernel=kernel, optimizer=optimizer, normalize_y=False, copy_X_train=False)
 
     if flags is None:
         flags = np.zeros_like(y, dtype=np.bool)


### PR DESCRIPTION
Adds two minor features that improve memory performance of xtalk modeling in `reflections.py` and gaussian process smoothing in `utils`.

• The first adds a sparse SVD option (using `scipy.sparse.linalg.svds`) to __only__ calculate the first singular values of a matrix, but keeps the full `np.linalg.svd` call as a feature in case the matrix is dense.

• The second allows the user to _thin_ the input x-axis in `utils.gp_interp1d` prior to GP model fitting. The GP must invert a matrix the size of the input x-axis when forming the model, so thinning it up front can drastically improve memory performance in the large matrix regime, with a generally small hit to precision.