### PR TITLE
added antnums2antnames dict in io.write_cal

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1660,17 +1660,22 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, e
 def _redcal_run_write_results(cal, hd, fistcal_filename, omnical_filename, omnivis_filename,
                               meta_filename, outdir, clobber=False, verbose=False, add_to_history=''):
     '''Helper function for writing the results of redcal_run.'''
+    # get antnums2antnames dictionary
+    antnums2antnames = dict(zip(hd.antenna_numbers, hd.antenna_names))
+ 
     if verbose:
         print('\nNow saving firstcal gains to', os.path.join(outdir, fistcal_filename))
     write_cal(fistcal_filename, cal['g_firstcal'], hd.freqs, hd.times,
               flags=cal['gf_firstcal'], outdir=outdir, overwrite=clobber, 
-              x_orientation=hd.x_orientation, history=version.history_string(add_to_history))
+              x_orientation=hd.x_orientation, history=version.history_string(add_to_history),
+              antnums2antnames=antnums2antnames)
 
     if verbose:
         print('Now saving omnical gains to', os.path.join(outdir, omnical_filename))
     write_cal(omnical_filename, cal['g_omnical'], hd.freqs, hd.times, flags=cal['gf_omnical'],
               quality=cal['chisq_per_ant'], total_qual=cal['chisq'], outdir=outdir, overwrite=clobber,
-              x_orientation=hd.x_orientation, history=version.history_string(add_to_history))
+              x_orientation=hd.x_orientation, history=version.history_string(add_to_history),
+              antnums2antnames=antnums2antnames)
 
     if verbose:
         print('Now saving omnical visibilities to', os.path.join(outdir, omnivis_filename))

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -479,11 +479,12 @@ class ReflectionFitter(FRFilter):
         else:
             kwargs = {'x_orientation': self.hd.x_orientation}
 
+        antnums2antnames = dict(zip(self.hd.antenna_numbers, self.hd.antenna_names))
         echo("...writing {}".format(output_calfits), verbose=verbose)
         uvc = io.write_cal(output_calfits, rgains, freq_array, time_array, flags=rflags,
                            quality=quals, total_qual=tquals, zero_check=False,
                            overwrite=overwrite, history=version.history_string(add_to_history),
-                           **kwargs)
+                           antnums2antnames=antnums2antnames, **kwargs)
 
         return uvc
 

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -808,7 +808,7 @@ class Test_Calibration_IO_Legacy(object):
         assert np.allclose(uvc2.gain_array[0, 0, :, :, 0], 0.0)
 
         # test antenna number and names ordering
-        antnums2antnames = {a: "THISANT{}".format(a+1) for a in ants}
+        antnums2antnames = {a: "THISANT{}".format(a + 1) for a in ants}
         uvc = io.write_cal("ex.calfits", gains, freqs, times, antnums2antnames=antnums2antnames,
                            return_uvc=True, write_file=False)
         assert sorted(uvc.antenna_names) == sorted(antnums2antnames.values())

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -807,6 +807,12 @@ class Test_Calibration_IO_Legacy(object):
         assert np.allclose(uvc1.gain_array[0, 0, :, :, 0], 1.0)
         assert np.allclose(uvc2.gain_array[0, 0, :, :, 0], 0.0)
 
+        # test antenna number and names ordering
+        antnums2antnames = {a: "THISANT{}".format(a+1) for a in ants}
+        uvc = io.write_cal("ex.calfits", gains, freqs, times, antnums2antnames=antnums2antnames,
+                           return_uvc=True, write_file=False)
+        assert sorted(uvc.antenna_names) == sorted(antnums2antnames.values())
+
     def test_update_cal(self):
         # load in cal
         fname = os.path.join(DATA_PATH, "test_input/zen.2457698.40355.xx.HH.uvc.omni.calfits")


### PR DESCRIPTION
Allow `io.write_cal` to set antenna_names by user input, rather than by-default setting them to `'ant{ant_num}'`. 