### PR TITLE
Remove unused check_histories

### DIFF
--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -12,7 +12,6 @@ import sys
 import shutil
 from scipy import constants
 import warnings
-from pyuvdata.utils import check_histories
 from pyuvdata import UVCal, UVData
 
 from .. import io

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -11,7 +11,6 @@ import sys
 import shutil
 from scipy import constants
 import warnings
-from pyuvdata.utils import check_histories
 from pyuvdata import UVCal, UVData
 
 from .. import io, smooth_cal, utils


### PR DESCRIPTION
These are deprecated in pyuvdata 1.5, but we don't use them anyway.