### PR TITLE
Smooth_cal blacklists in time and frequency

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from .datacontainer import DataContainer
 from .utils import polnum2str, polstr2num, jnum2str, jstr2num
-from .utils import split_pol, conj_pol, LST2JD
+from .utils import split_pol, conj_pol, LST2JD, HERA_TELESCOPE_LOCATION
 
 
 class HERACal(UVCal):
@@ -1048,8 +1048,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
               filetype='miriad', write_file=True, outdir="./", overwrite=False, verbose=True, history=" ",
               return_uvd=False, longitude=21.42830, start_jd=None, x_orientation="north", instrument="HERA",
               telescope_name="HERA", object_name='EOR', vis_units='uncalib', dec=-30.72152,
-              telescope_location=np.array([5109325.85521063, 2005235.09142983, -3239928.42475395]),
-              integration_time=None, **kwargs):
+              telescope_location=HERA_TELESCOPE_LOCATION, integration_time=None, **kwargs):
     """
     Take DataContainer dictionary, export to UVData object and write to file. See pyuvdata.UVdata
     documentation for more info on these attributes.

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -367,7 +367,7 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
     Returns:
         time_blacklist_array: boolean array with the same shape as time_grid in which blacklisted integrations are True'''
     
-    time_blacklist_array = np.zeros(length(time_grid), dtype=bool)
+    time_blacklist_array = np.zeros(len(time_grid), dtype=bool)
 
     # Calculate blacklisted times
     if len(time_blacklists) > 0:
@@ -562,8 +562,8 @@ class CalibrationSmoother():
                                      time_threshold=time_threshold, ant_threshold=time_threshold)
 
         # build blacklists
-        self.time_blacklist = build_time_grid_blacklist(self.time_grid, time_blacklists=time_blacklists, lst_blacklists=lst_blacklists,
-                                                        lat_lon_alt_degrees=lat_lon_alt_degrees, telescope_name=hc.telescope_name)
+        self.time_blacklist = build_time_blacklist(self.time_grid, time_blacklists=time_blacklists, lst_blacklists=lst_blacklists,
+                                                   lat_lon_alt_degrees=lat_lon_alt_degrees, telescope_name=hc.telescope_name)
         self.freq_blacklist = build_freq_blacklist(self.freqs, freq_blacklists=freq_blacklists, chan_blacklists=chan_blacklists)
 
         # pick a reference antenna that has the minimum number of flags (tie goes to lower antenna number) and then rephase

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -396,7 +396,7 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
             if bounds[0] < bounds[1]:
                 time_blacklist_array[(lst_grid >= bounds[0]) & (lst_grid <= bounds[1])] = True
             else:  # the bounds span the 24 hours --> 0 hours branch cut
-                time_blacklist_array[(lst_grid <= bounds[0]) | (lst_grid >= bounds[1])] = True
+                time_blacklist_array[(lst_grid >= bounds[0]) | (lst_grid <= bounds[1])] = True
 
     return time_blacklist_array
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -386,6 +386,26 @@ def _build_time_grid_blacklist(time_grid, time_blacklists=[], lst_blacklists=[],
     return time_grid_blacklist
 
 
+def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):
+    '''TODO: document'''
+
+    freq_blacklist_array = np.zeros(length(freqs), dtype=bool)
+
+    # Calculate blacklisted frequencies
+    if len(freq_blacklists) > 0:
+        for bounds in freq_blacklists:
+            assert len(bounds) == 2, 'freq_blacklists must be list of pairs of bounds'
+            assert bounds[0] <= bounds[1], 'freq_blacklists bounds must be in ascending order'
+            freq_blacklist_array[(freqs >= bounds[0]) & (freqs <= bounds[1])]
+
+    # Calculate blacklisted channels
+    if len(chan_blacklists) > 0:
+        for bounds in chan_blacklists:
+            assert len(bounds) == 2, 'chan_blacklists must be list of pairs of bounds'
+            assert bounds[0] <= bounds[1], 'chan_blacklists bounds must be in ascending order'
+            freq_blacklist_array[(np.arange(len(freqs)) >= bounds[0]) & (np.arange(len(freqs)) <= bounds[1])]
+
+    return freq_blacklist_array
 
 
 class CalibrationSmoother():

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import warnings
 import argparse
 import pyuvdata
+from collections import Iterable
 
 try:
     import uvtools
@@ -372,7 +373,7 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
     # Calculate blacklisted times
     if len(time_blacklists) > 0:
         for bounds in time_blacklists:
-            assert len(bounds) == 2, 'time_blacklists must be list of pairs of bounds'
+            assert isinstance(bounds, Iterable) and len(bounds) == 2, 'time_blacklists must be list of pairs of bounds'
             assert bounds[0] <= bounds[1], 'time_blacklist bounds must be in chronological order'
             time_blacklist_array[(time_grid >= bounds[0]) & (time_grid <= bounds[1])] = True
 
@@ -391,7 +392,7 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
 
         # add blacklisted times from lst_blacklists
         for bounds in lst_blacklists:
-            assert len(bounds) == 2, 'lst_blacklists must be list of pairs of bounds'
+            assert isinstance(bounds, Iterable) and len(bounds) == 2, 'lst_blacklists must be list of pairs of bounds'
             if bounds[0] < bounds[1]:
                 time_blacklist_array[(lst_grid >= bounds[0]) & (lst_grid <= bounds[1])] = True
             else:  # the bounds span the 24 hours --> 0 hours branch cut
@@ -418,14 +419,14 @@ def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):
     # Calculate blacklisted frequencies
     if len(freq_blacklists) > 0:
         for bounds in freq_blacklists:
-            assert len(bounds) == 2, 'freq_blacklists must be list of pairs of bounds'
+            assert isinstance(bounds, Iterable) and len(bounds) == 2, 'freq_blacklists must be list of pairs of bounds'
             assert bounds[0] <= bounds[1], 'freq_blacklists bounds must be in ascending order'
             freq_blacklist_array[(freqs >= bounds[0]) & (freqs <= bounds[1])] = True
 
     # Calculate blacklisted channels
     if len(chan_blacklists) > 0:
         for bounds in chan_blacklists:
-            assert len(bounds) == 2, 'chan_blacklists must be list of pairs of bounds'
+            assert isinstance(bounds, Iterable) and len(bounds) == 2, 'chan_blacklists must be list of pairs of bounds'
             assert bounds[0] <= bounds[1], 'chan_blacklists bounds must be in ascending order'
             freq_blacklist_array[(np.arange(len(freqs)) >= bounds[0]) & (np.arange(len(freqs)) <= bounds[1])] = True
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -719,6 +719,11 @@ class CalibrationSmoother():
             hc.write_calfits(outfilename, clobber=clobber)
 
 
+def _pair(dash_sep_arg_pair):
+    '''Helper function for argparser to turn dash-separted numbers into tuples of floats.'''
+    return tuple([float(arg) for arg in dash_sep_arg_pair.split('-', maxsplit=1)])
+
+
 def smooth_cal_argparser():
     '''Arg parser for commandline operation of 2D calibration smoothing.'''
     a = argparse.ArgumentParser(description="Smooth calibration solutions in time and frequency using the hera_cal.smooth_cal module.")
@@ -749,6 +754,18 @@ def smooth_cal_argparser():
     flg_opts.add_argument("--ant_threshold", default=0.5, type=float, help="If, after time and freq thesholding and broadcasting, an antenna is left \
                           unflagged for a number of visibilities less than ant_threshold times the maximum among all antennas, flag that antenna for all \
                           times and channels. 1.0 means no additional flagging (default 0.5).")
+
+    # Options relating to blacklisting time or frequency ranges
+    bkl_opts = a.add_argument_group(title="Blacklisting options used for assigning 0 weight to times/frequencies so that smooth_cal\n"
+                                    "interpolates/extrapoaltes over them (though they aren't necessarily flagged).")
+    bkl_opts.add_argument("--time_blacklists", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of times in Julian Day \
+                          bounding (inclusively) blacklisted times, e.g. '2458098.1-2458098.4'.")
+    bkl_opts.add_argument("--lst_blacklists", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of LSTs in hours \
+                          bounding (inclusively) blacklisted LSTs, e.g. '3-4 10-12 23-.5'")
+    bkl_opts.add_argument("--chan_blacklists", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of channel numbers \
+                          bounding (inclusively) blacklisted spectral ranges, e.g. '0-256 800-900'")
+    bkl_opts.add_argument("--freq_blacklists", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of frequencies in Hz \
+                          bounding (inclusively) blacklisted spectral ranges, e.g. '88e6-110e6 136e6-138e6'")
 
     # Options relating to performing the filter in time and frequency
     flt_opts = a.add_argument_group(title='Filtering options.')

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -365,7 +365,7 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
             is not None. Currently, only "HERA" will work since it's position is hard-coded in this module.
 
     Returns:
-        time_blacklist_array: boolean array with the same shape as time_grid of which integrations are blacklisted'''
+        time_blacklist_array: boolean array with the same shape as time_grid in which blacklisted integrations are True'''
     
     time_blacklist_array = np.zeros(length(time_grid), dtype=bool)
 
@@ -401,7 +401,17 @@ def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_l
 
 
 def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):
-    '''TODO: document'''
+    '''Converts pairs of bounds on blacklisted frequencies/channels into a boolean array of blacklisted freqs.
+
+    Arguments:
+        freqs: numpy array of frequencies
+        freq_blacklists: list of pairs of frequencies in the same units bounding (inclusively) the spectral regions that
+            are to be marked as True in the freq_blacklist_array
+        chan_blacklists: list of pairs of channel numbers bounding (inclusively) spectral regions that are to be marked 
+            as True in the freq_blacklist_array.
+
+    Returns:
+        freq_blacklist_array: boolean array with the same shape as freqs with blacklisted frequencies set to True'''
 
     freq_blacklist_array = np.zeros(length(freqs), dtype=bool)
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -350,23 +350,23 @@ def rephase_to_refant(gains, refant, flags=None, propagate_refant_flags=False):
                 gains[ant] = gains[ant] / refant_phasor
 
 
-def _build_time_grid_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_lon_alt_degrees=None, telescope_name='HERA'):
+def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_lon_alt_degrees=None, telescope_name='HERA'):
     '''TODO: ducment'''
     
-    time_grid_blacklist = np.zeros(length(time_grid), dtype=bool)
+    time_blacklist_array = np.zeros(length(time_grid), dtype=bool)
 
     # Calculate blacklisted times
     if len(time_blacklists) > 0:
         for bounds in time_blacklists:
             assert len(bounds) == 2, 'time_blacklists must be list of pairs of bounds'
-            assert bounds[0] < bounds[1], 'time_blacklist bounds must be in chronological order'
-            time_grid_blacklist[(time_grid >= bounds[0]) & (time_grid <= bounds[1])] = True
+            assert bounds[0] <= bounds[1], 'time_blacklist bounds must be in chronological order'
+            time_blacklist_array[(time_grid >= bounds[0]) & (time_grid <= bounds[1])] = True
 
     # Calculate blacklisted LSTs
     if len(lst_blacklists) > 0:
         # If lat_lon_alt is not specified, try to infer it from the telescope name, which calfits files generally carry around
         if lat_lon_alt_degrees is None:
-            if telescope_name is 'HERA':
+            if telescope_name.upper() == 'HERA':
                 lat_lon_alt_degrees = np.array(pyuvdata.utils.LatLonAlt_from_XYZ(utils.HERA_TELESCOPE_LOCATION))
                 lat_lon_alt_degrees *= [180 / np.pi, 180 / np.pi, 1]
             else:
@@ -379,11 +379,11 @@ def _build_time_grid_blacklist(time_grid, time_blacklists=[], lst_blacklists=[],
         for bounds in lst_blacklists:
             assert len(bounds) == 2, 'lst_blacklists must be list of pairs of bounds'
             if bounds[0] < bounds[1]:
-                time_grid_blacklist[(lst_grid >= bounds[0]) & (lst_grid <= bounds[1])] = True
+                time_blacklist_array[(lst_grid >= bounds[0]) & (lst_grid <= bounds[1])] = True
             else:  # the bounds span the 24 hours --> 0 hours branch cut
-                time_grid_blacklist[(lst_grid <= bounds[0]) | (lst_grid >= bounds[1])] = True
+                time_blacklist_array[(lst_grid <= bounds[0]) | (lst_grid >= bounds[1])] = True
 
-    return time_grid_blacklist
+    return time_blacklist_array
 
 
 def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -413,21 +413,21 @@ def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):
     Returns:
         freq_blacklist_array: boolean array with the same shape as freqs with blacklisted frequencies set to True'''
 
-    freq_blacklist_array = np.zeros(length(freqs), dtype=bool)
+    freq_blacklist_array = np.zeros(len(freqs), dtype=bool)
 
     # Calculate blacklisted frequencies
     if len(freq_blacklists) > 0:
         for bounds in freq_blacklists:
             assert len(bounds) == 2, 'freq_blacklists must be list of pairs of bounds'
             assert bounds[0] <= bounds[1], 'freq_blacklists bounds must be in ascending order'
-            freq_blacklist_array[(freqs >= bounds[0]) & (freqs <= bounds[1])]
+            freq_blacklist_array[(freqs >= bounds[0]) & (freqs <= bounds[1])] = True
 
     # Calculate blacklisted channels
     if len(chan_blacklists) > 0:
         for bounds in chan_blacklists:
             assert len(bounds) == 2, 'chan_blacklists must be list of pairs of bounds'
             assert bounds[0] <= bounds[1], 'chan_blacklists bounds must be in ascending order'
-            freq_blacklist_array[(np.arange(len(freqs)) >= bounds[0]) & (np.arange(len(freqs)) <= bounds[1])]
+            freq_blacklist_array[(np.arange(len(freqs)) >= bounds[0]) & (np.arange(len(freqs)) <= bounds[1])] = True
 
     return freq_blacklist_array
 
@@ -645,7 +645,6 @@ class CalibrationSmoother():
             win_kwargs : any keyword arguments for the window function selection in aipy.dsp.gen_window.
                     Currently, the only window that takes a kwarg is the tukey window with a alpha=0.5 default.
         '''
-
         # Loop over all antennas and perform a low-pass delay filter on gains
         for ant, gain_grid in self.gain_grids.items():
             utils.echo('    Now filtering antenna' + str(ant[0]) + ' ' + str(ant[1]) + ' in frequency...', verbose=self.verbose)

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -432,6 +432,26 @@ class CalibrationSmoother():
                 needed to flag that antenna gain at a particular time and frequency. antflag_thresh=0.0 is
                 aggressive flag broadcasting, antflag_thresh=1.0 is conservative flag_broadcasting.
                 Only used for converting per-baseline flags to per-antenna flags if flag_file_list is specified.
+            load_cspa: if True, also save chisq_per_ant into self.cspa, analogously to self.gain_grids. Does not
+                currently affect the smoothing functions, but is useful for interactive work.
+            load_chisq: if True, also save chisq into self.chisq, analogously to self.gain_grids except that the
+                keys are jpols, e.g. 'Jee' and not antennas. Does not currently affect the smoothing functions.
+            time_blacklists: list of pairs of times in Julian Day bounding (inclusively) regions in time that are
+                to receive 0 weight during smoothing, forcing the smoother to interpolate/extrapolate.
+                N.B. Blacklisted times are not necessarily flagged.
+            lst_blacklists:  list of pairs of LSTs in hours bounding (inclusively) regions of LST that are
+                to receive 0 weight during smoothing, forcing the smoother to interpolate/extrapolate. 
+                Regions crossing the 24h brach cut are acceptable (e.g. [(23, 1)] blacklists two total hours).
+                N.B. Blacklisted LSTS are not necessarily flagged.
+            lat_lon_alt_degrees: length 3 list or array of latitude (deg), longitude (deg), and altitude (m) of 
+                the array. Only used to convert LSTs to JD times. If the telescope_name in the calfits file is 'HERA',
+                this is not required.
+            freq_blacklists: list of pairs of frequencies in Hz hours bounding (inclusively) spectral regions 
+                that are to receive 0 weight during smoothing, forcing the smoother to interpolate/extrapolate.
+                N.B. Blacklisted frequencies are not necessarily flagged.
+            chan_blacklists: list of pairs of channel numbers bounding (inclusively) spectral regions 
+                that are to receive 0 weight during smoothing, forcing the smoother to interpolate/extrapolate.
+                N.B. Blacklisted channels are not necessarily flagged.
             pick_refant: if True, automatically picks one reference anteanna per polarization. The refants chosen have the
                 fewest total flags and causes the least noisy phases on other antennas when made the phase reference.
             freq_threshold: float. Finds the times that flagged for all antennas at a single channel but not flagged

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -4,10 +4,10 @@
 
 import numpy as np
 import scipy
-from collections import OrderedDict as odict
 from copy import deepcopy
 import warnings
 import argparse
+import pyuvdata
 
 try:
     import uvtools
@@ -410,7 +410,8 @@ def build_freq_blacklist(freqs, freq_blacklists=[], chan_blacklists=[]):
 
 class CalibrationSmoother():
 
-    def __init__(self, calfits_list, flag_file_list=[], flag_filetype='h5', antflag_thresh=0.0,
+    def __init__(self, calfits_list, flag_file_list=[], flag_filetype='h5', antflag_thresh=0.0, load_cspa=False, load_chisq=False, 
+                 time_blacklists=[], lst_blacklists=[], lat_lon_alt_degrees=None, freq_blacklists=[], chan_blacklists=[],
                  pick_refant=False, freq_threshold=1.0, time_threshold=1.0, ant_threshold=1.0, verbose=False):
         '''Class for smoothing calibration solutions in time and frequency for a whole day. Initialized with a list of
         calfits files and, optionally, a corresponding list of flag files, which must match the calfits files
@@ -515,6 +516,11 @@ class CalibrationSmoother():
         self.check_consistency()
         flag_threshold_and_broadcast(self.flag_grids, freq_threshold=freq_threshold,
                                      time_threshold=time_threshold, ant_threshold=time_threshold)
+
+        # build blacklists
+        self.time_blacklist = build_time_grid_blacklist(self.time_grid, time_blacklists=time_blacklists, lst_blacklists=lst_blacklists,
+                                                        lat_lon_alt_degrees=lat_lon_alt_degrees, telescope_name=hc.telescope_name)
+        self.freq_blacklist = build_freq_blacklist(self.freqs, freq_blacklists=freq_blacklists, chan_blacklists=chan_blacklists)
 
         # pick a reference antenna that has the minimum number of flags (tie goes to lower antenna number) and then rephase
         if pick_refant:

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -351,7 +351,21 @@ def rephase_to_refant(gains, refant, flags=None, propagate_refant_flags=False):
 
 
 def build_time_blacklist(time_grid, time_blacklists=[], lst_blacklists=[], lat_lon_alt_degrees=None, telescope_name='HERA'):
-    '''TODO: ducment'''
+    '''Converts pairs of bounds on blacklisted times/LSTs into a boolean array of blacklisted times.
+
+    Arguments:
+        time_grid: numpy array of times in Julian Day
+        time_blacklists: list of pairs of times in Julian Day bounding (inclusively) regions in time that are to be marked
+            as True in the time_blacklist_array
+        lst_blacklists:  list of pairs of LSTs in hours bounding (inclusively) regions of LST that are to be marked as True
+            in the time_blacklist_array. Regions crossing the 24h brach cut, e.g. [(23, 1)], are allowed.
+        lat_lon_alt_degrees: length 3 array of telescope location in degreees and altitude in meters. Only used to convert
+            times to LSTs if lst_blacklists is not empty
+        telescope_name: string name of telescope. Only used if lst_blacklists is not empty and lat_lon_alt_degrees 
+            is not None. Currently, only "HERA" will work since it's position is hard-coded in this module.
+
+    Returns:
+        time_blacklist_array: boolean array with the same shape as time_grid of which integrations are blacklisted'''
     
     time_blacklist_array = np.zeros(length(time_grid), dtype=bool)
 

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -185,8 +185,28 @@ class Test_Smooth_Cal_Helper_Functions(object):
             time_blacklist = smooth_cal.build_time_blacklist(time_grid, time_blacklists=[(2458838.3000)])
         with pytest.raises(AssertionError):
             time_blacklist = smooth_cal.build_time_blacklist(time_grid, time_blacklists=[(2458838.3004, 2458838.3000)])
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_time_blacklist(time_grid, lst_blacklists=[(2.5692)])
         with pytest.raises(NotImplementedError):
             time_blacklist = smooth_cal.build_time_blacklist(time_grid, lst_blacklists=[(2.5692, 2.5746)], telescope_name='NOT_A_REAL_TELESCOPE')
+
+    def test_build_freq_blacklist(self):
+        freqs = np.array([100e6, 120e6, 140e6, 160e6, 180e6, 200e6])
+        freq_blacklist = smooth_cal.build_freq_blacklist(freqs, freq_blacklists=[(0e6, 137e6)])
+        np.testing.assert_array_equal(freq_blacklist, [True, True, False, False, False, False])
+        
+        freq_blacklist = smooth_cal.build_freq_blacklist(freqs, chan_blacklists=[(4, 5)])
+        np.testing.assert_array_equal(freq_blacklist, [False, False, False, False, True, True])
+
+        # test errors
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_freq_blacklist(freqs, freq_blacklists=[(137e6)])
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_freq_blacklist(freqs, freq_blacklists=[(137e6, 0e6)])
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_freq_blacklist(freqs, chan_blacklists=[(1)])
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_freq_blacklist(freqs, chan_blacklists=[(3, 1)])
 
 
 class Test_Calibration_Smoother(object):

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -30,10 +30,11 @@ class Test_Smooth_Cal_Helper_Functions(object):
         assert len(kernel) == 201
 
     def test_smooth_cal_argparser(self):
-        sys.argv = [sys.argv[0], 'a', 'b', '--flag_file_list', 'c']
+        sys.argv = [sys.argv[0], 'a', 'b', '--flag_file_list', 'c', '--lst_blacklists', '3-4', '10-12', '23-.5']
         a = smooth_cal.smooth_cal_argparser()
         assert a.calfits_list == ['a', 'b']
         assert a.flag_file_list == ['c']
+        assert a.lst_blacklists == [(3, 4), (10, 12), (23, .5)]
 
     def test_time_filter(self):
         gains = np.ones((10, 10), dtype=complex)

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -220,7 +220,10 @@ class Test_Calibration_Smoother(object):
     def setup_method(self):
         calfits_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.abs.calfits_54x_only')))[0::2]
         flag_file_list = sorted(glob.glob(os.path.join(DATA_PATH, 'test_input/*.uvOCR_53x_54x_only.flags.applied.npz')))[0::2]
-        self.cs = smooth_cal.CalibrationSmoother(calfits_list, flag_file_list=flag_file_list, flag_filetype='npz')
+        self.cs = smooth_cal.CalibrationSmoother(calfits_list, flag_file_list=flag_file_list, flag_filetype='npz',
+                                                 time_blacklists=[(2458101.44795386, 2458101.44919662)], 
+                                                 lst_blacklists=[(6.17226452, 6.17824609)],
+                                                 freq_blacklists=[(136e6, 138e6), (149e6, 151e6)], chan_blacklists=[(0, 64)])
 
     @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
     @pytest.mark.filterwarnings("ignore:overflow encountered in square")

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -208,6 +208,12 @@ class Test_Smooth_Cal_Helper_Functions(object):
         with pytest.raises(AssertionError):
             time_blacklist = smooth_cal.build_freq_blacklist(freqs, chan_blacklists=[(3, 1)])
 
+    def test_build_wgts_grid(self):
+        flag_grid = np.zeros((2, 3))
+        flag_grid[0, 0] = True
+        wgts_grid = smooth_cal._build_wgts_grid(flag_grid, time_blacklist=[False, True], freq_blacklist=[False, False, True])
+        np.testing.assert_array_equal(wgts_grid, [[0, 1, 0], [0, 0, 0]])
+
 
 class Test_Calibration_Smoother(object):
 

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -162,6 +162,32 @@ class Test_Smooth_Cal_Helper_Functions(object):
         np.testing.assert_array_equal(flags[0, 'Jxx'], np.array([False, True]))
         np.testing.assert_array_equal(flags[1, 'Jxx'], np.array([True, True]))
 
+    def test_build_time_blacklist(self):
+        time_grid = np.array([2458838.30008962, 2458838.30020147, 2458838.30031332, 2458838.30042517, 2458838.30053701, 2458838.30064886])
+        lst_grid = np.array([2.56920604, 2.57189775, 2.57458945, 2.57728116, 2.57997286, 2.58266456])
+
+        # test time cuts
+        time_blacklist = smooth_cal.build_time_blacklist(time_grid, time_blacklists=[(2458838.3000, 2458838.3004)])
+        np.testing.assert_array_equal(time_blacklist, [True, True, True, False, False, False])
+
+        # test LST cuts
+        time_blacklist = smooth_cal.build_time_blacklist(time_grid, lst_blacklists=[(2.5692, 2.5746)])
+        np.testing.assert_array_equal(time_blacklist, [True, True, True, False, False, False])
+
+        # try shifting hera position so that the time_grd spans the branch cut in LSTs
+        hera_lat_lon_alt_degrees = (-30.721526120689507, 21.428303826863015, 1051.690000018105)
+        shifted_llad = np.array(hera_lat_lon_alt_degrees) + [0, 321.38115825, 0]
+        time_blacklist = smooth_cal.build_time_blacklist(time_grid, lst_blacklists=[(23.995, 0.005)], lat_lon_alt_degrees=shifted_llad)
+        np.testing.assert_array_equal(time_blacklist, [False, True, True, True, False, False])
+
+        # test errors
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_time_blacklist(time_grid, time_blacklists=[(2458838.3000)])
+        with pytest.raises(AssertionError):
+            time_blacklist = smooth_cal.build_time_blacklist(time_grid, time_blacklists=[(2458838.3004, 2458838.3000)])
+        with pytest.raises(NotImplementedError):
+            time_blacklist = smooth_cal.build_time_blacklist(time_grid, lst_blacklists=[(2.5692, 2.5746)], telescope_name='NOT_A_REAL_TELESCOPE')
+
 
 class Test_Calibration_Smoother(object):
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -23,6 +23,11 @@ except ImportError:
     AIPY = False
 
 
+# Taken from a H1C data file and confirmed to match a H3C data file
+HERA_TELESCOPE_LOCATION = np.array([5109325.855210627429187297821044921875,
+                                    2005235.091429826803505420684814453125,
+                                    -3239928.424753960222005844116210937500])
+
 # Defines characters to look for to see if the polarization string is in east/north format. Nominally {'e', 'n'}.
 _KEY_CARDINAL_CHARS = set([c.lower() for c in _x_orientation_rep_dict('north').values()])
 # Define characters that appear in all Jones polarization strings. Nominally {'j'}.

--- a/scripts/smooth_cal_run.py
+++ b/scripts/smooth_cal_run.py
@@ -20,7 +20,9 @@ if a.window == 'tukey':  # set window kwargs
 
 if a.run_if_first is None or sorted(a.calfits_list)[0] == a.run_if_first:
     cs = CalibrationSmoother(a.calfits_list, flag_file_list=a.flag_file_list, flag_filetype=a.flag_filetype,
-                             antflag_thresh=a.antflag_thresh, pick_refant=a.pick_refant, freq_threshold=a.freq_threshold, 
+                             antflag_thresh=a.antflag_thresh, time_blacklists=a.time_blacklists,
+                             lst_blacklists=a.lst_blacklists, freq_blacklists=a.freq_blacklists,
+                             chan_blacklists=a.chan_blacklists, pick_refant=a.pick_refant, freq_threshold=a.freq_threshold, 
                              time_threshold=a.time_threshold, ant_threshold=a.ant_threshold, verbose=a.verbose)
     cs.time_freq_2D_filter(freq_scale=a.freq_scale, time_scale=a.time_scale, tol=a.tol,
                            filter_mode=a.filter_mode, window=a.window, maxiter=a.maxiter, **win_kwargs)


### PR DESCRIPTION
This PR implements a notion of blacklisted times/freqs in smooth_cal. These are not flagged, but they get 0 weight in the CLEAN algorithm, effectively forcing the calibration solution to interpolate or extrapolate over them. This is particularly useful for abscal vs. simulations with missing sources at known LSTs.

Here's some screenshots of it in action.

![Screen Shot 2020-04-29 at 9 47 11 PM](https://user-images.githubusercontent.com/5281139/80673048-1e1f8900-8a63-11ea-97c0-849b02b7e727.png)
![Screen Shot 2020-04-29 at 9 47 20 PM](https://user-images.githubusercontent.com/5281139/80673052-1fe94c80-8a63-11ea-8142-7719bb131832.png)

In particular, I want to highlight the two regions of strongest disagreement, the fornax transit and the galactic anticenter transit. In this plot of time-averaged calibration amplitude, it's clear that our blacklisted lsts, in this case 2.5-4.3h and 6.5-9.5h, leave us with much more stable gains.

![Screen Shot 2020-04-29 at 9 47 46 PM](https://user-images.githubusercontent.com/5281139/80673138-63dc5180-8a63-11ea-92de-95dedae7d9de.png)

This closes #537 .