### PR TITLE
Proper normalization of chi^2 per antenna

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -915,6 +915,21 @@ def predict_chisq_per_bl(reds):
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}
 
 
+def predict_chisq_per_red(reds):
+    '''Predict the expected value of chi^2 for each redundant baselines group 
+    (equivalently, the effective number of degrees of freedom).
+    
+    Arguments:
+        reds: list of list of baselines (with polarizations) considered redundant
+    
+    Returns:
+        predicted_chisq_per_bl: dictionary mapping unique baseline tuples to the 
+            expected sum(|Vij - gigj*Vi-j|^2/sigmaij^2) over baselines in a group 
+    '''
+    predicted_chisq_per_bl = predict_chisq_per_bl(reds)
+    return {red[0]: np.sum([predicted_chisq_per_bl[bl] for bl in red]) for red in reds}
+
+
 def _get_pol_load_list(pols, pol_mode='1pol'):
     '''Get a list of lists of polarizations to load simultaneously, depending on the polarizations
     in the data and the pol_mode (which can be 1pol, 2pol, 4pol, or 4pol_minV)'''

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -906,9 +906,9 @@ def predict_chisq_per_bl(reds):
     rc = redcal.RedundantCalibrator(reds)
     solver = rc._solver(linsolve.LogProductSolver, dummy_data)
 
-    A = solver.ls_amp.get_A()[:,:,0]
+    A = solver.ls_amp.get_A()[:, :, 0]
     A_data_resolution = A.dot(np.linalg.pinv(A.T.dot(A)).dot(A.T))
-    B = solver.ls_phs.get_A()[:,:,0]
+    B = solver.ls_phs.get_A()[:, :, 0]
     B_data_resolution = B.dot(np.linalg.pinv(B.T.dot(B)).dot(B.T))
 
     predicted_chisq_per_bl = 1.0 - np.diag(A_data_resolution + B_data_resolution) / 2.0

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -906,9 +906,20 @@ def predict_chisq_per_bl(reds):
     rc = RedundantCalibrator(reds)
     solver = rc._solver(linsolve.LogProductSolver, dummy_data)
 
-    A = solver.ls_amp.get_A()[:, :, 0]
+    # A = solver.ls_amp.get_A()[:, :, 0]
+    # B = solver.ls_phs.get_A()[:, :, 0]
+    # The following code corrects the ordering of equations in A and B. It is only necessary in python 2.
+    import ast
+    eqs_dict = {bl: eq for eq, bl in rc.build_eqs().items()}
+    eqs = [linsolve.ast_getterms(ast.parse(eqs_dict[bl], mode='eval')) for bl in bls]
+    amp_keys = [linsolve.jointerms([linsolve.conjterm([t], mode='amp') for t in eq[0]]) for eq in eqs]
+    A_eq_order = [solver.ls_amp.keys.index(k) for k in amp_keys]
+    A = solver.ls_amp.get_A()[A_eq_order, :, 0]
+    phs_keys = [linsolve.jointerms([linsolve.conjterm([t], mode='phs') for t in eq[0]]) for eq in eqs]
+    B_eq_order = [solver.ls_phs.keys.index(k) for k in phs_keys]
+    B = solver.ls_phs.get_A()[B_eq_order, :, 0]
+    # Delete the above when python 2 support is dropped.
     A_data_resolution = A.dot(np.linalg.pinv(A.T.dot(A)).dot(A.T))
-    B = solver.ls_phs.get_A()[:, :, 0]
     B_data_resolution = B.dot(np.linalg.pinv(B.T.dot(B)).dot(B.T))
 
     predicted_chisq_per_bl = 1.0 - np.diag(A_data_resolution + B_data_resolution) / 2.0

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1120,7 +1120,6 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
             Used for counting the number of non-flagged visibilities that went into each redundant group.
     '''
     # Solve for unsolved-for unique baselines whose antennas are both in cal['g_omnical']
-    input_cal = deepcopy(cal)
     bls_to_use = [bl for red in all_reds for bl in red 
                   if (not np.any([bl in cal['v_omnical'] for bl in red])
                       and ((split_bl(bl)[0] in cal['g_omnical']) 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1091,17 +1091,19 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
     '''This function expands and harmonizes a calibration solution produced by 
     redcal.redundantly_calibrate to a set of un-filtered redundancies, modifying cal in place.
 
