### PR TITLE
Dead antenna resurrection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,9 @@ install:
   - pip install .
   - conda list
 script:
-  #- pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
-  - pytest hera_cal/tests/test_redcal.py # --cov=hera_cal --cov-report=term --cov-report=xml
+  - pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
   - pycodestyle . --ignore=E501,W291,W293,W503,W601
 after_success:
-  #- coveralls
+  - coveralls
 notifications:
-  # webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
+  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ install:
   - pip install .
   - conda list
 script:
-  - pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
+  #- pytest hera_cal --cov=hera_cal --cov-report=term --cov-report=xml
+  - pytest hera_cal/tests/test_redcal.py # --cov=hera_cal --cov-report=term --cov-report=xml
   - pycodestyle . --ignore=E501,W291,W293,W503,W601
 after_success:
-  - coveralls
+  #- coveralls
 notifications:
-  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
+  # webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -934,7 +934,7 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False):
         w_ls[eq] = (predict_noise_variance_from_autos(bl, data, dt=dt))**-1
         if weight_by_nsamples:
             ubl_key = [red[0] for red in all_reds if bl in red][0]
-            w_ls[eq] *= cal['vns_omnical'][ubl_key] # weight by nsamples in the bl group
+            w_ls[eq] *= cal['vns_omnical'][ubl_key]  # weight by nsamples in the bl group
     ls = linsolve.LinearSolver(d_ls, wgts=w_ls, **consts)
     sol = ls.solve()
     return {rc_all.unpack_sol_key(k): sol for k, sol in sol.items()}

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1384,7 +1384,7 @@ def redcal_run(input_data, filetype='uvh5', firstcal_ext='.first.calfits', omnic
 
         # Determine whether to add additional antennas to exclude
         z_scores = per_antenna_modified_z_scores({ant: np.nanmedian(cspa) for ant, cspa in cal['chisq_per_ant'].items()
-                                                  if not np.all(cspa == 0)})
+                                                  if (ant[0] not in ex_ants) and not np.all(cspa == 0)})
         n_ex = len(ex_ants)
         for ant, score in z_scores.items():
             if (score >= ant_z_thresh):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -976,7 +976,6 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
                       and (split_bl(bl)[1] in cal['g_omnical'])))]
     if len(bls_to_use) > 0:
         new_vis = linear_cal_update(bls_to_use, cal, data, all_reds)
-        make_sol_finite(new_vis)
         for ubl, vis in new_vis.items():
             cal['v_omnical'][ubl] = vis
             cal['vf_omnical'][ubl] = ~np.isfinite(vis)
@@ -1008,7 +1007,6 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
         
         # solve for new gains and update cal
         new_gains = linear_cal_update(bls_to_use, cal, data, all_reds)
-        make_sol_finite(new_gains)
         for ant, g in new_gains.items():
             cal['g_omnical'][ant] = g
             # keep omnical gains flagged, also keep firstcal gains and flags consistent
@@ -1032,12 +1030,16 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
                       and (split_bl(bl)[1] in cal['g_omnical'])))]
     if len(bls_to_use) > 0:
         new_vis = linear_cal_update(bls_to_use, cal, data, all_reds)
-        make_sol_finite(new_vis)
         for bl, vis in new_vis.items():
             cal['v_omnical'][bl] = vis
             # keep omnical visibility solutions flagged and nsamples at 0
             cal['vf_omnical'][bl] = np.ones_like(vis, dtype=bool)
             cal['vns_omnical'][bl] = np.zeros_like(vis, dtype=np.float32)
+
+    # make sure there are no infs or nans
+    make_sol_finite(cal['v_omnical'])
+    make_sol_finite(cal['g_omnical'])
+    make_sol_finite(cal['chisq_per_ant'])
 
 
 def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit=1e-6, fc_maxiter=50, 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1025,6 +1025,41 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
         rv['chisq'] /= (nObs - len(rv['g_omnical']) - len(rv['v_omnical']) + nDegen / 2.0)
     return rv
 
