### PR TITLE
Update polarity solver

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -265,9 +265,11 @@ def _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=0, max_rel_angl
     or "even" (two or zero flipped antennas). See find_polarity_flipped_ants() for parameter descriptions.
     '''
     # make sure edge_cut and max_rel_angle are sensible
-    assert 0 < max_rel_angle <= np.pi / 2, "max_rel_angle must be between 0 and np.pi/2."
+    if not (0 < max_rel_angle <= np.pi / 2):
+        raise ValueError("max_rel_angle must be between 0 and np.pi/2.")
     Nfreqs = list(dly_cal_data.values())[0].shape[1]
-    assert 2 * edge_cut < Nfreqs, "edge_cut cannot be >= Nfreqs/2"
+    if 2 * edge_cut >= Nfreqs:
+        raise ValueError("edge_cut cannot be >= Nfreqs/2")
     fslice = slice(edge_cut, Nfreqs - edge_cut)
 
     polarity_groups = {}

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -292,10 +292,10 @@ def _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=0, max_rel_angl
 
 
 def _infer_polarity_flips(polarity_groups, prior_is_flipped, prior_even_vs_odd_IDs):
-    '''Take a set of polarity groups built by _build_polarity_baseline_groups() and 
-    prior identifications of which antennas are flipped and which groups are "even" 
-    (0 or 2 polarity flips) and which ones are "odd" (1 polarity flip). Use those 
-    priors to infer as many additional flips and groups IDs as possible and return
+    '''Take a set of polarity groups built by _build_polarity_baseline_groups() and prior 
+    identifications of which antennas are flipped and which groups of baselines are "even" 
+    (0 or 2 polarity flipped antennas) and which ones are "odd" (1 polarity flipped antenna). 
+    Use those priors to infer as many additional flips and groups IDs as possible and return
     the updated is_flipped and even_vs_odd_IDs dictionaries after getting stuck.
     '''
     is_flipped, even_vs_odd_IDs = deepcopy(prior_is_flipped), deepcopy(prior_even_vs_odd_IDs)
@@ -432,9 +432,9 @@ def find_polarity_flipped_ants(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np
            and define its polarity as "not flipped."
         4) Follow that chain of logic as far as possible, identifying as many groups and antennas as possible.
         5) If a full solution is found, return it.
-        5) When we get stuck, make anther assumption recursively (go to 2) about the most-lopsided un-IDed group.
+        5) When we get stuck, make another assumption recursively (go to 2) about the most-lopsided un-IDed group.
         6) Continue until a contradiction arises or the max_recursion_depth is reached. In that case, try the 
-           opposite assumption at the previous step, eventually recursivly trying all assumptions.
+           opposite assumption at the previous step, eventually recursively trying all assumptions.
 
     Arugments:
         dly_cal_data: DataContainer mapping baseline tuples e.g. (0, 1, 'Jee') to delay-only calibrated visibilities
