### PR TITLE
Add the ability to filter reds for max number of tip/tilt degeneracies

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -227,7 +227,7 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
     
     if max_dims is not None:
         while True:
-        # Compute idealized antenna positions from redundancies
+            # Compute idealized antenna positions from redundancies
             idealized_antpos = reds_to_antpos(reds, tol=IDEALIZED_BL_TOL)
             if len(list(idealized_antpos.values())[0]) <= max_dims:
                 break
@@ -1453,7 +1453,6 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
             # keep omnical visibility solutions flagged and nsamples at 0
             cal['vf_omnical'][bl] = np.ones_like(vis, dtype=bool)
             cal['vns_omnical'][bl] = np.zeros_like(vis, dtype=np.float32)
-
 
 
 def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit=1e-6,

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -18,6 +18,7 @@ from .apply_cal import calibrate_in_place
 
 
 SEC_PER_DAY = 86400.
+IDEALIZED_BL_TOL = 1e-8  # bl_error_tol for redcal.get_reds when using antenna positions calculated from reds
 
 
 def get_pos_reds(antpos, bl_error_tol=1.0):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1502,7 +1502,8 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
         'omni_meta': dictionary of information about the omnical convergence and chi^2 of the solution
     '''
     rv = {}  # dictionary of return values
-    rc = RedundantCalibrator(filter_reds(reds, max_dims=max_dims))
+    filtered_reds = filter_reds(reds, max_dims=max_dims)
+    rc = RedundantCalibrator(filtered_reds)
     if freqs is None:
         freqs = data.freqs
     if times_by_bl is None:
@@ -1531,7 +1532,7 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in rv['g_omnical'].items()}
 
     # compute chisqs
-    rv['chisq'], rv['chisq_per_ant'] = normalized_chisq(data, data_wgts, reds, rv['v_omnical'], rv['g_omnical'])
+    rv['chisq'], rv['chisq_per_ant'] = normalized_chisq(data, data_wgts, filtered_reds, rv['v_omnical'], rv['g_omnical'])
     return rv
 
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -156,7 +156,7 @@ class TestMethods(object):
         antpos[37] = np.array([np.pi, np.pi, 0])  # add one off-grid antenna
         reds = om.get_reds(antpos)
         # remove third, fourth, fifth, and sixth rows
-        reds = om.filter_reds(reds, ex_ants=list(range(9,33)))
+        reds = om.filter_reds(reds, ex_ants=list(range(9, 33)))
 
         # Max 1 dimension means largest 1D array
         new_reds = om.filter_reds(reds, max_dims=1)

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -150,6 +150,29 @@ class TestMethods(object):
         assert om.filter_reds(reds, antpos=antpos, min_bl_cut=85) == reds[-3:]
         assert om.filter_reds(reds, antpos=antpos, max_bl_cut=15) == reds[:3]
 
+    def test_filter_reds_max_dim(self):
+        # build hex array with 4 on a side and 7 total rows
+        antpos = hex_array(4, split_core=False, outriggers=0)
+        antpos[37] = np.array([np.pi, np.pi, 0])  # add one off-grid antenna
+        reds = om.get_reds(antpos)
+        # remove third, fourth, fifth, and sixth rows
+        reds = om.filter_reds(reds, ex_ants=list(range(9,33)))
+
+        # Max 1 dimension means largest 1D array
+        new_reds = om.filter_reds(reds, max_dims=1)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == set(range(4, 9))
+
+        # Max 2 dimensions means only rows 1 and 2
+        new_reds = om.filter_reds(reds, max_dims=2)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == set(range(0, 9))
+                
+        # Max 3 dimensions means all 3 good rows, but keeps out the off-grid antenna
+        new_reds = om.filter_reds(reds, max_dims=3)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == (set(range(0, 9)) | set(range(33, 37)))
+
     def test_add_pol_reds(self):
         reds = [[(1, 2)]]
         polReds = om.add_pol_reds(reds, pols=['xx'], pol_mode='1pol')

--- a/scripts/redcal_run.py
+++ b/scripts/redcal_run.py
@@ -17,4 +17,4 @@ redcal_run(a.input_data, firstcal_ext=a.firstcal_ext, omnical_ext=a.omnical_ext,
            ex_ants=a.ex_ants, ant_z_thresh=a.ant_z_thresh, max_rerun=a.max_rerun, solar_horizon=a.solar_horizon, flag_nchan_low=a.flag_nchan_low,
            flag_nchan_high=a.flag_nchan_high, bl_error_tol=a.bl_error_tol, min_bl_cut=a.min_bl_cut, max_bl_cut=a.max_bl_cut, 
            fc_conv_crit=a.fc_conv_crit, fc_maxiter=a.fc_maxiter, oc_conv_crit=a.oc_conv_crit, oc_maxiter=a.oc_maxiter, 
-           check_every=a.check_every, check_after=a.check_after, gain=a.gain, add_to_history=' '.join(sys.argv), verbose=a.verbose)
+           check_every=a.check_every, check_after=a.check_after, gain=a.gain, max_dims=a.max_dims, add_to_history=' '.join(sys.argv), verbose=a.verbose)


### PR DESCRIPTION
This PR adds the ability to filter redundancies to keep the maximum number of tip/tilt degeneracies below some number. This is achieved by removing antennas, which leaves them flagged after calibration. Since a "classically redundantly calibratable" array has 2 tip/tilt degeneracies, this is the new default for the redcal run algorithms, though the parameter is exposed to the user.

This resolves #590 