### PR TITLE
Add apply_cal x_orientation check

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,6 @@ dependencies:
     - git+https://github.com/HERA-Team/hera_qm
     - git+https://github.com/HERA-Team/linsolve
     - git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim
+    - git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/hera_sim

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -13,14 +13,15 @@ from . import utils
 
 
 def _check_polarization_consistency(data, gains):
-    '''This fucntion raises an error if all the gain keys are cardinal but none of the data keys are 
-    cardinal (e/n rather than x/y), or vice versa. In the mixed case, no errors are raised.'''
-    data_keys_cardinal = [utils._is_cardinal(bl[2]) for bl in data.keys()]
-    gain_keys_cardinal = [utils._is_cardinal(ant[1]) for ant in gains.keys()]
-    if np.all(data_keys_cardinal) and not np.any(gain_keys_cardinal):
-        raise KeyError("All the data keys are cardinal (e.g. 'nn' or 'ee'), but none of the gain keys are.")
-    elif np.all(gain_keys_cardinal) and not np.any(data_keys_cardinal):
-        raise KeyError("All the gain keys are cardinal (e.g. 'Jnn' or 'Jee'), but none of the data keys are.")
+    '''This fucntion raises an error if all the gain keys are cardinal but none of the data keys are cardinal
+    (e/n rather than x/y), or vice versa. In the mixed case, or if one is empty, no errors are raised.'''
+    if (len(data) > 0) and (len(gains) > 0):
+        data_keys_cardinal = [utils._is_cardinal(bl[2]) for bl in data.keys()]
+        gain_keys_cardinal = [utils._is_cardinal(ant[1]) for ant in gains.keys()]
+        if np.all(data_keys_cardinal) and not np.any(gain_keys_cardinal):
+            raise KeyError("All the data keys are cardinal (e.g. 'nn' or 'ee'), but none of the gain keys are.")
+        elif np.all(gain_keys_cardinal) and not np.any(data_keys_cardinal):
+            raise KeyError("All the gain keys are cardinal (e.g. 'Jnn' or 'Jee'), but none of the data keys are.")
 
 
 def calibrate_redundant_solution(data, data_flags, new_gains, new_flags, all_reds,

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -20,7 +20,7 @@ def _check_polarization_consistency(data, gains):
     if np.all(data_keys_cardinal) and not np.any(gain_keys_cardinal):
         raise KeyError("All the data keys are cardinal (e.g. 'nn' or 'ee'), but none of the gain keys are.")
     elif np.all(gain_keys_cardinal) and not np.any(data_keys_cardinal):
-        KeyError("All the gain keys are cardinal (e.g. 'Jnn' or 'Jee'), but none of the data keys are.")
+        raise KeyError("All the gain keys are cardinal (e.g. 'Jnn' or 'Jee'), but none of the data keys are.")
 
 
 def calibrate_redundant_solution(data, data_flags, new_gains, new_flags, all_reds,

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -151,11 +151,12 @@ class Test_Update_Cal(object):
         # test flag propagation when missing antennas in gains
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.calibrate_in_place(dc, {}, flags, cal_flags, gain_convention='divide')
+        wrong_ant_gains = {(2, 'Jxx'): deepcopy(g0_new)}
+        ac.calibrate_in_place(dc, wrong_ant_gains, flags, cal_flags, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains={}, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains=wrong_ant_gains, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
 
         # test error

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -151,12 +151,11 @@ class Test_Update_Cal(object):
         # test flag propagation when missing antennas in gains
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        wrong_ant_gains = {(2, 'Jxx'): deepcopy(g0_new)}
-        ac.calibrate_in_place(dc, wrong_ant_gains, flags, cal_flags, gain_convention='divide')
+        ac.calibrate_in_place(dc, {}, flags, cal_flags, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
         dc = DataContainer({(0, 1, 'xx'): deepcopy(vis)})
         flags = DataContainer({(0, 1, 'xx'): deepcopy(f)})
-        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains=wrong_ant_gains, gain_convention='divide')
+        ac.calibrate_in_place(dc, g_new, flags, cal_flags, old_gains={}, gain_convention='divide')
         np.testing.assert_array_equal(flags[(0, 1, 'xx')], True)
 
         # test error

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -25,6 +25,21 @@ from .. import utils
 @pytest.mark.filterwarnings("ignore:It seems that the latitude and longitude are in radians")
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")
 class Test_Update_Cal(object):
+    def test_check_polarization_consistency(self):
+        gains = {(0, 'Jnn'): np.zeros((2, 2))}
+        data = {(0, 1, 'nn'): np.zeros((2, 2))}
+        ac._check_polarization_consistency(data, gains)
+
+        gains = {(0, 'Jnn'): np.zeros((2, 2))}
+        data = {(0, 1, 'xx'): np.zeros((2, 2))}
+        with pytest.raises(KeyError):
+            ac._check_polarization_consistency(data, gains)
+
+        gains = {(0, 'Jxx'): np.zeros((2, 2))}
+        data = {(0, 1, 'nn'): np.zeros((2, 2))}
+        with pytest.raises(KeyError):
+            ac._check_polarization_consistency(data, gains)
+
     def test_calibrate_avg_gains_in_place(self):
         np.random.seed(20)
         vis = np.random.randn(10, 10) + 1.0j * np.random.randn(10, 10)


### PR DESCRIPTION
Added a check in `apply_cal.calibrate_in_place` and `apply_cal.calibrate_redundant_solution` to make sure if that all the gain keys are cardinal (e.g. north/east rather than x/y) but all the data keys are not (or vice versa), an error is raised.

This closes #570.