### PR TITLE
Allow redcal_run to output its results after iteration 0

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1558,6 +1558,8 @@ def redcal_argparser():
     a.add_argument("--omnical_ext", default='.omni.calfits', type=str, help="string to replace file extension of input_data for saving omnical calfits")
     a.add_argument("--omnivis_ext", default='.omni_vis.uvh5', type=str, help="string to replace file extension of input_data for saving omnical visibilities as uvh5")
     a.add_argument("--outdir", default=None, type=str, help="folder to save data products. Default is the same as the folder containing input_data")
+    a.add_argument("--iter0_prefix", default='', type=str, help="if not default '', save the omnical results with this prefix appended to each file after the 0th iteration, \
+                   but only if redcal has found any antennas to exclude and re-run without.")
     a.add_argument("--clobber", default=False, action="store_true", help="overwrites existing files for the firstcal and omnical results")
     a.add_argument("--verbose", default=False, action="store_true", help="print calibration progress updates")
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1426,10 +1426,11 @@ def _redcal_run_write_results(cal, hd, fistcal_filename, omnical_filename, omniv
 
     if verbose:
         print('Now saving omnical visibilities to', os.path.join(outdir, omnivis_filename))
-    hd.read(bls=cal['v_omnical'].keys())
-    hd.update(data=cal['v_omnical'], flags=cal['vf_omnical'], nsamples=cal['vns_omnical'])
-    hd.history += version.history_string(add_to_history)
-    hd.write_uvh5(os.path.join(outdir, omnivis_filename), clobber=True)
+    hd_out = HERAData(hd.filepaths[0], filetype=hd.filetype)
+    hd_out.read(bls=cal['v_omnical'].keys())
+    hd_out.update(data=cal['v_omnical'], flags=cal['vf_omnical'], nsamples=cal['vns_omnical'])
+    hd_out.history += version.history_string(add_to_history)
+    hd_out.write_uvh5(os.path.join(outdir, omnivis_filename), clobber=True)
 
 
 def redcal_run(input_data, filetype='uvh5', firstcal_ext='.first.calfits', omnical_ext='.omni.calfits', 
@@ -1542,9 +1543,8 @@ def redcal_run(input_data, filetype='uvh5', firstcal_ext='.first.calfits', omnic
                                       add_to_history=add_to_history + '\n' + 'Iteration 0 Results.\n')
 
     # output results files
-    _redcal_run_write_results(cal, hd, filename_no_ext + firstcal_ext, filename_no_ext + omnical_ext,
-                              filename_no_ext + omnivis_ext, outdir, clobber=clobber, verbose=verbose,
-                              add_to_history=add_to_history + '\n' + high_z_ant_hist)
+    _redcal_run_write_results(cal, hd, filename_no_ext + firstcal_ext, filename_no_ext + omnical_ext, filename_no_ext + omnivis_ext,
+                              outdir, clobber=clobber, verbose=verbose, add_to_history=add_to_history + '\n' + high_z_ant_hist)
 
     return cal
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1447,7 +1447,7 @@ class TestRunMethods(object):
             warnings.simplefilter("ignore")
             sys.stdout = open(os.devnull, 'w')
             cal = om.redcal_run(input_data, verbose=True, ant_z_thresh=1.8, add_to_history='testing',
-                    iter0_prefix='.iter0', ant_metrics_file=ant_metrics_file, clobber=True)
+                                iter0_prefix='.iter0', ant_metrics_file=ant_metrics_file, clobber=True)
 
             hd = io.HERAData(input_data)
             ex_ants = set([])

--- a/scripts/redcal_run.py
+++ b/scripts/redcal_run.py
@@ -12,8 +12,8 @@ import sys
 
 a = redcal_argparser()
 
-redcal_run(a.input_data, firstcal_ext=a.firstcal_ext, omnical_ext=a.omnical_ext, omnivis_ext=a.omnivis_ext,
-           outdir=a.outdir, ant_metrics_file=a.ant_metrics_file, clobber=a.clobber, nInt_to_load=a.nInt_to_load, pol_mode=a.pol_mode,
+redcal_run(a.input_data, firstcal_ext=a.firstcal_ext, omnical_ext=a.omnical_ext, omnivis_ext=a.omnivis_ext, outdir=a.outdir,
+           iter0_prefix=a.iter0_prefix, ant_metrics_file=a.ant_metrics_file, clobber=a.clobber, nInt_to_load=a.nInt_to_load, pol_mode=a.pol_mode,
            ex_ants=a.ex_ants, ant_z_thresh=a.ant_z_thresh, max_rerun=a.max_rerun, solar_horizon=a.solar_horizon, flag_nchan_low=a.flag_nchan_low,
            flag_nchan_high=a.flag_nchan_high, bl_error_tol=a.bl_error_tol, min_bl_cut=a.min_bl_cut, max_bl_cut=a.max_bl_cut, 
            fc_conv_crit=a.fc_conv_crit, fc_maxiter=a.fc_maxiter, oc_conv_crit=a.oc_conv_crit, oc_maxiter=a.oc_maxiter, 


### PR DESCRIPTION
This PR allows redcal to store the results of the first.calfits, omni.calfits, and omni_vis.uvh5 files (or whatever you call them, but those are the defaults) after the 0th iteration of redundant calibration (i.e. with no extra antenna flagging). This only happens when `iter0_prefix` is not `''` and when redcal actually needs to run multiple iterations to find and remove non-redundant antennas.

This closes #552.