-    It does five related things:
+    It does six related things:
         1) Visibility solutions in cal['v_omnical'] and cal['vf_omnical'] are now keyed by the first 
             entry in each red in all_reds, even if they were originally keyed by a different entry.
         2) Unique baselines that were exluded from the redundant calibration are filled in by a 
             noise-weighted average of calibrated visibilities.
-        3) cal gets a new entry, cal['vns_omnical'] which is a nsamples data container of the number of 
+        3) cal['chisq'] and cal['chisq_per_ant'] are recalculated using the full set of redundancies
+            (but still excluding the dead antennas)
+        4) cal gets a new entry, cal['vns_omnical'] which is a nsamples data container of the number of 
             visibilites that went into each unique baseline visibility solution
-        4) gains missing from cal['g_omnical'] (e.g. ex_ants) are backsolved using omnical solutions 
+        5) gains missing from cal['g_omnical'] (e.g. ex_ants) are backsolved using omnical solutions 
             as fixed priors. These gains remain flagged in cal['gf_omnical']. For bookkeeping purposes, 
             cal['g_firstcal'] and cal['gf_firstcal'] and filled in with 1.0s and Trues respectively.
-        5) Unique baseline visibiltiy solutions that could not be solved for withose these backsolved 
+        6) Unique baseline visibiltiy solutions that could not be solved for withose these backsolved 
             gains are then solved for. These remain flagged in cal['vf_omnical'] and have all 0s 
             for samples in cal['vns_omnical']. 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1178,8 +1178,9 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
         reds_for_chisq = filter_reds(all_reds, bls=bls_for_chisq)
         predicted_chisq_per_ant = predict_chisq_per_ant(reds_for_chisq)
         for ant, cspa in chisq_per_ant.items():
