### PR TITLE
Remove deprecated transposition in write_vis

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1104,7 +1104,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     # get antenna positions in ITRF frame
     tel_lat_lon_alt = uvutils.LatLonAlt_from_XYZ(telescope_location)
     antenna_positions = np.array(list(map(lambda k: antpos[k], antenna_numbers)))
-    antenna_positions = uvutils.ECEF_from_ENU(antenna_positions.T, *tel_lat_lon_alt).T - telescope_location
+    antenna_positions = uvutils.ECEF_from_ENU(antenna_positions, *tel_lat_lon_alt) - telescope_location
 
     # get zenith location: can only write drift phase
     phase_type = 'drift'

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -628,15 +628,18 @@ class Test_Visibility_IO_Legacy(object):
             nsample[k] = np.ones_like(nsample[k], np.float)
 
         # test basic execution
-        uvd = io.write_vis("ex.uv", data, l, f, ap, start_jd=2458044, return_uvd=True, overwrite=True, verbose=True, x_orientation='east')
-        uvd2 = UVData()
-        uvd2.read_miriad('ex.uv')
-        assert os.path.exists('ex.uv')
+        uvd = io.write_vis("ex.uvh5", data, l, f, ap, start_jd=2458044, return_uvd=True, overwrite=True, verbose=True, x_orientation='east', filetype='uvh5')
+        hd = HERAData("ex.uvh5")
+        hd.read()
+        assert os.path.exists('ex.uvh5')
         assert uvd.data_array.shape == (1680, 1, 64, 1)
-        assert uvd2.data_array.shape == (1680, 1, 64, 1)
+        assert hd.data_array.shape == (1680, 1, 64, 1)
         assert np.allclose(data[(24, 25, 'ee')][30, 32], uvd.get_data(24, 25, 'ee')[30, 32])
-        assert np.allclose(data[(24, 25, 'ee')][30, 32], uvd2.get_data(24, 25, 'ee')[30, 32])
-        assert uvd2.x_orientation.lower() == 'east'
+        assert np.allclose(data[(24, 25, 'ee')][30, 32], hd.get_data(24, 25, 'ee')[30, 32])
+        assert hd.x_orientation.lower() == 'east'
+        for ant in ap:
+            np.testing.assert_array_almost_equal(hd.antpos[ant], ap[ant])
+        os.remove("ex.uvh5")
 
         # test with nsample and flags
         uvd = io.write_vis("ex.uv", data, l, f, ap, start_jd=2458044, flags=flgs, nsamples=nsample, x_orientation='east', return_uvd=True, overwrite=True, verbose=True)


### PR DESCRIPTION
This was creating an error in pyvudata.

Add test to make sure antenna position dictionaries produced are correct.