### PR TITLE
Abscal Weighting Fix For Redundant Data

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2993,9 +2993,7 @@ def build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flag
         if antpos is None:
             antpos = data_flags.antpos
         reds = redcal.get_reds(antpos, bl_error_tol=tol, pols=data_flags.pols())
-        ex_ants = [ant for ant, flags in gain_flags.items() if np.all(flags)]
         reds = redcal.filter_reds(reds, ants=[split_bl(bl)[0] for bl in autocorrs])
-        reds = redcal.filter_reds(reds, ex_ants=ex_ants)
 
     # build weights dict using (noise variance * nsamples)^-1 * (0 if data or model is flagged)
     wgts = {}
@@ -3010,7 +3008,7 @@ def build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flag
             # use autocorrelations from all unflagged antennas in unique baseline to produce weights
             else:
                 try:  # get redundant group that includes this baseline
-                    red_here = [red for red in reds if bl in red][0]
+                    red_here = [red for red in reds if (bl in red) or (reverse_bl(bl) in red)][0]
                 except IndexError:  # this baseline has no unflagged redundancies
                     noise_var = np.inf
                 else:

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -757,7 +757,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         autocorrs = DataContainer({bl: np.ones((3, 4), dtype=complex) for bl in auto_bls})
         autocorrs[(1, 1, 'ee')][2, 2] = 3
         auto_flags = DataContainer({bl: np.zeros((3, 4), dtype=bool) for bl in auto_bls})
-        
+
         wgts = abscal.build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flags)
         for bl in wgts:
             for t in range(3):
@@ -779,16 +779,18 @@ class Test_Post_Redcal_Abscal_Run(object):
         data_flags = DataContainer({bl: np.zeros((3, 4), dtype=bool) for bl in bls})
         data_flags.times_by_bl = {bl[:2]: np.arange(3) / 86400 for bl in bls}
         data_flags.freqs = np.arange(4)
-        data_flags.antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0])}
+        data_flags.antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0]), 3: np.array([30, 0, 0])}
         data_nsamples = DataContainer({bl: np.ones((3, 4), dtype=float) for bl in bls})
-        data_nsamples[(0, 1, 'ee')] *= 2
+        data_nsamples[(0, 1, 'ee')] *= 3
+        data_nsamples[(0, 2, 'ee')] *= 2
         model_flags = data_flags
         autocorrs = DataContainer({bl: np.ones((3, 4), dtype=complex) for bl in auto_bls})
         autocorrs[(2, 2, 'ee')][2, 2] = 3
         auto_flags = DataContainer({bl: np.zeros((3, 4), dtype=bool) for bl in auto_bls})
         auto_flags[(0, 0, 'ee')][1, 1] = True
 
-        gain_flags = {ant: np.zeros((3, 4), dtype=bool) for ant in [(0, 'Jee'), (1, 'Jee'), (2, 'Jee')]}
+        gain_flags = {ant: np.zeros((3, 4), dtype=bool) for ant in [(0, 'Jee'), (1, 'Jee'), (2, 'Jee'), (-1, 'Jee')]}
+        gain_flags[(0, 'Jee')] += True
         wgts = abscal.build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flags,
                                       data_is_redsol=True, gain_flags=gain_flags, tol=1.0)
         for bl in wgts:
@@ -796,16 +798,17 @@ class Test_Post_Redcal_Abscal_Run(object):
                 for f in range(3):
                     if bl == (0, 1, 'ee'):
                         if t == 2 and f == 2:
-                            assert wgts[bl][t, f] == 2 / (((1 / 3) + (1 / 1))**-1 * 2)
+                            assert wgts[bl][t, f] == 3 / (((1 / 3) + (1 / 1))**-1 * 2)
                         else:
-                            assert wgts[bl][t, f] == 2
+                            assert wgts[bl][t, f] == 3
                     elif bl == (0, 2, 'ee'):
                         if t == 2 and f == 2:
-                            assert wgts[bl][t, f] == 1 / (((1 / 3))**-1 * 1)
+                            assert wgts[bl][t, f] == 2 / (((1 / 3))**-1 * 1)
                         elif t == 1 and f == 1:
                             assert wgts[bl][t, f] == 0
                         else:
-                            assert wgts[bl][t, f] == 1
+                            assert wgts[bl][t, f] == 2
+
 
     def test_post_redcal_abscal(self):
         # setup

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -809,7 +809,6 @@ class Test_Post_Redcal_Abscal_Run(object):
                         else:
                             assert wgts[bl][t, f] == 2
 
-
     def test_post_redcal_abscal(self):
         # setup
         hd = io.HERAData(self.data_file)


### PR DESCRIPTION
This fixes a bug in the calculation of abscal data weights when the data is redundant. This was not handling flagged antennas wrong, which created a real problem when one of the antennas in unique baseline key was flagged, even though that unique baseline group had many unflagged pairs of antennas as redundant baselines in it.

This also modifies a unittest to expose the error on the current master branch.