-            cal['chisq_per_ant'][ant] = chisq_per_ant[ant] / predicted_chisq_per_ant[ant]
-            cal['chisq_per_ant'][ant][~np.isfinite(cspa)] = np.zeros_like(cspa[~np.isfinite(cspa)])
+            if ant not in cal['chisq_per_ant']:
+                cal['chisq_per_ant'][ant] = chisq_per_ant[ant] / predicted_chisq_per_ant[ant]
+                cal['chisq_per_ant'][ant][~np.isfinite(cspa)] = np.zeros_like(cspa[~np.isfinite(cspa)])
     
     # Solve for unsolved-for unique baselines visbility solutions
     bls_to_use = [bl for red in all_reds for bl in red 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1110,7 +1110,8 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
     Arguments:
         cal: dictionary of redundant calibration solutions produced by redcal.redundantly_calibrate. 
             Modified in place, including adding an entry with key 'vns_omnical' that gives a number of
-            samples that went into each unique baseline visibility solution
+            samples that went into each unique baseline visibility solution. Excluded antennas are
+            assumed to be missing from cal['g_omnical'] and cal['chisq_per_ant'].
         all_reds: list of lists of redundant baseline tuples, e.g. (0,1,'xx'). The first
             item in each list will be treated as the key for the unique baseline. Must be a superset of
             the reds used for producing cal

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -893,10 +893,10 @@ def predict_chisq_per_bl(reds):
     '''Predict the expected value of chi^2 for each baselines (equivalently, the
     effective number of degrees of freedom). This is calculated from the logcal 
     A and B matrices and their respective data resolution matrices.
-    
+
     Arguments:
         reds: list of list of baselines (with polarizations) considered redundant
-    
+
     Returns:
         predicted_chisq_per_bl: dictionary mapping baseline tuples to the expected
             value of chi^2 = |Vij - gigj*Vi-j|^2/sigmaij^2.
@@ -918,16 +918,34 @@ def predict_chisq_per_bl(reds):
 def predict_chisq_per_red(reds):
     '''Predict the expected value of chi^2 for each redundant baselines group 
     (equivalently, the effective number of degrees of freedom).
-    
+
     Arguments:
         reds: list of list of baselines (with polarizations) considered redundant
-    
+
     Returns:
         predicted_chisq_per_bl: dictionary mapping unique baseline tuples to the 
             expected sum(|Vij - gigj*Vi-j|^2/sigmaij^2) over baselines in a group 
     '''
     predicted_chisq_per_bl = predict_chisq_per_bl(reds)
     return {red[0]: np.sum([predicted_chisq_per_bl[bl] for bl in red]) for red in reds}
+
+
+def predict_chisq_per_ant(reds):
+    '''Predict the expected value of chi^2 per antenna (equivalently, the effective 
+    number of degrees of freedom). The sum over all antennas will twice the total
+    DoF, since each baseline has two antennas.
+
+    Arguments:
+        reds: list of list of baselines (with polarizations) considered redundant
+
+    Returns:
+        predicted_chisq_per_ant: dictionary mapping antenna-pol tuples to the expected 
+        sum(|Vij - gigj*Vi-j|^2/sigmaij^2) over all baselines including that antenna
+    '''
+    predicted_chisq_per_bl = predict_chisq_per_bl(reds)
+    bls = [bl for red in reds for bl in red]
+    ants = sorted(set([ant for bl in bls for ant in split_bl(bl)]))
+    return {ant: np.sum([predicted_chisq_per_bl[bl] for bl in bls if ant in split_bl(bl)]) for ant in ants}
 
 
 def _get_pol_load_list(pols, pol_mode='1pol'):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1217,15 +1217,12 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
                                                          split_by_antpol=(rc.pol_mode in ['1pol', '2pol']))
     predicted_chisq_per_ant = predict_chisq_per_ant(reds)
     rv['chisq_per_ant'] = {ant: cs / predicted_chisq_per_ant[ant] for ant, cs in rv['chisq_per_ant'].items()}
+    predicted_chisq = np.sum(list(predicted_chisq_per_ant.values())) / 2.0
     if rc.pol_mode in ['1pol', '2pol']:  # in this case, chisq is split by antpol
         for antpol in rv['chisq'].keys():
-            Ngains = len([ant for ant in rv['g_omnical'].keys() if ant[1] == antpol])
-            Nvis = len([bl for bl in rv['v_omnical'].keys() if bl[2] == join_pol(antpol, antpol)])
-            rv['chisq'][antpol] /= (nObs[antpol] - Ngains - Nvis + nDegen / {'1pol': 2.0, '2pol': 4.0}[rc.pol_mode])  
-    elif rc.pol_mode == '4pol':
-        rv['chisq'] /= (nObs - len(rv['g_omnical']) - len(rv['v_omnical']) + nDegen / 2.0)
-    else:  # 4pol_minV
-        rv['chisq'] /= (nObs - len(rv['g_omnical']) - len(rv['v_omnical']) + nDegen / 2.0)
+            rv['chisq'][antpol] /= (predicted_chisq / {'1pol': 1.0, '2pol': 2.0}[rc.pol_mode])
+    else:
+        rv['chisq'] /= predicted_chisq
     return rv
 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1212,11 +1212,11 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in rv['g_omnical'].items()}
 
     # compute chisqs
-    rv['chisq'], nObs, rv['chisq_per_ant'], nObs_per_ant = utils.chisq(data, rv['v_omnical'], data_wgts=data_wgts,
-                                                                       gains=rv['g_omnical'], reds=reds,
-                                                                       split_by_antpol=(rc.pol_mode in ['1pol', '2pol']))
-    rv['chisq_per_ant'] = {ant: cs / nObs_per_ant[ant] for ant, cs in rv['chisq_per_ant'].items()}
-    nDegen = rc.count_degens()  # need to add back in nDegen/2 complex degrees of freedom
+    rv['chisq'], _, rv['chisq_per_ant'], _ = utils.chisq(data, rv['v_omnical'], data_wgts=data_wgts,
+                                                         gains=rv['g_omnical'], reds=reds,
+                                                         split_by_antpol=(rc.pol_mode in ['1pol', '2pol']))
+    predicted_chisq_per_ant = predict_chisq_per_ant(reds)
+    rv['chisq_per_ant'] = {ant: cs / predicted_chisq_per_ant[ant] for ant, cs in rv['chisq_per_ant'].items()}
     if rc.pol_mode in ['1pol', '2pol']:  # in this case, chisq is split by antpol
         for antpol in rv['chisq'].keys():
             Ngains = len([ant for ant in rv['g_omnical'].keys() if ant[1] == antpol])

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -903,7 +903,7 @@ def predict_chisq_per_bl(reds):
     '''
     bls = [bl for red in reds for bl in red]
     dummy_data = DataContainer({bl: np.ones((1, 1), dtype=np.complex) for bl in bls})
-    rc = redcal.RedundantCalibrator(reds)
+    rc = RedundantCalibrator(reds)
     solver = rc._solver(linsolve.LogProductSolver, dummy_data)
 
     A = solver.ls_amp.get_A()[:, :, 0]

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1109,6 +1109,57 @@ class TestRedundantCalibrator(object):
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
 
+    def test_predict_chisq_statistically(self):
+        np.random.seed(21)
+        antpos = hex_array(2, split_core=False, outriggers=0)
+        reds = om.get_reds(antpos)
+        freqs = np.linspace(100e6, 200e6, 64, endpoint=False)
+        times = np.linspace(0, 600. / 60 / 60 / 24, 60, endpoint=False)
+        df = np.median(np.diff(freqs))
+        dt = np.median(np.diff(times)) * 3600. * 24
+
+        # Simulate redundant data with noise
+        noise_var = .001
+        g, tv, d = sim_red_data(reds, shape=(len(times), len(freqs)), gain_scatter=.00)
+        ants = g.keys()
+        n = DataContainer({bl: np.sqrt(noise_var / 2) * (np.random.randn(*vis.shape) + 1j * np.random.randn(*vis.shape)) for bl, vis in d.items()})
+        noisy_data = n + DataContainer(d)
+
+        # Set up autocorrelations so that the predicted noise variance is the actual simulated noise variance 
+        for antnum in antpos.keys():
+            noisy_data[(antnum, antnum, 'xx')] = np.sqrt(noise_var * dt * df)
+        noisy_data.freqs = deepcopy(freqs)
+        noisy_data.times_by_bl = {bl[0:2]: deepcopy(times) for bl in noisy_data.keys()}
+        cal = om.redundantly_calibrate(noisy_data, reds)
+
+        # Compute various chi^2s
+        chisq_per_bl = {}
+        chisq_per_red = {red[0]: 0.0 for red in reds}
+        chisq_per_ant = {ant: 0.0 for ant in ants}
+        for red in reds:
+            for bl in red:
+                d_here = noisy_data[bl]
+                ant0, ant1 = split_bl(bl)
+                g1, g2 = cal['g_omnical'][ant0], cal['g_omnical'][ant1]
+                v_here = cal['v_omnical'][red[0]]
+                chisq_per_bl[bl] = np.abs(d_here - g1 * np.conj(g2) * v_here)**2 / noise_var
+                chisq_per_red[red[0]] += chisq_per_bl[bl]
+                chisq_per_ant[ant0] += chisq_per_bl[bl]
+                chisq_per_ant[ant1] += chisq_per_bl[bl]
+
+        # compare predictions at the 2% level
+        predicted_chisq_per_bl = om.predict_chisq_per_bl(reds)
+        for bl in chisq_per_bl:
+            np.testing.assert_almost_equal(np.mean(chisq_per_bl[bl]), predicted_chisq_per_bl[bl], -np.log10(.02))
+
+        predicted_chisq_per_red = om.predict_chisq_per_red(reds)
+        for red in chisq_per_red:
+            np.testing.assert_almost_equal(np.mean(chisq_per_red[red]), predicted_chisq_per_red[red], -np.log10(.02))
+
+        predicted_chisq_per_ant = om.predict_chisq_per_ant(reds)
+        for ant in chisq_per_ant:
+            np.testing.assert_almost_equal(np.mean(chisq_per_ant[ant]), predicted_chisq_per_ant[ant], -np.log10(.02))
+
 
 class TestRedcalAndAbscal(object):
     

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -966,8 +966,8 @@ class TestRedundantCalibrator(object):
         np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
         np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
         for red in reds:
-            if len(red) == 0:
-                assert chisq_per_bl[red[0]] < 1e-10
+            if len(red) == 1:
+                np.testing.assert_almost_equal(chisq_per_bl[red[0]], 1e-10)
 
         # Test hex array
         antpos = hex_array(3, split_core=False, outriggers=0)
@@ -978,8 +978,8 @@ class TestRedundantCalibrator(object):
         np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
         np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
         for red in reds:
-            if len(red) == 0:
-                assert chisq_per_bl[red[0]] < 1e-10
+            if len(red) == 1:
+                np.testing.assert_almost_equal(chisq_per_bl[red[0]], 1e-10)
 
         # Test 2 pol array
         antpos = hex_array(3, split_core=False, outriggers=0)
@@ -990,8 +990,8 @@ class TestRedundantCalibrator(object):
         np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
         np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
         for red in reds:
-            if len(red) == 0:
-                assert chisq_per_bl[red[0]] < 1e-10
+            if len(red) == 1:
+                np.testing.assert_almost_equal(chisq_per_bl[red[0]], 1e-10)
 
     def test_predict_chisq_per_red(self):
         pass

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1064,7 +1064,7 @@ class TestRedundantCalibrator(object):
         for red in reds:
             for bl in red:        
                 for ant in split_bl(bl):
-                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0 / (len(red))
         for ant in ants:
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
@@ -1084,7 +1084,7 @@ class TestRedundantCalibrator(object):
         for red in reds:
             for bl in red:        
                 for ant in split_bl(bl):
-                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0 / (len(red))
         for ant in ants:
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
@@ -1104,7 +1104,7 @@ class TestRedundantCalibrator(object):
         for red in reds:
             for bl in red:        
                 for ant in split_bl(bl):
-                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0 / (len(red))
         for ant in ants:
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
             assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1049,7 +1049,65 @@ class TestRedundantCalibrator(object):
                 assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] > 0
 
     def test_predict_chisq_per_ant(self):
