### PR TITLE
Adds utils.red_average for redundant baseline averaging

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -796,10 +796,10 @@ def global_phase_slope_logcal(model, data, antpos, solver='linfit', wgts=None,
         red = [bl for bl in _red if bl in ap]
         if len(red) > 0:
             reds.append(red)
-    avg_data, avg_flags, _ = utils.red_average(data, reds=reds, wgt_by_int=False, flags=flags, inplace=False)
+    avg_data, avg_flags, _ = utils.red_average(data, reds=reds, flags=flags, inplace=False)
     red_keys = list(avg_data.keys())
     avg_wgts = DataContainer({k: (~avg_flags[k]).astype(np.float) for k in avg_flags})
-    avg_model, _, _ = utils.red_average(model, reds=reds, wgt_by_int=False, flags=flags, inplace=False)
+    avg_model, _, _ = utils.red_average(model, reds=reds, flags=flags, inplace=False)
 
     ls_data, ls_wgts, bls, pols = {}, {}, {}, {}
     for rk in red_keys:

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -33,6 +33,7 @@ from scipy import signal, interpolate, spatial
 from scipy.optimize import brute, minimize
 from pyuvdata import UVCal, UVData
 import linsolve
+import warnings
 
 from . import version
 from .apply_cal import calibrate_in_place
@@ -1494,7 +1495,8 @@ def avg_data_across_red_bls(data, antpos, wgts=None, broadcast_wgts=True, tol=1.
     Output: (red_data, red_wgts, red_keys)
     -------
     """
-    print("Warning: This function will be deprecated in the next hera_cal release.")
+    warnings.warn("Warning: This function will be deprecated in the next hera_cal release.")
+
     # get data keys
     keys = list(data.keys())
 

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -552,6 +552,11 @@ def test_red_average():
     # averaged data should equal original, unaveraged data due to weighting
     assert np.isclose(hda3.get_data(reds[0][0] + ('xx',)), hd.get_data(reds[0][0] + ('xx',))).all()
 
+    # exceptions
+    _data = copy.deepcopy(data)
+    _data.antpos = None
+    pytest.raises(ValueError, utils.red_average, _data)
+
 
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")
 def test_gain_relative_difference():

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -495,7 +495,7 @@ def test_red_average():
     blkey = reds[0][0] + ('xx',)
 
     # test redundant average
-    hda = utils.red_average(hd, reds, wgt_by_int=False, inplace=False)
+    hda = utils.red_average(hd, reds, inplace=False)
 
     # assert type and averaging is correct
     assert isinstance(hda, io.HERAData)
@@ -508,54 +508,55 @@ def test_red_average():
     assert np.isclose(hda.get_data(blkey), davg).all()
 
     # try with DataContainer
-    data_avg, flag_avg, _ = utils.red_average(data, reds, flags=flags, wgt_by_int=False, inplace=False)
+    data_avg, flag_avg, _ = utils.red_average(data, reds, flags=flags, inplace=False)
     assert isinstance(data_avg, datacontainer.DataContainer)
     assert len(data_avg) == len(reds)
     assert np.isclose(data_avg[blkey], davg).all()
     assert np.isclose(flag_avg[blkey], hda.get_flags(blkey)).all()
     # try with no flags
-    data_avg2, _, _ = utils.red_average(data, reds, wgt_by_int=False, inplace=False)
+    data_avg2, _, _ = utils.red_average(data, reds, inplace=False)
     assert np.isclose(data_avg2[blkey], np.mean([data[bl + ('xx',)] for bl in reds[0]], axis=0)).all()
 
     # test inplace
     _hda = copy.deepcopy(hd)
-    utils.red_average(_hda, wgt_by_int=False, inplace=True)
+    utils.red_average(_hda, inplace=True)
     assert hda == _hda
 
     # try with DataContainer
     data2, flags2 = copy.deepcopy(data), copy.deepcopy(flags)
-    utils.red_average(data2, flags=flags2, wgt_by_int=False, inplace=True)
+    utils.red_average(data2, flags=flags2, inplace=True)
     assert np.isclose(data2[blkey], data_avg[blkey]).all()
     assert np.isclose(flags2[blkey], flag_avg[blkey]).all()
 
     # try automatic red calc
-    hda2 = utils.red_average(hd, wgt_by_int=False, inplace=False)
+    hda2 = utils.red_average(hd, inplace=False)
     assert hda == hda2
-    data_avg3, _, _ = utils.red_average(data, flags=flags, wgt_by_int=False, inplace=False)
+    data_avg3, _, _ = utils.red_average(data, flags=flags, inplace=False)
     assert np.isclose(data_avg[blkey], data_avg3[blkey]).all()
 
     # try with large tolerance
-    hda3 = utils.red_average(hd, bl_tol=1000, wgt_by_int=False, inplace=False)
+    hda3 = utils.red_average(hd, bl_tol=1000, inplace=False)
     assert hda3.Nbls == 1
-
-    # try different weighting
-    hda3 = utils.red_average(hd, wgt_by_int=True, inplace=False)
-    # because nsamp is the same, this should == hda2
-    assert hda3 == hda2
 
     # now try with modified nsamples
     _hd = copy.deepcopy(hd)
     _hd.nsample_array[:] = 0.0
     _hd.nsample_array[hd.antpair2ind(reds[0][0] + ('xx',))] = 1.0
     _hd.flag_array[:] = False
-    hda3 = utils.red_average(_hd, wgt_by_int=True, inplace=False)
+    hda3 = utils.red_average(_hd, inplace=False)
     # averaged data should equal original, unaveraged data due to weighting
     assert np.isclose(hda3.get_data(reds[0][0] + ('xx',)), hd.get_data(reds[0][0] + ('xx',))).all()
+
+    # try with manual weights
+    wgts = datacontainer.DataContainer({k: _hd.get_nsamples(k) for k in _hd.get_antpairpols()})
+    hda4 = utils.red_average(_hd, wgts=wgts, inplace=False)
+    assert hda3 == hda4
 
     # exceptions
     _data = copy.deepcopy(data)
     _data.antpos = None
     pytest.raises(ValueError, utils.red_average, _data)
+    pytest.raises(ValueError, utils.red_average, 'foo')
 
 
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1093,8 +1093,9 @@ def red_average(hd, reds=None, bl_tol=1.0, wgt_by_int=False, inplace=False):
             # take the weighted average
             wsum = np.sum(w, axis=0).clip(1e-10, np.inf)
             davg = np.sum(d * w, axis=0) / wsum
-            navg = np.sum(n, axis=0)
-            iavg = np.sum(tint * w, axis=0) / wsum
+            navg = np.sum(n * f, axis=0)
+            fmax = np.max(f, axis=2)
+            iavg = np.sum(tint.squeeze() * fmax, axis=0) / np.sum(fmax, axis=0).clip(1e-10, np.inf)
             favg = np.isclose(wsum, 0.0)
 
             # replace in HERAData with first bl of blg

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1053,11 +1053,12 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
             The first baseline in each reds sublist is kept.
         wgts : DataContainer
             Manual weights to use in redundant average. This supercedes flags and nsamples
-            if provided, and will also be used if input data is a UVData or a subclass of it.
+            If provided, and will also be used if input data is a UVData or a subclass of it.
         flags : DataContainer
-            if data is a DataContainer, these are its flags
+            If data is a DataContainer, these are its flags. Default (None) is no flags.
         nsamples : DataContainer
-            if data is a DataContainer, these are its nsamples
+            If data is a DataContainer, these are its nsamples. Default (None) is 1.0 for all pixels.
+            Furthermore, if data is a DataContainer, integration_time is 1.0 for all pixels.
 
     Returns:
         if fed a DataContainer:


### PR DESCRIPTION
Adds `utils.red_average` for redundantly averaging baselines in a `HERAData` or `UVData` object, and replaces functionality in `abscal.avg_data_across_reds`