### PR TITLE
Adds **kwargs to HERAData.read

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -91,7 +91,7 @@ class DelayFilter(VisClean):
         return filled_data, filled_flags
 
     def write_filtered_data(self, res_outfilename=None, CLEAN_outfilename=None, filled_outfilename=None, filetype='uvh5',
-                            partial_write=False, clobber=False, add_to_history='', **kwargs):
+                            partial_write=False, clobber=False, add_to_history='', extra_attrs={}, **kwargs):
         '''
         Method for writing data products.
         
@@ -107,8 +107,8 @@ class DelayFilter(VisClean):
             partial_write: use uvh5 partial writing capability (only works when going from uvh5 to uvh5)
             clobber: if True, overwrites existing file at the outfilename
             add_to_history: string appended to the history of the output file
-            kwargs: addtional UVData keyword arguments update the before saving.
-                Must be valid UVData object attributes.
+            extra_attrs : additional attributes to update to HERAData before write
+            kwargs : extra kwargs to pass to UVData.write_*() call
         '''
         if not hasattr(self, 'data'):
             raise ValueError("Cannot write data without first loading")
@@ -132,7 +132,7 @@ class DelayFilter(VisClean):
                                               add_to_history=version.history_string(add_to_history), **kwargs)
                     else:
                         self.write_data(data_out, outfilename, filetype=filetype, overwrite=clobber, flags=flags_out,
-                                        add_to_history=add_to_history, **kwargs)
+                                        add_to_history=add_to_history, extra_attrs=extra_attrs, **kwargs)
 
 
 def partial_load_delay_filter_and_write(infilename, calfile=None, Nbls=1,

--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -107,7 +107,7 @@ class DelayFilter(VisClean):
             partial_write: use uvh5 partial writing capability (only works when going from uvh5 to uvh5)
             clobber: if True, overwrites existing file at the outfilename
             add_to_history: string appended to the history of the output file
-            extra_attrs : additional attributes to update to HERAData before write
+            extra_attrs : additional UVData/HERAData attributes to update before writing
             kwargs : extra kwargs to pass to UVData.write_*() call
         '''
         if not hasattr(self, 'data'):

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -944,7 +944,7 @@ def read_redcal_meta(meta_filename):
 #######################################################################
 
 
-def to_HERAData(input_data, filetype='miriad'):
+def to_HERAData(input_data, filetype='miriad', **check_kwargs):
     '''Converts a string path, UVData, or HERAData object, or a list of any one of those, to a
     single HERAData object without loading any new data.
 
@@ -952,6 +952,8 @@ def to_HERAData(input_data, filetype='miriad'):
         input_data: data file path, or UVData/HERAData instance, or list of either strings of data
             file paths or list of UVData/HERAData instances to combine into a single HERAData object
         filetype: 'miriad', 'uvfits', or 'uvh5'. Ignored if input_data is UVData/HERAData objects
+        check_kwargs : run_check, check_extra and run_check_acceptability
+            See UVData.read for more details.
 
     Returns:
         hd: HERAData object. Will not have data loaded if initialized from string(s).
@@ -959,7 +961,7 @@ def to_HERAData(input_data, filetype='miriad'):
     if filetype not in ['miriad', 'uvfits', 'uvh5']:
         raise NotImplementedError("Data filetype must be 'miriad', 'uvfits', or 'uvh5'.")
     if isinstance(input_data, str):  # single visibility data path
-        return HERAData(input_data, filetype=filetype)
+        return HERAData(input_data, filetype=filetype, **check_kwargs)
     elif isinstance(input_data, HERAData):  # already a HERAData object
         return input_data
     elif isinstance(input_data, UVData):  # single UVData object
@@ -971,7 +973,7 @@ def to_HERAData(input_data, filetype='miriad'):
         return hd
     elif isinstance(input_data, collections.Iterable):  # List loading
         if np.all([isinstance(i, str) for i in input_data]):  # List of visibility data paths
-            return HERAData(input_data, filetype=filetype)
+            return HERAData(input_data, filetype=filetype, **check_kwargs)
         elif np.all([isinstance(i, (UVData, HERAData)) for i in input_data]):  # List of uvdata objects
             hd = reduce(operator.add, input_data)
             hd.__class__ = HERAData

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -383,7 +383,7 @@ class HERAData(UVData):
 
     def read(self, bls=None, polarizations=None, times=None, frequencies=None,
              freq_chans=None, axis=None, read_data=True, return_data=True,
-             run_check=True, check_extra=True, run_check_acceptability=True):
+             run_check=True, check_extra=True, run_check_acceptability=True, **kwargs):
         '''Reads data from file. Supports partial data loading. Default: read all data in file.
 
         Arguments:
@@ -413,6 +413,7 @@ class HERAData(UVData):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
+            kwargs: extra keyword arguments to pass to UVData.read()
 
         Returns:
             data: DataContainer mapping baseline keys to complex visibility waterfalls
@@ -434,13 +435,15 @@ class HERAData(UVData):
                 if self.filetype == 'uvh5':
                     super().read(self.filepaths, file_type='uvh5', axis=axis, bls=bls, polarizations=polarizations,
                                  times=times, frequencies=frequencies, freq_chans=freq_chans, read_data=read_data,
-                                 run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability)
+                                 run_check=run_check, check_extra=check_extra,
+                                 run_check_acceptability=run_check_acceptability, **kwargs)
                 else:
                     if not read_data:
                         raise NotImplementedError('reading only metadata is not implemented for ' + self.filetype)
                     if self.filetype == 'miriad':
                         super().read(self.filepaths, file_type='miriad', axis=axis, bls=bls, polarizations=polarizations,
-                                     run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability)
+                                     run_check=run_check, check_extra=check_extra,
+                                     run_check_acceptability=run_check_acceptability, **kwargs)
                         if any([times is not None, frequencies is not None, freq_chans is not None]):
                             warnings.warn('miriad does not support partial loading for times and frequencies. '
                                           'Loading the file first and then performing select.')
@@ -448,7 +451,7 @@ class HERAData(UVData):
                     elif self.filetype == 'uvfits':
                         super().read(self.filepaths, file_type='uvfits', axis=axis, bls=bls, polarizations=polarizations,
                                      times=times, frequencies=frequencies, freq_chans=freq_chans, run_check=run_check,
-                                     check_extra=check_extra, run_check_acceptability=run_check_acceptability)
+                                     check_extra=check_extra, run_check_acceptability=run_check_acceptability, **kwargs)
                         self.unphase_to_drift()
             finally:
                 self.read = temp_read  # reset back to this function, regardless of whether the above try excecutes successfully

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -199,7 +199,7 @@ class HERAData(UVData):
     # times_by+bl: dictionary mapping antpairs to times (JD). Also includes all reverse pairs.
     # times_by+bl: dictionary mapping antpairs to LSTs (radians). Also includes all reverse pairs.
 
-    def __init__(self, input_data, filetype='uvh5', **check_kwargs):
+    def __init__(self, input_data, filetype='uvh5', **read_kwargs):
         '''Instantiate a HERAData object. If the filetype == uvh5, read in and store
         useful metadata (see get_metadata_dict()), either as object attributes or,
         if input_data is a list, as dictionaries mapping string paths to metadata.