-        pass
+        # Test linear array
+        antpos = linear_array(7)
+        ants = [(ant, 'Jxx') for ant in antpos]
+        reds = om.get_reds(antpos)
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_ant = om.predict_chisq_per_ant(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_ant.values())), 2 * dof)
+        non_degen_dof_per_ant = {ant: -2 for ant in ants}
+        for red in reds:
+            for bl in red:        
+                for ant in split_bl(bl):
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+        for ant in ants:
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
+            
+        # Test hex array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        ants = [(ant, 'Jxx') for ant in antpos]
+        reds = om.get_reds(antpos)
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_ant = om.predict_chisq_per_ant(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_ant.values())), 2 * dof)
+        non_degen_dof_per_ant = {ant: -2 for ant in ants}
+        for red in reds:
+            for bl in red:        
+                for ant in split_bl(bl):
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+        for ant in ants:
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
+
+        # Test 2 pol array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        ants = [(ant, pol) for ant in antpos for pol in ['Jxx', 'Jyy']]
+        reds = om.get_reds(antpos, pols=['xx', 'yy'])
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_ant = om.predict_chisq_per_ant(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = 2.0 * len(antpos) * (len(antpos) - 1) / 2 - len(reds) - 2 * len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_ant.values())), 2 * dof)
+        non_degen_dof_per_ant = {ant: -2 for ant in ants}
+        for red in reds:
+            for bl in red:        
+                for ant in split_bl(bl):
+                    non_degen_dof_per_ant[ant] += 1.0 - 1.0/(len(red))
+        for ant in ants:
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] < 2
+            assert chisq_per_ant[ant] - non_degen_dof_per_ant[ant] > 0
 
 
 class TestRedcalAndAbscal(object):

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1426,7 +1426,7 @@ class TestRunMethods(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             sys.stdout = open(os.devnull, 'w')
-            cal = om.redcal_run(input_data, verbose=True, ant_z_thresh=1.5, add_to_history='testing', ant_metrics_file=ant_metrics_file, clobber=True)
+            cal = om.redcal_run(input_data, verbose=True, ant_z_thresh=1.8, add_to_history='testing', ant_metrics_file=ant_metrics_file, clobber=True)
             sys.stdout = sys.__stdout__
 
         bad_ants = [50, 12]  # this is based on experiments with this particular file

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1004,13 +1004,13 @@ class TestRedundantCalibrator(object):
         rc = om.RedundantCalibrator(reds)
         dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
         np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
-        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
+        non_degen_dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
         for red in reds:
-            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] < 1
             if len(red) == 1:
                 assert chisq_per_red[red[0]] < 1e-10
             else:
-                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
+                assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] > 0
 
         # Test hex array
         antpos = hex_array(3, split_core=False, outriggers=0)
@@ -1022,13 +1022,13 @@ class TestRedundantCalibrator(object):
         rc = om.RedundantCalibrator(reds)
         dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
         np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
-        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
+        non_degen_dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
         for red in reds:
-            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] < 1
             if len(red) == 1:
                 assert chisq_per_red[red[0]] < 1e-10
             else:
-                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
+                assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] > 0
 
         # Test 2 pol array
         antpos = hex_array(3, split_core=False, outriggers=0)
@@ -1040,13 +1040,13 @@ class TestRedundantCalibrator(object):
         rc = om.RedundantCalibrator(reds)
         dof = 2.0 * len(antpos) * (len(antpos) - 1) / 2 - len(reds) - 2 * len(antpos) + rc.count_degens() / 2.0
         np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
-        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl / 2 - nubl / 2) for red in reds}
+        non_degen_dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl / 2 - nubl / 2) for red in reds}
         for red in reds:
-            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] < 1
             if len(red) == 1:
                 assert chisq_per_red[red[0]] < 1e-10
             else:
-                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
+                assert chisq_per_red[red[0]] - non_degen_dof_per_ubl[red[0]] > 0
 
     def test_predict_chisq_per_ant(self):
         pass

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -956,6 +956,48 @@ class TestRedundantCalibrator(object):
         assert not om.is_redundantly_calibratable(pos)
         assert om.is_redundantly_calibratable(pos, require_coplanarity=False)
 