@@ -830,8 +830,8 @@ class RedundantCalibrator:
                 for find_polarity_flipped_ants or when computing delays and offsets in utils.fft_dly
             max_rel_angle: cutoff median phase to assign baselines the "majority" polarity group.
                 (pi - max_rel_angle() is the cutoff for "minority" group. Must be between 0 and pi/2.
-            max_recursion_depth: maximum number of assumptions to try before giving up. Warning: the 
-                complexity of this scales exponentially as 2^max_recursion_depth.
+            max_recursion_depth: maximum number of assumptions to try before giving up.
+                Warning: the maximum complexity of this scales exponentially as 2^max_recursion_depth.
 
         Returns:
             meta: dictionary of metadata (including delays and suspected antenna flips for each integration)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -451,7 +451,7 @@ def find_polarity_flipped_ants(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np
     '''
     
     ants = set([ant for red in reds for bl in red for ant in utils.split_bl(bl)])
-    polarity_groups = _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=edge_cut, max_rel_angle=np.pi/8)
+    polarity_groups = _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=edge_cut, max_rel_angle=np.pi / 8)
     
     try:
         is_flipped, even_vs_odd_IDs = _recursive_try_assumptions(polarity_groups, ants, {}, {}, 1, max_recursion_depth=5)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -802,7 +802,7 @@ class RedundantCalibrator:
 
     def firstcal(self, data, freqs, wgts={}, maxiter=25, conv_crit=1e-6,
                  sparse=False, mode='default', norm=True, medfilt=False, kernel=(1, 11),
-                 edge_cut=0, max_rel_angle=(np.pi / 8), max_assumptions=5):
+                 edge_cut=0, max_rel_angle=(np.pi / 8), max_recursion_depth=6):
         """Solve for a calibration solution parameterized by a single delay and phase offset
         per antenna using the phase difference between nominally redundant measurements. 
         Delays are solved in a single iteration, but phase offsets are solved for 
@@ -828,8 +828,8 @@ class RedundantCalibrator:
                 for find_polarity_flipped_ants or when computing delays and offsets in utils.fft_dly
             max_rel_angle: cutoff median phase to assign baselines the "majority" polarity group.
                 (pi - max_rel_angle() is the cutoff for "minority" group. Must be between 0 and pi/2.
-            max_assumptions: maximum number of assumptions to try before giving up. Warning: the complexity
-                of this scales exponentially as 2^max_assumptions.
+            max_recursion_depth: maximum number of assumptions to try before giving up. Warning: the 
+                complexity of this scales exponentially as 2^max_recursion_depth.
 
         Returns:
             meta: dictionary of metadata (including delays and suspected antenna flips for each integration)
@@ -851,7 +851,8 @@ class RedundantCalibrator:
                 
                 # build metadata and apply detected polarities as a firstcal starting point
                 meta = {'dlys': {ant: dly.flatten() for ant, dly in dlys.items()}}
-                polarity_flips = find_polarity_flipped_ants(data, self.reds, max_rel_angle=max_rel_angle, edge_cut=edge_cut, max_assumptions=max_assumptions)
+                polarity_flips = find_polarity_flipped_ants(data, self.reds, max_rel_angle=max_rel_angle,
+                                                            edge_cut=edge_cut, max_recursion_depth=max_recursion_depth)
                 meta['polarity_flips'] = {ant: np.array([polarity_flips[ant] for i in range(len(dlys[ant]))])
                                           for ant in polarity_flips}
                 if np.all([flip is not None for flip in polarity_flips.values()]):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -404,8 +404,8 @@ def _recursive_try_assumptions(polarity_groups, ants, prior_is_flipped, prior_ev
     for assumed_ID in ['even/odd', 'odd/even']:
         even_vs_odd_IDs = deepcopy(prior_even_vs_odd_IDs)
         even_vs_odd_IDs[new_assumption_key] = assumed_ID
-        if len(prior_is_flipped) == 0:  # we need a starting antenna as a reference
-            prior_is_flipped = _find_starting_is_flipped(polarity_groups, ants, even_vs_odd_IDs)
+        # find new starting assumption about antennas based on the current even_vs_odd_IDs
+        prior_is_flipped = _find_starting_is_flipped(polarity_groups, ants, even_vs_odd_IDs)
         try:
             new_is_flipped, new_even_vs_odd_IDs = _infer_polarity_flips(polarity_groups, prior_is_flipped, even_vs_odd_IDs)
             return _recursive_try_assumptions(polarity_groups, ants, new_is_flipped, new_even_vs_odd_IDs, 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -446,6 +446,9 @@ def find_polarity_flipped_ants(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np
                 break
             except AssertionError:
                 is_flipped = {ant: None for ant in ants}  # this means it hasn't succeded.
+        if not np.all([is_flipped[ant] is None for ant in ants]):
+            break
+
     return {ant: (is_flipped[ant] if ant in is_flipped else None) for ant in ants}
 
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -248,10 +248,10 @@ class TestMethods(object):
             assert np.all([m is None for m in meta['polarity_flips'][ant]])
 
         # test errors
-        with pytest.raises(AssertionError):
-            meta, g_fc = rc.firstcal(data, freqs, edge_cut=100)
-        with pytest.raises(AssertionError):
-            meta, g_fc = rc.firstcal(data, freqs, max_rel_angle=np.pi)
+        with pytest.raises(ValueError):
+            om._build_polarity_baseline_groups(data, reds, edge_cut=100)
+        with pytest.raises(ValueError):
+            om._build_polarity_baseline_groups(data, reds, max_rel_angle=np.pi)
 
 
 class TestRedundantCalibrator(object):


### PR DESCRIPTION
I've reworked the way the polarity solver works. The top level interface is the same, but under the hood the main change is as follows.

Before: Take a set of ~5 common baselines, iterate through all assumptions whether the groupings are even/odd or odd/even, and then try to reach a conclusion about the polarity of all the antennas. Unfortunately, this often got stuck, especially when none of the baselines connected disjoint parts of the array (this will be an even bigger issue when the array crosses the split hex boundaries).

Now: Pick a baseline, try an assumption, and see how far that carries you. Make more assumptions recursively until a solution is found, a contradiction is found or some maximum depth is reached. When you fail on an assumption, try the opposite assumption (again recursively).

In my experiments, this found valid polarity solutions far more often. Note the titles of Figure 7:

Before: https://github.com/HERA-Team/H3C_plots/blob/f5749c05ee7dd91496c7c1d6f5be7b2b8f9d228d/Redcal_Inspect_2458838.ipynb
After: https://github.com/HERA-Team/H3C_plots/blob/f02bf3a5a5ac3a1de3a2e3af47cc0df42fead6cd/Redcal_Inspect_2458838.ipynb