+def lookup (self):
+	"""Given a list of excluded, predicted to be broken antennas, produce a dictionary of all
+	baselines as keys, and their corresponding unique baselines that do not contain an excluded
+   	antenna as that keys data"""
+    keys = list(rv['g_omnical'].keys())
+    keysv = list(rv['v_omnical'].keys())
+    lookup_dict = {}
+	for i,keysv in enumerate(reds):
+    	reference = [i]
+    	lookup.update({bl:reference for bl in keysv})
+	for mdlbl in rv['v_omnical'].keys():
+    	lookup[mdlbl][0] = mdlbl
+    return lookup_dict
+
+def sol_dead_ants(self):
+    """Given a list of broken antennas, solve for their gain based on other baselines"""
+    sol_ants = list()
+	for i in exclude:
+    	ant_pick = (i, 'Jxx')
+    	sol_ants.append(ant_pick)
+	def make_g_bl(ant):
+    	return 'g{}_{}'.format(*ant)
+	def make_vis_bl(bl):
+    	return 'v_{}_{}_{}'.format(*bl)
+	def make_equ(bl):
+    	ant1,ant2 = hera_cal.utils.split_bl(bl)
+    	equ = '{}*{}_*{}'.format(make_g_bl(ant1),make_g_bl(ant2),make_vis_bl(bl))
+    	return equ
+	bls = [bl for bl in lookup.keys() if np.sum([ant in hera_cal.utils.split_bl(bl) for ant in sol_ants]) == 1 and type(lookup[bl][0]) != int]
+	#checking sum = 1 to ensure one and only one antenna in a baseline is an unsolved antenna
+	data = {make_equ(bl): vis_data[bl] for bl in bls}
+	consts = {make_vis_bl(bl):cal['v_omnical'][lookup[bl][0]] for bl in bls}
+	consts.update({make_g_bl(ant):cal['g_omnical'][ant] for ant in cal['g_omnical']})
+	ls = linsolve.LinearSolver(data,**consts)
+	sol = ls.solve()
 
 def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, ex_ants=[], solar_horizon=0.0,
                      flag_nchan_low=0, flag_nchan_high=0, fc_conv_crit=1e-6, fc_maxiter=50, oc_conv_crit=1e-10, 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -951,6 +951,7 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
         # weight by inverse noise variance inferred from autocorrelations
         dt = np.median(np.ediff1d(data.times_by_bl[bl[:2]])) * SEC_PER_DAY
         bl_wgts[bl] = (predict_noise_variance_from_autos(bl, data, dt=dt))**-1
+        bl_wgts[bl][~np.isfinite(bl_wgts[bl])] = 0.0
         if weight_by_nsamples:
             bl_wgts[bl] *= cal['vns_omnical'][bl_to_ubl_map[bl]]  # weight by nsamples in the bl group
         if weight_by_flags:
@@ -977,7 +978,8 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
     d_ls, w_ls = {}, {}
     for eq, bl in eqs.items():
         d_ls[eq] = data[bl]
-        w_ls[eq] = np.ones_like(data[bl], dtype=float)#bl_wgts[bl]
+        #w_ls[eq] = np.ones_like(data[bl], dtype=float)
+        w_ls[eq] = bl_wgts[bl]
     ls = linsolve.LinearSolver(d_ls, wgts=w_ls, **consts)
     sol = {rc_all.unpack_sol_key(k): val for k, val in ls.solve(mode='pinv').items()}
     # for k, val in sol.items():

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -944,8 +944,8 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
                             bl_flg_wgts[bl] *= (1.0 - cal['gf_omnical'][split_bl(bl)[i]])
         totally_flagged = np.sum(list(bl_flg_wgts.values()), axis=0) == 0
         for bl in bls:
-            # this avoids singular matrices and is fixed  later in expand_omni_sol
-            bl_flg_wgts[bl][totally_flagged] = np.nan  
+            # this avoids singular matrices and is fixed later in expand_omni_sol
+            bl_flg_wgts[bl][totally_flagged] = np.nan
 
     d_ls, w_ls = {}, {}
     for eq, bl in eqs.items():
@@ -959,7 +959,7 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
         if weight_by_flags:
             w_ls[eq] *= bl_flg_wgts[bl]
     ls = linsolve.LinearSolver(d_ls, wgts=w_ls, **consts)
-    sol = ls.solve()
+    sol = ls.solve(mode='pinv')
     return {rc_all.unpack_sol_key(k): sol for k, sol in sol.items()}
 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1219,17 +1219,16 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, e
                 if verbose:
                     print('    Now calibrating times', hd.times[tinds[0]], 'through', hd.times[tinds[-1]], '...')
                 if nInt_to_load is None:  # don't perform partial I/O
-                    data, flags, nsamples = hd.build_datacontainers()  # this may contain unused polarizations, but that's OK
+                    data, _, nsamples = hd.build_datacontainers()  # this may contain unused polarizations, but that's OK
                     for bl in data:
                         data[bl] = data[bl][tinds, fSlice]  # cut down size of DataContainers to match unflagged indices
-                        flags[bl] = flags[bl][tinds, fSlice]
                         nsamples[bl] = nsamples[bl][tinds, fSlice] 
                 else:  # perform partial i/o
