### PR TITLE
Update read to support pyuvdata's handling of lists of files

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -42,7 +42,7 @@ class HERACal(UVCal):
         Arguments:
             input_cal: string calfits file path or list of paths
         '''
-        super(HERACal, self).__init__()
+        super().__init__()
 
         # parse input_data as filepath(s)
         if isinstance(input_cal, str):
@@ -211,7 +211,7 @@ class HERAData(UVData):
                 See UVData.read for more details.
         '''
         # initialize as empty UVData object
-        super(HERAData, self).__init__()
+        super().__init__()
 
         # parse input_data as filepath(s)
         if isinstance(input_data, str):

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -382,8 +382,8 @@ class HERAData(UVData):
         return data, flags, nsamples
 
     def read(self, bls=None, polarizations=None, times=None, frequencies=None,
-             freq_chans=None, read_data=True, return_data=True, run_check=True,
-             check_extra=True, run_check_acceptability=True):
+             freq_chans=None, axis=None, read_data=True, return_data=True,
+             run_check=True, check_extra=True, run_check_acceptability=True):
         '''Reads data from file. Supports partial data loading. Default: read all data in file.
 
         Arguments:
@@ -401,6 +401,8 @@ class HERAData(UVData):
                 is False. Miriad will load then select on this axis.
             freq_chans: The frequency channel numbers to include when reading data. Ignored
                 if read_data is False. Miriad will load then select on this axis.
+            axis: Axis for fast concatenation of files (if len(self.filepaths) > 1).
+                Allowed values are: 'blt', 'freq', 'polarization'.
             read_data: Read in the visibility and flag data. If set to false, only the
                 basic metadata will be read in and nothing will be returned. Results in an
                 incompletely defined object (check will not pass). Default True.
@@ -427,26 +429,23 @@ class HERAData(UVData):
         if self.filepaths is not None:
             # load data
             if self.filetype == 'uvh5':
-                self.read_uvh5(self.filepaths, bls=bls, polarizations=polarizations, times=times,
-                               frequencies=frequencies, freq_chans=freq_chans, read_data=read_data,
-                               run_check=run_check, check_extra=check_extra,
-                               run_check_acceptability=run_check_acceptability)
+                super().read(self.filepaths, file_type='uvh5', axis=axis, bls=bls, polarizations=polarizations,
+                             times=times, frequencies=frequencies, freq_chans=freq_chans, read_data=read_data,
+                             run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability)
             else:
                 if not read_data:
                     raise NotImplementedError('reading only metadata is not implemented for ' + self.filetype)
                 if self.filetype == 'miriad':
-                    self.read_miriad(self.filepaths, bls=bls, polarizations=polarizations,
-                                     run_check=run_check, check_extra=check_extra,
-                                     run_check_acceptability=run_check_acceptability)
+                    super().read(self.filepaths, file_type='miriad', axis=axis, bls=bls, polarizations=polarizations,
+                                 run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability)
                     if any([times is not None, frequencies is not None, freq_chans is not None]):
                         warnings.warn('miriad does not support partial loading for times and frequencies. '
                                       'Loading the file first and then performing select.')
                         self.select(times=times, frequencies=frequencies, freq_chans=freq_chans)
                 elif self.filetype == 'uvfits':
-                    self.read_uvfits(self.filepaths, bls=bls, polarizations=polarizations,
-                                     times=times, frequencies=frequencies, freq_chans=freq_chans,
-                                     run_check=run_check, check_extra=check_extra,
-                                     run_check_acceptability=run_check_acceptability)
+                    super().read(self.filepaths, file_type='uvfits', axis=axis, bls=bls, polarizations=polarizations,
+                                 times=times, frequencies=frequencies, freq_chans=freq_chans, run_check=run_check,
+                                 check_extra=check_extra, run_check_acceptability=run_check_acceptability)
                     self.unphase_to_drift()
 
         # process data into DataContainers

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -233,7 +233,7 @@ class Test_HERAData(object):
         hd = HERAData(self.uvh5_1)
         assert hd._polnum_indices == {-5: 0}
         hd = HERAData(self.four_pol, filetype='miriad')
-        hd.read(bls=[(53, 53)])
+        hd.read(bls=[(53, 53)], axis='polarization')
         assert hd._polnum_indices == {-8: 3, -7: 2, -6: 1, -5: 0}
 
     def test_get_slice(self):
@@ -329,6 +329,20 @@ class Test_HERAData(object):
         # assert __getitem__ is a read when key does not exist
         o = hd[(54, 54, 'ee')]
         assert len(hd._blt_slices) == 1
+
+        # test read list
+        hd = HERAData([self.uvh5_1, self.uvh5_2])
+        d, f, n = hd.read(axis='blt')
+        for dc in [d, f, n]:
+            assert len(dc) == 3
+            assert len(dc.times) == 120
+            assert len(dc.lsts) == 120
+            assert len(dc.freqs) == 1024
+            for i in [53, 54]:
+                for j in [53, 54]:
+                    assert (i, j, 'ee') in dc
+            for bl in dc:
+                assert dc[bl].shape == (120, 1024)
 
         # miriad
         hd = HERAData(self.miriad_1, filetype='miriad')


### PR DESCRIPTION
We now use super to call `UVData.read()` rather than calling `UVData.read_uvh5()`, etc. inside `io.HERAData` objects. Also added support for fast concatenation via the `axis` paramter.

This closes #549.