+    def test_predict_chisq_per_bl(self):
+        # Test linear array
+        antpos = linear_array(7)
+        reds = om.get_reds(antpos)
+        chisq_per_bl = om.predict_chisq_per_bl(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
+        np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
+        for red in reds:
+            if len(red) == 0:
+                assert chisq_per_bl[red[0]] < 1e-10
+
+        # Test hex array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        reds = om.get_reds(antpos)
+        chisq_per_bl = om.predict_chisq_per_bl(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
+        np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
+        for red in reds:
+            if len(red) == 0:
+                assert chisq_per_bl[red[0]] < 1e-10
+
+        # Test 2 pol array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        reds = om.get_reds(antpos, pols=['xx', 'yy'])
+        chisq_per_bl = om.predict_chisq_per_bl(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = 2.0 * len(antpos) * (len(antpos) - 1) / 2 - len(reds) - 2 * len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_bl.values())), dof)
+        np.testing.assert_array_less(list(chisq_per_bl.values()), 1.0)
+        for red in reds:
+            if len(red) == 0:
+                assert chisq_per_bl[red[0]] < 1e-10
+
+    def test_predict_chisq_per_red(self):
+        pass
+
+    def test_predict_chisq_per_ant(self):
+        pass
 
 class TestRedcalAndAbscal(object):
     

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -994,10 +994,63 @@ class TestRedundantCalibrator(object):
                 np.testing.assert_almost_equal(chisq_per_bl[red[0]], 1e-10)
 
     def test_predict_chisq_per_red(self):