-                    data, flags, nsamples = hd.read(times=hd.times[tinds], frequencies=hd.freqs[fSlice], polarizations=pols)
+                    data, _, nsamples = hd.read(times=hd.times[tinds], frequencies=hd.freqs[fSlice], polarizations=pols)
                 cal = redundantly_calibrate(data, reds, freqs=hd.freqs[fSlice], times_by_bl=hd.times_by_bl,
                                             fc_conv_crit=fc_conv_crit, fc_maxiter=fc_maxiter, oc_conv_crit=oc_conv_crit, 
                                             oc_maxiter=oc_maxiter, check_every=check_every, check_after=check_after, gain=gain)
-                expand_omni_vis(cal, filter_reds(all_reds, pols=pols), data, flags, nsamples)
+                expand_omni_sol(cal, filter_reds(all_reds, pols=pols), data, nsamples)
                 
                 # gather results
                 for ant in cal['g_omnical'].keys():

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -941,11 +941,8 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
                 else:
                     bl_to_ubl_map[bl] = red[0]
 
-    # build up weights and flags
+    # build up weights
     bl_wgts = {bl: 1.0 for bl in bls}
-    # to_flag = {ant: np.ones_like(data[bl], dtype=bool) for bl in bls for ant in split_bl(bl)}  # starts all flagged
-    # to_flag.update({ubl: np.ones_like(to_flag[list(to_flag.keys())[0]], dtype=bool)
-    #                 for ubl in set(bl_to_ubl_map.values())})
     for bl in bls:
         ant0, ant1 = split_bl(bl)
         # weight by inverse noise variance inferred from autocorrelations
@@ -962,29 +959,10 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
             if ant1 in cal['gf_omnical']:
                 bl_wgts[bl] *= (1.0 - cal['gf_omnical'][ant1])
 
-    #     # set flags to False if any good data is available
-    #     wgts_are_bad = (~np.isfinite(bl_wgts[bl])) | (bl_wgts[bl] == 0)
-    #     bl_wgts[bl][wgts_are_bad] = 0.0
-    #     to_flag[ant0] &= wgts_are_bad 
-    #     to_flag[ant1] &= wgts_are_bad
-    #     if bl_to_ubl_map[bl] is not None:
-    #         to_flag[ant1] &= wgts_are_bad
-
-    # totally_flagged = np.sum(list(bl_wgts.values()), axis=0) == 0
-    # for bl in bls:
-    #     # this avoids singular matrices and is fixed later
-    #     bl_wgts[bl][totally_flagged] = 1.0
-
-    d_ls, w_ls = {}, {}
-    for eq, bl in eqs.items():
-        d_ls[eq] = data[bl]
-        #w_ls[eq] = np.ones_like(data[bl], dtype=float)
-        w_ls[eq] = bl_wgts[bl]
+    d_ls = {eq: data[bl] for eq, bl in eqs.items()}
+    w_ls = {eq: bl_wgts[bl] for eq, bl in eqs.items()}
     ls = linsolve.LinearSolver(d_ls, wgts=w_ls, **consts)
     sol = {rc_all.unpack_sol_key(k): val for k, val in ls.solve(mode='pinv').items()}
-    # for k, val in sol.items():
-    #     sol[k][to_flag[k]] = np.nan
-    #     sol[k][totally_flagged] = np.nan
     return sol
 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1003,13 +1003,24 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
                       (split_bl(bl)[1] not in cal['g_omnical']))]
         if len(bls_to_use) == 0:
             break # iterate to also solve for ants only found in bls with other ex_ants
-        for ant, g in linear_cal_update(bls_to_use, cal, data, all_reds).items():
+        
+        # solve for new gains and update cal
+        new_gains = linear_cal_update(bls_to_use, cal, data, all_reds)
+        for ant, g in new_gains.items():
             cal['g_omnical'][ant] = g
             # keep omnical gains flagged, also keep firstcal gains and flags consistent
             cal['gf_omnical'][ant] = np.ones_like(g, dtype=bool)
             cal['g_firstcal'][ant] = np.ones_like(g, dtype=np.complex64)
             cal['gf_firstcal'][ant] = np.ones_like(g, dtype=bool) 