@@ -207,8 +207,8 @@ class HERAData(UVData):
         Arguments:
             input_data: string data file path or list of string data file paths
             filetype: supports 'uvh5' (defualt), 'miriad', 'uvfits'
-            check_kwargs : run_check, check_extra and run_check_acceptability
-                See UVData.read for more details.
+            read_kwargs : kwargs to pass to UVData.read (e.g. run_check, check_extra and
+                run_check_acceptability). Only used for uvh5 filetype
         '''
         # initialize as empty UVData object
         super().__init__()
@@ -233,14 +233,14 @@ class HERAData(UVData):
             # read all UVData metadata from first file
             temp_paths = copy.deepcopy(self.filepaths)
             self.filepaths = self.filepaths[0]
-            self.read(read_data=False, **check_kwargs)
+            self.read(read_data=False, **read_kwargs)
             self.filepaths = temp_paths
 
             if len(self.filepaths) > 1:  # save HERAData_metas in dicts
                 for meta in self.HERAData_metas:
                     setattr(self, meta, {})
                 for f in self.filepaths:
-                    hd = HERAData(f, filetype='uvh5', **check_kwargs)
+                    hd = HERAData(f, filetype='uvh5', **read_kwargs)
                     meta_dict = hd.get_metadata_dict()
                     for meta in self.HERAData_metas:
                         getattr(self, meta)[f] = meta_dict[meta]
@@ -944,7 +944,7 @@ def read_redcal_meta(meta_filename):
 #######################################################################
 
 
-def to_HERAData(input_data, filetype='miriad', **check_kwargs):
+def to_HERAData(input_data, filetype='miriad', **read_kwargs):
     '''Converts a string path, UVData, or HERAData object, or a list of any one of those, to a
     single HERAData object without loading any new data.
 
