### PR TITLE
Fix too many dimensions in idealized antpos

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2856,10 +2856,9 @@ def post_redcal_abscal(model, data, flags, rc_flags, min_bl_cut=None, max_bl_cut
     idealized_antpos = redcal.reds_to_antpos(redcal.get_reds(data.antpos, bl_error_tol=tol), tol=IDEALIZED_BL_TOL)
     if np.max([len(pos) for pos in idealized_antpos.values()]) > 2:  # the array is not redundant (i.e. extra degeneracies)
         suspected_off_grid = [ant for ant, pos in idealized_antpos.items() if np.any(np.abs(pos[2:]) > IDEALIZED_BL_TOL)]
-        ex_ants = [ant for ant in idealized_antpos if np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
+        not_flagged = [ant for ant in suspected_off_grid if not np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
         warnings.warn(('WARNING: The following antennas appear not to be redundant with the main array:\n         {}\n'
-                       '         Of them, {} is not flagged.\n').format(suspected_off_grid, 
-                                                                     [ant for ant in suspected_off_grid if ant not in ex_ants]))
+                       '         Of them, {} is not flagged.\n').format(suspected_off_grid, not_flagged))
         idealized_antpos = {ant: pos[:2] for ant, pos in idealized_antpos.items()}
     AC._set_antpos(idealized_antpos)
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2857,8 +2857,8 @@ def post_redcal_abscal(model, data, flags, rc_flags, min_bl_cut=None, max_bl_cut
     if np.max([len(pos) for pos in idealized_antpos.values()]) > 2:  # the array is not redundant (i.e. extra degeneracies)
         suspected_off_grid = [ant for ant, pos in idealized_antpos.items() if np.any(np.abs(pos[2:]) > IDEALIZED_BL_TOL)]
         ex_ants = [ant for ant in idealized_antpos if np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
-        warnings.warn(('WARNING: The following antennas appear not to be redundant with the main array:\n{}\n'
-                       '         Of them, {} is not flagged').format(suspected_off_grid, 
+        warnings.warn(('WARNING: The following antennas appear not to be redundant with the main array:\n         {}\n'
+                       '         Of them, {} is not flagged.\n').format(suspected_off_grid, 
                                                                      [ant for ant in suspected_off_grid if ant not in ex_ants]))
         idealized_antpos = {ant: pos[:2] for ant, pos in idealized_antpos.items()}
     AC._set_antpos(idealized_antpos)

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2853,7 +2853,9 @@ def post_redcal_abscal(model, data, flags, rc_flags, min_bl_cut=None, max_bl_cut
                 refant=refant_num, min_bl_cut=min_bl_cut, max_bl_cut=max_bl_cut)
     
     # use idealized antpos derived from the reds that results in perfect redundancy, then use tol ~ 0 subsequently
-    idealized_antpos = redcal.reds_to_antpos(redcal.get_reds(data.antpos, bl_error_tol=tol))
+    ex_ants = [ant for ant in data.antpos if np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
+    reds = redcal.filter_reds(redcal.get_reds(data.antpos, bl_error_tol=tol), ex_ants=ex_ants)
+    idealized_antpos = redcal.reds_to_antpos(reds, tol=IDEALIZED_BL_TOL)
     AC._set_antpos(idealized_antpos)
 
     # Per-Channel Absolute Amplitude Calibration

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2859,7 +2859,7 @@ def post_redcal_abscal(model, data, flags, rc_flags, min_bl_cut=None, max_bl_cut
         ex_ants = [ant for ant in idealized_antpos if np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
         warnings.warn(('WARNING: The following antennas appear not to be redundant with the main array:\n{}\n'
                        '         Of them, {} is not flagged').format(suspected_off_grid, 
-                                                                      [ant for ant in suspected_off_grid if ant not in ex_ants]))
+                                                                     [ant for ant in suspected_off_grid if ant not in ex_ants]))
         idealized_antpos = {ant: pos[:2] for ant, pos in idealized_antpos.items()}
     AC._set_antpos(idealized_antpos)
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2856,6 +2856,7 @@ def post_redcal_abscal(model, data, flags, rc_flags, min_bl_cut=None, max_bl_cut
     ex_ants = [ant for ant in data.antpos if np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
     reds = redcal.filter_reds(redcal.get_reds(data.antpos, bl_error_tol=tol), ex_ants=ex_ants)
     idealized_antpos = redcal.reds_to_antpos(reds, tol=IDEALIZED_BL_TOL)
+    idealized_antpos.update({xa: np.zeros_like(list(idealized_antpos.values())[0]) for xa in ex_ants})
     AC._set_antpos(idealized_antpos)
 
     # Per-Channel Absolute Amplitude Calibration

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -224,6 +224,7 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
 def reds_to_antpos(reds, tol=1e-10):
     '''Computes a set of antenna positions consistent with the given redundancies.
     Useful for projecting out phase slope degeneracies, see https://arxiv.org/abs/1712.07212
+
     Arguments:
         reds: list of lists of redundant baseline tuples, either (i,j,pol) or (i,j)
         tol: level for two vectors to be considered equal (enabling dimensionality reduction)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -727,7 +727,8 @@ class Test_Post_Redcal_Abscal_Run(object):
                                AC.custom_phs_slope_gain, AC.custom_TT_Phi_gain],
                               [(), (AC.antpos,), (AC.antpos,), (AC.antpos,)]):
             custom_gains = func([gkxx, gkyy], *args)
-            assert not np.all(np.isclose(np.abs(custom_gains[gkxx] - custom_gains[gkyy]), 0.0, atol=1e-12))
+            if not np.all(rc_gains_subset[gkxx]) and not np.all(rc_gains_subset[gkyy]):
+                assert not np.all(np.isclose(np.abs(custom_gains[gkxx] - custom_gains[gkyy]), 0.0, atol=1e-12))
 
     def test_post_redcal_abscal_run(self):
         with warnings.catch_warnings():

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -727,8 +727,7 @@ class Test_Post_Redcal_Abscal_Run(object):
                                AC.custom_phs_slope_gain, AC.custom_TT_Phi_gain],
                               [(), (AC.antpos,), (AC.antpos,), (AC.antpos,)]):
             custom_gains = func([gkxx, gkyy], *args)
-            if not np.all(rc_gains_subset[gkxx]) and not np.all(rc_gains_subset[gkyy]):
-                assert not np.all(np.isclose(np.abs(custom_gains[gkxx] - custom_gains[gkyy]), 0.0, atol=1e-12))
+            assert not np.all(np.isclose(np.abs(custom_gains[gkxx] - custom_gains[gkyy]), 0.0, atol=1e-12))
 
     def test_post_redcal_abscal_run(self):
         with warnings.catch_warnings():


### PR DESCRIPTION
This is currently breaking the pipeline H1C IDR3. 

When off-grid antennas are included, the idealized_antpos will have too many dimensions (get reds only works up to 3D). Here we lop off those extra dimensions and warn the user, making sure that reds_to_antpos puts the most important dimensions first so that the extraneous dimensions are always at the end.