### PR TITLE
Future install and scipy.sparse.linalg svd ordering issue fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - astropy-healpix
   - pyephem
   - basemap
+  - future
   - pip:
     - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
     - git+https://github.com/HERA-Team/hera_qm

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -580,6 +580,11 @@ class ReflectionFitter(FRFilter):
                 if Nk is None:
                     Nk = min(dfft[k].shape) - 2
                 u, svals, v = sparse.linalg.svds(dfft[k] * wgts[k], k=Nk, which='LM')
+                # some numpy versions flip SV ordering here: make sure its high-to-low
+                if svals[1] > svals[0]:
+                    svals = svals[::-1]
+                    u = u[:, ::-1]
+                    v = v[::-1, :]
             else:
                 u, svals, v = np.linalg.svd(dfft[k] * wgts[k], full_matrices=False)
 

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -581,7 +581,7 @@ class ReflectionFitter(FRFilter):
                     Nk = min(dfft[k].shape) - 2
                 u, svals, v = sparse.linalg.svds(dfft[k] * wgts[k], k=Nk, which='LM')
                 # some numpy versions flip SV ordering here: make sure its high-to-low
-                if svals[1] > svals[0]:
+                if svals[-1] > svals[0]:
                     svals = svals[::-1]
                     u = u[:, ::-1]
                     v = v[::-1, :]

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -341,8 +341,6 @@ class Test_ReflectionFitter_XTalk(object):
         # test containers exist
         assert np.all([hasattr(RF, o) for o in ['umodes', 'vmodes', 'svals', 'uflags', 'pcomp_model', 'dfft']])
         # test good information compression
-        print(RF.data[bl])
-        print(RF.svals[bl])
         assert RF.svals[bl][0] / RF.svals[bl][1] > 20
 
         # assert its a good fit to the xtalk at 250 ns delay

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -341,6 +341,8 @@ class Test_ReflectionFitter_XTalk(object):
         # test containers exist
         assert np.all([hasattr(RF, o) for o in ['umodes', 'vmodes', 'svals', 'uflags', 'pcomp_model', 'dfft']])
         # test good information compression
+        print(RF.data[bl])
+        print(RF.svals[bl])
         assert RF.svals[bl][0] / RF.svals[bl][1] > 20
 
         # assert its a good fit to the xtalk at 250 ns delay


### PR DESCRIPTION
Made `future` an explicit dependency in travis, and also fixed an SVD eigenvalue ordering problem that some versions of numpy exhibit, where the orders is low-to-high instead of the usual high-to-low, which was causing a test to fail. Fixed this by spotting and correcting the ordering when it occurs.