@@ -952,8 +952,8 @@ def to_HERAData(input_data, filetype='miriad', **check_kwargs):
         input_data: data file path, or UVData/HERAData instance, or list of either strings of data
             file paths or list of UVData/HERAData instances to combine into a single HERAData object
         filetype: 'miriad', 'uvfits', or 'uvh5'. Ignored if input_data is UVData/HERAData objects
-        check_kwargs : run_check, check_extra and run_check_acceptability
-            See UVData.read for more details.
+        read_kwargs : kwargs to pass to UVData.read (e.g. run_check, check_extra and
+            run_check_acceptability). Only used for uvh5 filetype
 
     Returns:
         hd: HERAData object. Will not have data loaded if initialized from string(s).
@@ -961,7 +961,7 @@ def to_HERAData(input_data, filetype='miriad', **check_kwargs):
     if filetype not in ['miriad', 'uvfits', 'uvh5']:
         raise NotImplementedError("Data filetype must be 'miriad', 'uvfits', or 'uvh5'.")
     if isinstance(input_data, str):  # single visibility data path
-        return HERAData(input_data, filetype=filetype, **check_kwargs)
+        return HERAData(input_data, filetype=filetype, **read_kwargs)
     elif isinstance(input_data, HERAData):  # already a HERAData object
         return input_data
     elif isinstance(input_data, UVData):  # single UVData object
@@ -973,7 +973,7 @@ def to_HERAData(input_data, filetype='miriad', **check_kwargs):
         return hd
     elif isinstance(input_data, collections.Iterable):  # List loading
         if np.all([isinstance(i, str) for i in input_data]):  # List of visibility data paths
-            return HERAData(input_data, filetype=filetype, **check_kwargs)
+            return HERAData(input_data, filetype=filetype, **read_kwargs)
         elif np.all([isinstance(i, (UVData, HERAData)) for i in input_data]):  # List of uvdata objects
             hd = reduce(operator.add, input_data)
             hd.__class__ = HERAData

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -60,7 +60,8 @@ class Test_DelayFilter(object):
             dfil.write_filtered_data()
         with pytest.raises(NotImplementedError):
             dfil.write_filtered_data(res_outfilename=outfilename, partial_write=True)
-        dfil.write_filtered_data(res_outfilename=outfilename, add_to_history='Hello_world.', clobber=True, telescope_name='PAPER')
+        extra_attrs = dict(telescope_name="PAPER")
+        dfil.write_filtered_data(res_outfilename=outfilename, add_to_history='Hello_world.', clobber=True, extra_attrs=extra_attrs)
 
         uvd = UVData()
         uvd.read_uvh5(outfilename)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -330,6 +330,13 @@ class Test_HERAData(object):
         o = hd[(54, 54, 'ee')]
         assert len(hd._blt_slices) == 1
 
+        # test read with extra UVData kwargs
+        hd = HERAData(self.uvh5_1)
+        d, f, n = hd.read(bls=hd.bls[:2], frequencies=hd.freqs[:100], multidim_index=True)
+        k = list(d.keys())[0]
+        assert len(d) == 2
+        assert d[k].shape == (hd.Ntimes, 100)
+
         # test read list
         hd = HERAData([self.uvh5_1, self.uvh5_2])
         d, f, n = hd.read(axis='blt')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -84,7 +84,7 @@ class Test_VisClean(object):
 
         # test read-write-read
         V.read()
-        V.write_data(V.data, "./ex.uvh5", overwrite=True, filetype='uvh5', vis_units='Jy')
+        V.write_data(V.data, "./ex.uvh5", overwrite=True, filetype='uvh5', extra_attrs=dict(vis_units='Jy'))
         V2 = VisClean("./ex.uvh5", filetype='uvh5')
         V2.read()
         assert V2.hd.vis_units == 'Jy'

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -226,7 +226,7 @@ class VisClean(object):
             partial_write : bool, if True, begin (or continue) a partial write to
             the output filename and store file descriptor in self.hd._writers.
             add_to_history : string, string to append to hd history.
-            extra_attrs : additional attributes to update to HERAData before write
+            extra_attrs : additional UVData/HERAData attributes to update before writing
             kwargs : extra kwargs to pass to UVData.write_*() call
         """
         # get common keys

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -29,7 +29,7 @@ class VisClean(object):
     VisClean object for visibility CLEANing and filtering.
     """
 