-            cal['chisq_per_ant'] #TODO: update
+        
+        # compute new chisq_per_ant for new gains
+        data_subset = DataContainer({bl: data[bl] for bl in bls_to_use})
+        dts_by_bl = {bl: np.median(np.ediff1d(data.times_by_bl[bl[:2]])) * SEC_PER_DAY) for bl in bls_to_use}
+        data_wgts = {bl: predict_noise_variance_from_autos(bl, data, dt=dts_by_bl[bl])**-1 for bl in bls_to_use}
+        _, _, chisq_per_ant, nObs_per_ant = utils.chisq(data, rv['v_omnical'], data_wgts=data_wgts,
+                                                        gains=rv['g_omnical'], reds=all_reds)
+        for ant in new_gains:
+            cal['chisq_per_ant'][ant] = chisq_per_ant[ant] / nObs_per_ant[ant]
     
     # Solve for unsolved-for unique baselines visbility solutions
     bls_to_use = [bl for red in all_reds for bl in red 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1036,40 +1036,40 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     return rv
 
 def lookup (self):
-	"""Given a list of excluded, predicted to be broken antennas, produce a dictionary of all
-	baselines as keys, and their corresponding unique baselines that do not contain an excluded
-   	antenna as that keys data"""
+    """Given a list of excluded, predicted to be broken antennas, produce a dictionary of all
+    baselines as keys, and their corresponding unique baselines that do not contain an excluded
+    antenna as that keys data"""
     keys = list(rv['g_omnical'].keys())
     keysv = list(rv['v_omnical'].keys())
     lookup_dict = {}
-	for i,keysv in enumerate(reds):
-    	reference = [i]
-    	lookup.update({bl:reference for bl in keysv})
-	for mdlbl in rv['v_omnical'].keys():
-    	lookup[mdlbl][0] = mdlbl
+    for i,keysv in enumerate(reds):
+        reference = [i]
+        lookup.update({bl:reference for bl in keysv})
+    for mdlbl in rv['v_omnical'].keys():
+        lookup[mdlbl][0] = mdlbl
     return lookup_dict
 
 def sol_dead_ants(self):
     """Given a list of broken antennas, solve for their gain based on other baselines"""
     sol_ants = list()
-	for i in exclude:
-    	ant_pick = (i, 'Jxx')
-    	sol_ants.append(ant_pick)
-	def make_g_bl(ant):
-    	return 'g{}_{}'.format(*ant)
-	def make_vis_bl(bl):
-    	return 'v_{}_{}_{}'.format(*bl)
-	def make_equ(bl):
-    	ant1,ant2 = hera_cal.utils.split_bl(bl)
-    	equ = '{}*{}_*{}'.format(make_g_bl(ant1),make_g_bl(ant2),make_vis_bl(bl))
-    	return equ
-	bls = [bl for bl in lookup.keys() if np.sum([ant in hera_cal.utils.split_bl(bl) for ant in sol_ants]) == 1 and type(lookup[bl][0]) != int]
-	#checking sum = 1 to ensure one and only one antenna in a baseline is an unsolved antenna
-	data = {make_equ(bl): vis_data[bl] for bl in bls}
-	consts = {make_vis_bl(bl):cal['v_omnical'][lookup[bl][0]] for bl in bls}
-	consts.update({make_g_bl(ant):cal['g_omnical'][ant] for ant in cal['g_omnical']})
-	ls = linsolve.LinearSolver(data,**consts)
-	sol = ls.solve()
+    for i in exclude:
+        ant_pick = (i, 'Jxx')
+        sol_ants.append(ant_pick)
+    def make_g_bl(ant):
+        return 'g{}_{}'.format(*ant)
+    def make_vis_bl(bl):
+        return 'v_{}_{}_{}'.format(*bl)
+    def make_equ(bl):
+        ant1,ant2 = hera_cal.utils.split_bl(bl)
+        equ = '{}*{}_*{}'.format(make_g_bl(ant1),make_g_bl(ant2),make_vis_bl(bl))
+        return equ
+    bls = [bl for bl in lookup.keys() if np.sum([ant in hera_cal.utils.split_bl(bl) for ant in sol_ants]) == 1 and type(lookup[bl][0]) != int]
+    #checking sum = 1 to ensure one and only one antenna in a baseline is an unsolved antenna
+    data = {make_equ(bl): vis_data[bl] for bl in bls}
+    consts = {make_vis_bl(bl):cal['v_omnical'][lookup[bl][0]] for bl in bls}
+    consts.update({make_g_bl(ant):cal['g_omnical'][ant] for ant in cal['g_omnical']})
+    ls = linsolve.LinearSolver(data,**consts)
+    sol = ls.solve()
 
 def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, ex_ants=[], solar_horizon=0.0,
                      flag_nchan_low=0, flag_nchan_high=0, fc_conv_crit=1e-6, fc_maxiter=50, oc_conv_crit=1e-10, 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -918,7 +918,7 @@ def linear_cal_update(bls, cal, data, all_reds):
             item in each list will be treated as the key for the unique baseline. Must be 
             a superset of the reds used for producing cal.
     '''
-    rc_all = redcal.RedundantCalibrator(all_reds)
+    rc_all = RedundantCalibrator(all_reds)
     consts = {rc_all.pack_sol_key(ant): cal['g_omnical'][ant] for ant in cal['g_omnical']}
     consts.update({rc_all.pack_sol_key([red[0] for red in all_reds if bl in red][0]): 
                    cal['v_omnical'][bl] for bl in cal['v_omnical']})

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1112,6 +1112,11 @@ class TestRunMethods(object):
             # test redundant baseline counting
             np.testing.assert_array_equal(rv['vns_omnical'][(1, 12, pol)][~rv['vf_omnical'][(1, 12, pol)]], 4.0)
             np.testing.assert_array_equal(rv['vns_omnical'][(23, 27, pol)], 0.0)
+            np.testing.assert_array_equal(rv['vns_omnical'][(1, 27, pol)], 0.0)
+        for ant in [(1, 'Jxx'), (1, 'Jyy'), (27, 'Jxx'), (27, 'Jyy')]:
+            assert not np.all(rv['g_omnical'][ant] == 1.0)
+            assert not np.all(rv['chisq_per_ant'][ant] == 0.0)
+            np.testing.assert_array_equal(rv['gf_omnical'][ant], True)
 
     def test_redcal_run(self):
         input_data = os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5')

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1098,6 +1098,7 @@ class TestRunMethods(object):
         for nsamples in rv['vns_omnical'].values():
             np.testing.assert_array_equal(nsamples, 0)
 
+        # this tests redcal.expand_omni_sol
         hd = io.HERAData(os.path.join(DATA_PATH, 'zen.2458098.43124.downsample.uvh5'))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -1143,7 +1144,6 @@ class TestRunMethods(object):
                 np.testing.assert_array_equal(flags[ant][zero_check], True)
             np.testing.assert_array_almost_equal(quals[ant][~zero_check], cal['chisq_per_ant'][ant][~zero_check])
             if ant[0] in bad_ants:
-                np.testing.assert_array_equal(gains[ant], 1.0)
                 np.testing.assert_array_equal(flags[ant], True)
         for antpol in total_qual.keys():
             np.testing.assert_array_almost_equal(total_qual[antpol], cal['chisq'][antpol])

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1068,17 +1068,17 @@ class TestRunMethods(object):
         reds = om.get_reds(antpos, pols=pols)
         np.random.seed(21)
         freqs = np.linspace(100e6, 200e6, 64, endpoint=False)
-        times = np.linspace(0, 600./60/60/24, 3, endpoint=False)
+        times = np.linspace(0, 600. / 60 / 60 / 24, 3, endpoint=False)
         df = np.median(np.diff(freqs))
         dt = np.median(np.diff(times)) * 3600. * 24
 
-        g, tv, d = sim_red_data(reds, shape=(len(times),len(freqs)), gain_scatter=.01)
+        g, tv, d = sim_red_data(reds, shape=(len(times), len(freqs)), gain_scatter=.01)
         tv, d = DataContainer(tv), DataContainer(d)
         nsamples = DataContainer({bl: np.ones_like(d[bl], dtype=float) for bl in d})
 
         for antnum in antpos.keys():
             for pol in pols:
-                d[(antnum, antnum, pol)] = np.ones((len(times),len(freqs)), dtype=complex)
+                d[(antnum, antnum, pol)] = np.ones((len(times), len(freqs)), dtype=complex)
         d.freqs = deepcopy(freqs)
         d.times_by_bl = {bl[0:2]: deepcopy(times) for bl in d.keys()}
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -795,8 +795,9 @@ def chisq(data, model, data_wgts=None, gains=None, gain_flags=None, split_by_ant
     if reds is not None:
         model = copy.deepcopy(model)
         for red in reds:
-            for bl in red:
-                model[bl] = model[red[0]]
+            if np.any([bl in data for bl in red]):
+                for bl in red:
+                    model[bl] = model[red[0]]
 
     for bl in data.keys():
         ap1, ap2 = split_pol(bl[2])


### PR DESCRIPTION
This PR implements a way to solve for the gains of antennas despite flagging them in redundant calibration. After omnical, this solves for all unique visibilities and antenna gains in a way that leaves them flagged and does not affect any other antennas. This also lets us calculate chi^2 per antenna, which might help us assess whether to readmit a dubious antenna.

This follows-up on the work done by @Vasqalex this summer.

This closes #489.