-        pass
+        # Test linear array
+        antpos = linear_array(7)
+        reds = om.get_reds(antpos)
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_red = om.predict_chisq_per_red(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
+        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
+        for red in reds:
+            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            if len(red) == 1:
+                assert chisq_per_red[red[0]] < 1e-10
+            else:
+                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
+
+        # Test hex array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        reds = om.get_reds(antpos)
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_red = om.predict_chisq_per_red(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = len(antpos) * (len(antpos) - 1) / 2 - len(reds) - len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
+        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl - nubl) for red in reds}
+        for red in reds:
+            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            if len(red) == 1:
+                assert chisq_per_red[red[0]] < 1e-10
+            else:
+                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
+
+        # Test 2 pol array
+        antpos = hex_array(3, split_core=False, outriggers=0)
+        reds = om.get_reds(antpos, pols=['xx', 'yy'])
+        nubl = len(reds)
+        nbl = np.sum([len(red) for red in reds])
+        nant = len(antpos)
+        chisq_per_red = om.predict_chisq_per_red(reds)
+        rc = om.RedundantCalibrator(reds)
+        dof = 2.0 * len(antpos) * (len(antpos) - 1) / 2 - len(reds) - 2 * len(antpos) + rc.count_degens() / 2.0
+        np.testing.assert_approx_equal(np.sum(list(chisq_per_red.values())), dof)
+        dof_per_ubl = {red[0]: len(red) - 1 - nant * (len(red) - 1.) / (nbl / 2 - nubl / 2) for red in reds}
+        for red in reds:
+            assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] < 1
+            if len(red) == 1:
+                assert chisq_per_red[red[0]] < 1e-10
+            else:
+                assert chisq_per_red[red[0]] - dof_per_ubl[red[0]] > 0
 
     def test_predict_chisq_per_ant(self):
         pass
+
 
 class TestRedcalAndAbscal(object):
     


### PR DESCRIPTION
This PR does several interrelated things.

1.  We now have functions that that predict chi^2 (equivalently, the number of DoF) per baseline, per redundant group, and per antenna using only the list of list of redundant baselines. These work quite well (better than 1% accuracy in my tests), though I can't prove that this is perfect. 
2. The calculation of the proper number of DoF for chi^2 is replaced by summing up these predictions without any hit to runtime.
3. Chi^2 per antenna is now renormalized using these predicted DoF. This closes #520. Excluded antennas are renormalized using reds as if they were not-excluded, but good antennas are not affected by this.
4. Until now, the calculation of chi^2 and chi^2 we performed only on the baselines used for calibration. If long or short baselines were excluded, they also did not factor into chi^2 or chi^2 per ant. Now in `expand_omni_sol`, after calculating the unique baselines excluded by these cuts, chi^2 and chi^2 per ant for all good antennas are recalculated to include all baselines between good antennas (ex_ants are still removed). To me, this feels like this allows a more apples-to-apples comparison of calibration techniques... if we use fewer baselines, this should always raise chi^2 in my mind.  This closes #530.