-    def __init__(self, input_data, filetype='uvh5', input_cal=None, link_data=True):
+    def __init__(self, input_data, filetype='uvh5', input_cal=None, link_data=True, **check_kwargs):
         """
         Initialize the object.
 
@@ -43,10 +43,12 @@ class VisClean(object):
                 as they are built.
             link_data : bool, if True, attempt to link DataContainers
                 from HERAData object, otherwise only link metadata if possible.
+            check_kwargs : dict, passes values to UVData run_check, check_extra
+                and run_check_acceptability keyword arguments.
         """
         # attach HERAData
         self.clear_containers()
-        self.hd = io.to_HERAData(input_data, filetype=filetype)
+        self.hd = io.to_HERAData(input_data, filetype=filetype, **check_kwargs)
 
         # attach calibration
         if input_cal is not None:

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -29,7 +29,7 @@ class VisClean(object):
     VisClean object for visibility CLEANing and filtering.
     """
 
-    def __init__(self, input_data, filetype='uvh5', input_cal=None, link_data=True, **check_kwargs):
+    def __init__(self, input_data, filetype='uvh5', input_cal=None, link_data=True, **read_kwargs):
         """
         Initialize the object.
 
@@ -43,12 +43,12 @@ class VisClean(object):
                 as they are built.
             link_data : bool, if True, attempt to link DataContainers
                 from HERAData object, otherwise only link metadata if possible.
-            check_kwargs : dict, passes values to UVData run_check, check_extra
-                and run_check_acceptability keyword arguments.
+            read_kwargs : kwargs to pass to UVData.read (e.g. run_check, check_extra and
+                run_check_acceptability). Only used for uvh5 filetype
         """
         # attach HERAData
         self.clear_containers()
-        self.hd = io.to_HERAData(input_data, filetype=filetype, **check_kwargs)
+        self.hd = io.to_HERAData(input_data, filetype=filetype, **read_kwargs)
 
         # attach calibration
         if input_cal is not None:

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -205,7 +205,7 @@ class VisClean(object):
 
     def write_data(self, data, filename, overwrite=False, flags=None, nsamples=None,
                    times=None, lsts=None, filetype='uvh5', partial_write=False,
-                   add_to_history='', verbose=True, **kwargs):
+                   add_to_history='', verbose=True, extra_attrs={}, **kwargs):
         """
         Write data to file.
 
@@ -224,7 +224,8 @@ class VisClean(object):
             partial_write : bool, if True, begin (or continue) a partial write to
             the output filename and store file descriptor in self.hd._writers.
             add_to_history : string, string to append to hd history.
-            kwargs : additional attributes to update before write to disk.
+            extra_attrs : additional attributes to update to HERAData before write
+            kwargs : extra kwargs to pass to UVData.write_*() call
         """
         # get common keys
         keys = [k for k in self.hd.get_antpairpols() if data.has_key(k)]
@@ -259,21 +260,21 @@ class VisClean(object):
         # add history
         hd.history += version.history_string(add_to_history)
 
-        # update other kwargs
-        for attribute, value in kwargs.items():
+        # update other extra attrs
+        for attribute, value in extra_attrs.items():
             hd.__setattr__(attribute, value)
 
         # write to disk
         if filetype == 'miriad':
-            hd.write_miriad(filename, clobber=overwrite)
+            hd.write_miriad(filename, clobber=overwrite, **kwargs)
         elif filetype == 'uvh5':
             if partial_write:
-                hd.partial_write(filename, clobber=overwrite, inplace=True)
+                hd.partial_write(filename, clobber=overwrite, inplace=True, **kwargs)
                 self.hd._writers.update(hd._writers)
             else:
-                hd.write_uvh5(filename, clobber=overwrite)
+                hd.write_uvh5(filename, clobber=overwrite, **kwargs)
         elif filetype == 'uvfits':
-            hd.write_uvfits(filename)
+            hd.write_uvfits(filename, **kwargs)
         else:
             raise ValueError("filetype {} not recognized".format(filetype))
         echo("...writing to {}".format(filename), verbose=verbose)


### PR DESCRIPTION
This adds **kwargs to HERAData.read signature to allow for passing extra kwargs upon read. This is motivated for reading in UVH5 files with multidimensional slicing (recent UVData addition). We could explicitly pass this kwarg, but it most general cases this kwarg should be False, and it makes sense to just add this ability for many of the other `UVData.read` kwargs. 

This does the same for `VisClean.write_data`, however, it had an existing `**kwargs` argument for updating additional `UVData` attributes before the write. This moves that to `extra_attrs={}` and makes `**kwargs` for passing additional kwargs to `UVData.write_`. This is a small API change--@jsdillon let me know if you think this is fine, or if we should wait on this and issue deprecation warnings. I don't think there are that many users of `VisClean` currently other than myself..