### PR TITLE
Reference Antenna Flag Propagation

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3025,7 +3025,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, output_file=None
         # impose a single reference antenna on the final antenna solution
         if refant is None:
             refant = pick_reference_antenna(abscal_gains, abscal_flags, hc.freqs, per_pol=True)
-        rephase_to_refant(abscal_gains, refant, flags=abscal_flags)
+        rephase_to_refant(abscal_gains, refant, flags=abscal_flags, propagate_refant_flags=True)
     else:
         echo("No model files overlap with data files in LST. Result will be fully flagged.", verbose=verbose)
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -333,6 +333,9 @@ def rephase_to_refant(gains, refant, flags=None, propagate_refant_flags=False):
         flags: Optional dictionary mapping antenna keys to flag waterfall.
             Used only to verify that all gains are flagged where the refant is flagged.
         propagate_refant_flags: If True and flags is not None, update flags so that all antennas are flagged
+            at the specific frequencies and times that the reference antenna is also flagged. If False and
+            there exists times and frequencies where the reference antenna is flagged but another antenna
+            is not flagged, a ValueError will be raised.
     '''
     for pol, ref in (refant.items() if not isinstance(refant, tuple) else [(None, refant)]):
         refant_phasor = gains[ref] / np.abs(gains[ref])

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -157,6 +157,9 @@ class Test_Smooth_Cal_Helper_Functions(object):
                  (1, 'Jxx'): np.array([True, False])}
         with pytest.raises(ValueError):
             smooth_cal.rephase_to_refant(gains, (0, 'Jxx'), flags=flags)
+        smooth_cal.rephase_to_refant(gains, (0, 'Jxx'), flags=flags, propagate_refant_flags=True)
+        np.testing.assert_array_equal(flags[0, 'Jxx'], np.array([False, True]))
+        np.testing.assert_array_equal(flags[1, 'Jxx'], np.array([True, True]))
 
 
 class Test_Calibration_Smoother(object):


### PR DESCRIPTION
On a single integration of a single file in IDR3 (2458185.23736) I'm finding that the antenna chosen automatically as the reference in abscal (in part because it has the minimal number of flags) has flags where another antenna does not. This raises an error, but it seems to me like the safest thing to do is just also flag those antennas there. This implements that as an option for rephase_to_reference.