### PR TITLE
Fix error in abscal when antennas are flagged and thus don't appear in n chisq_per_ant

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3013,7 +3013,8 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, output_file=None
                         for ant in data_ants:
                             abscal_gains[ant][tinds, :] = rc_gains_subset[ant] * delta_gains[ant]
                             abscal_flags[ant][tinds, :] = rc_flags_subset[ant] + delta_flags[ant]
-                            abscal_chisq_per_ant[ant][tinds, :] = quals[ant] / nObs_per_ant[ant]  # Note, not normalized for DoF
+                            if not np.all(abscal_flags[ant][tinds, :]):
+                                abscal_chisq_per_ant[ant][tinds, :] = quals[ant] / nObs_per_ant[ant]  # Note, not normalized for DoF
                         for antpol in total_qual.keys():
                             abscal_chisq[antpol][tinds, :] = total_qual[antpol] / nObs[antpol]  # Note, not normalized for DoF
                             


### PR DESCRIPTION
Fixes the following issue by @zacharymartinot:

> I tried running the pipeline with min/max baseline lengths of 1-15m i.e. only use the shortest baselines and I ran into this error in ABSCAL step. Looks like this is because antenna 98 doesn't have a neighbor, so it isnt included in the abscal solution with these parameters. Supposedly antenna 98 is flagged already, so I'm not sure what needs to be done to get around this 
```TT_phs_logcal convergence criterion: 23.025083068618052
...configuring linsolve data for TT_phs_logcal
...running linsolve
...finished linsolve
TT_phs_logcal convergence criterion: 2.326672383473066e-14
Traceback (most recent call last):
  File "/lustre/aoc/projects/hera/zmartino/anaconda3/envs/main/bin/post_redcal_abscal_run.py",
 line 18, in <module>   
    phs_conv_crit=a.phs_conv_crit, clobber=a.clobber, add_to_history=' '.join(sys.argv), verbose=a.verbose)
  File "/lustre/aoc/projects/hera/zmartino/anaconda3/envs/main/lib/python3.7/site-packages/hera_cal/abscal.py", line 3016, in post_redcal_abscal_run
    abscal_chisq_per_ant[ant][tinds, :] = quals[ant] / nObs_per_ant[ant]  # Note, not normalized for DoF
KeyError: (98, 'Jxx')