### PR TITLE
Reconstitute

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -87,7 +87,7 @@ class DelayFilter(VisClean):
 
 
 def load_delay_filter_and_write(infilename, calfile=None, Nbls_per_load=None, spw_range=None, cache_dir=None,
-                                read_cache=False, write_cache=False,
+                                read_cache=False, write_cache=False, round_up_bllens=False,
                                 res_outfilename=None, CLEAN_outfilename=None, filled_outfilename=None,
                                 clobber=False, add_to_history='', **filter_kwargs):
     '''
@@ -104,6 +104,7 @@ def load_delay_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
         read_cache: bool, If true, read existing cache files in cache_dir before running.
         write_cache: bool. If true, create new cache file with precomputed matrices
                            that were not in previously loaded cache files.
+        round_up_bllens: bool, if True, round up baseline lengths. Default is False.
         res_outfilename: path for writing the filtered visibilities with flags
         CLEAN_outfilename: path for writing the CLEAN model visibilities (with the same flags)
         filled_outfilename: path for writing the original data but with flags unflagged and replaced
@@ -120,7 +121,7 @@ def load_delay_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
         spw_range = [0, hd.Nfreqs]
     freqs = hd.freqs[spw_range[0]:spw_range[1]]
     if Nbls_per_load is None:
-        df = DelayFilter(hd, input_cal=calfile)
+        df = DelayFilter(hd, input_cal=calfile, round_up_bllens=round_up_bllens)
         df.read(frequencies=freqs)
         df.run_delay_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache, **filter_kwargs)
         df.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
@@ -129,7 +130,7 @@ def load_delay_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
                                extra_attrs={'Nfreqs': len(freqs), 'freq_array': np.asarray([freqs])})
     else:
         for i in range(0, len(hd.bls), Nbls_per_load):
-            df = DelayFilter(hd, input_cal=calfile)
+            df = DelayFilter(hd, input_cal=calfile, round_up_bllens=round_up_bllens)
             df.read(bls=hd.bls[i:i + Nbls_per_load], frequencies=freqs)
             df.run_delay_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache, **filter_kwargs)
             df.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1689,23 +1689,30 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
 
 
 def baselines_from_filelist_position(filename, filelist, polarizations):
-    """
-    Determine indices of baselines to process from the position of a filename within
-    a list of baselines in filelist.
+    """Determine indices of baselines to process.
 
-    Arguments:
-        filename, string
-            name of the file being processed.
-        filelist, list of strings
-            name of all files over which computations are being parallelized.
-        polarizations, list of strings
-            polarizations to include in baseline parallelization.
-    Returns:
+
+    This function determines baselines to process given the position of a filename
+    in a list of files.
+
+
+    Parameters
+    ----------
+    filename : string
+        name of the file being processed.
+    filelist : list of strings
+        name of all files over which computations are being parallelized.
+    polarizations : list of strings
+        polarizations to include in baseline parallelization.
+
+    Returns
+    -------
+    list
         list of baselines to process based on the position of the filename in the list of files.
     """
     # sanitize polarizations
     for pol in polarizations:
-        if pol not in POL_STR2NUM_DICT and pol not in ['ee', 'en', 'ne', 'nn']:
+        if pol.lower() not in POL_STR2NUM_DICT and pol.lower() not in ['ee', 'en', 'ne', 'nn']:
             raise ValueError("invalid polarization %s provided!" % pol)
     # The reason this function is not in utils is that it needs to use HERAData
     hd = HERAData(filename)

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -17,6 +17,7 @@ import h5py
 import pickle
 import random
 import glob
+from pyuvdata.utils import POL_STR2NUM_DICT
 
 try:
     import aipy
@@ -1685,3 +1686,35 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
 
     # Write to calfits file
     cal.write_calfits(outfilename, clobber=clobber)
+
+
+def baselines_from_filelist_position(filename, filelist, polarizations):
+    """
+    Determine indices of baselines to process from the position of a filename within
+    a list of baselines in filelist.
+
+    Arguments:
+        filename, string
+            name of the file being processed.
+        filelist, list of strings
+            name of all files over which computations are being parallelized.
+        polarizations, list of strings
+            polarizations to include in baseline parallelization.
+    Returns:
+        list of baselines to process based on the position of the filename in the list of files.
+    """
+    # sanitize polarizations
+    for pol in polarizations:
+        if pol not in POL_STR2NUM_DICT and pol not in ['ee', 'en', 'ne', 'nn']:
+            raise ValueError("invalid polarization %s provided!" % pol)
+    # The reason this function is not in utils is that it needs to use HERAData
+    hd = HERAData(filename)
+    bls = [bl for bl in hd.bls if bl[-1] in polarizations]
+    file_index = filelist.index(filename)
+    nfiles = len(filelist)
+    # Determine chunk size
+    nbls = len(bls)
+    chunk_size = nbls // nfiles + 1
+    lower_index = file_index * chunk_size
+    upper_index = np.min([(file_index + 1) * chunk_size, nbls])
+    return bls[lower_index:upper_index]

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -17,7 +17,6 @@ import h5py
 import pickle
 import random
 import glob
-import argparse
 
 try:
     import aipy

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1688,7 +1688,7 @@ def update_cal(infilename, outfilename, gains=None, flags=None, quals=None, add_
     cal.write_calfits(outfilename, clobber=clobber)
 
 
-def baselines_from_filelist_position(filename, filelist, polarizations):
+def baselines_from_filelist_position(filename, filelist, polarizations=None):
     """Determine indices of baselines to process.
 
 
@@ -1710,6 +1710,8 @@ def baselines_from_filelist_position(filename, filelist, polarizations):
     list
         list of baselines to process based on the position of the filename in the list of files.
     """
+    if polarizations is None:
+        polarizations = ['ee', 'nn', 'en', 'ne']
     # sanitize polarizations
     for pol in polarizations:
         if pol.lower() not in POL_STR2NUM_DICT and pol.lower() not in ['ee', 'en', 'ne', 'nn']:

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -38,15 +38,17 @@ class Test_DelayFilter(object):
         # test skip_wgt imposition of flags
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         k = (24, 25, 'ee')
-        dfil = df.DelayFilter(fname, filetype='miriad')
-        dfil.read(bls=[k])
-        wgts = {k: np.ones_like(dfil.flags[k], dtype=np.float)}
-        wgts[k][0, :] = 0.0
-        dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
-        assert dfil.clean_info[k]['status']['axis_1'][0] == 'skipped'
-        np.testing.assert_array_equal(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
-        np.testing.assert_array_equal(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
-        np.testing.assert_array_equal(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+        # test that everything runs when baselines lengths are rounded. 
+        for round_up_bllens in [True, False]:
+            dfil = df.DelayFilter(fname, filetype='miriad')
+            dfil.read(bls=[k])
+            wgts = {k: np.ones_like(dfil.flags[k], dtype=np.float)}
+            wgts[k][0, :] = 0.0
+            dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
+            assert dfil.clean_info[k]['status']['axis_1'][0] == 'skipped'
+            np.testing.assert_array_equal(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
+            np.testing.assert_array_equal(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
+            np.testing.assert_array_equal(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
 
     def test_write_filtered_data(self):
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -1008,21 +1008,22 @@ def test_get_file_times():
 def test_baselines_from_filelist_position():
     filelist = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.first.uvh5"),
                 os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.second.uvh5")]
-    baselines = []
     # below, we test whether for each file we get a chunk of baselines whose length is either greater then 0
     # or less then then 3 (the number of total baselines in this dataset)
-    for file in filelist:
-        baseline_chunk = io.baselines_from_filelist_position(file, filelist, ['ee'])
-        assert len(baseline_chunk) > 0 and len(baseline_chunk) < 3
-        baselines += baseline_chunk
-    # Next, we check whether the total number of chunked baselines equals the original number of baselines
-    assert len(baselines) == 3
-    # sort baselines by the sum of antenna number
-    ant_sum = [bl[0] + bl[1] for bl in baselines]
-    sum_indices = np.argsort(ant_sum)
-    baselines_sorted = [baselines[m] for m in sum_indices]
-    # check that the sorted baselines are all of the original baselines.
-    assert baselines_sorted == [(53, 53, 'ee'), (53, 54, 'ee'), (54, 54, 'ee')]
-    # check that providing an invalid polarization will raise an exception.
-    with pytest.raises(ValueError):
-        io.baselines_from_filelist_position(file, filelist, 'lasdf')
+    for pollist in [['ee'], None]:
+        baselines = []
+        for file in filelist:
+            baseline_chunk = io.baselines_from_filelist_position(file, filelist, pollist)
+            assert len(baseline_chunk) > 0 and len(baseline_chunk) < 3
+            baselines += baseline_chunk
+        # Next, we check whether the total number of chunked baselines equals the original number of baselines
+        assert len(baselines) == 3
+        # sort baselines by the sum of antenna number
+        ant_sum = [bl[0] + bl[1] for bl in baselines]
+        sum_indices = np.argsort(ant_sum)
+        baselines_sorted = [baselines[m] for m in sum_indices]
+        # check that the sorted baselines are all of the original baselines.
+        assert baselines_sorted == [(53, 53, 'ee'), (53, 54, 'ee'), (54, 54, 'ee')]
+        # check that providing an invalid polarization will raise an exception.
+        with pytest.raises(ValueError):
+            io.baselines_from_filelist_position(file, filelist, 'lasdf')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -376,7 +376,9 @@ class Test_VisClean(object):
         assert a.clobber is True
         assert a.spw_range[0] == 0
         assert a.spw_range[1] == 20
-        # test multifile
+
+    def test_filter_argparser_multifile(self):
+        # test multifile functionality of _filter_argparser
         sys.argv = [sys.argv[0], 'a', '--clobber', '--spw_range', '0', '20', '--calfilelist', 'cal1', 'cal2', 'cal3',
                     '--datafilelist', 'a', 'b', 'c']
         parser = vis_clean._filter_argparser(multifile=True)

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -376,3 +376,14 @@ class Test_VisClean(object):
         assert a.clobber is True
         assert a.spw_range[0] == 0
         assert a.spw_range[1] == 20
+        # test multifile
+        sys.argv = [sys.argv[0], 'a', '--clobber', '--spw_range', '0', '20', '--calfilelist', 'cal1', 'cal2', 'cal3',
+                    '--datafilelist', 'a', 'b', 'c']
+        parser = vis_clean._filter_argparser(multifile=True)
+        a = parser.parse_args()
+        assert a.datafilelist == ['a', 'b', 'c']
+        assert a.calfilelist == ['cal1', 'cal2', 'cal3']
+        assert a.infilename == 'a'
+        assert a.clobber is True
+        assert a.spw_range[0] == 0
+        assert a.spw_range[1] == 20

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -203,19 +203,16 @@ class Test_XTalkFilter(object):
         assert a.infilename == 'a'
         assert a.outfilename == 'a.out'
 
-    def test_reconstitute_xtalk_files(self):
+    def test_reconstitute_xtalk_files(self, tmp_path):
         # First, construct some cross-talk baseline files.
         datafiles = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.first.uvh5"),
                      os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.second.uvh5")]
 
         cals = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only.part1"),
                 os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only.part2")]
-        cdir = os.getcwd()
-        cdir = os.path.join(cdir, 'cache_temp')
         # make a cache directory
-        if os.path.isdir(cdir):
-            shutil.rmtree(cdir)
-        os.mkdir(cdir)
+        cdir = tmp_path /  "cache_temp"
+        cdir.mkdir()
         # cross-talk filter chunked baselines
         for filenum, file in enumerate(datafiles):
             baselines = io.baselines_from_filelist_position(file, datafiles, polarizations=['ee'])

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -211,7 +211,7 @@ class Test_XTalkFilter(object):
         cals = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only.part1"),
                 os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only.part2")]
         # make a cache directory
-        cdir = tmp_path /  "cache_temp"
+        cdir = tmp_path / "cache_temp"
         cdir.mkdir()
         # cross-talk filter chunked baselines
         for filenum, file in enumerate(datafiles):

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -37,7 +37,7 @@ class Test_XTalkFilter(object):
         # test skip_wgt imposition of flags
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         k = (24, 25, 'ee')
-        # check successful run when round_up_bllens is True and when False. 
+        # check successful run when round_up_bllens is True and when False.
         for round_up_bllens in [True, False]:
             xfil = xf.XTalkFilter(fname, filetype='miriad', round_up_bllens=round_up_bllens)
             xfil.read(bls=[k])
@@ -218,7 +218,7 @@ class Test_XTalkFilter(object):
         # cross-talk filter chunked baselines
         for filenum, file in enumerate(datafiles):
             baselines = io.baselines_from_filelist_position(file, datafiles, polarizations=['ee'])
-            fragment_filename = os.path.join(DATA_PATH, 'test_output/temp.fragment.part.%d.h5' % filenum)
+            fragment_filename = os.path.join(tmp_path, '/temp.fragment.part.%d.h5' % filenum)
             xf.load_xtalk_filter_and_write_baseline_list(datafiles, baseline_list=baselines, calfile_list=cals,
                                                          spw_range=[0, 20], cache_dir=cdir, read_cache=True, write_cache=True,
                                                          res_outfilename=fragment_filename, clobber=True)
@@ -233,19 +233,19 @@ class Test_XTalkFilter(object):
         for filenum, file in enumerate(datafiles):
             # reconstitute
             xf.reconstitute_xtalk_files(templatefile=file,
-                                        fragments=glob.glob(DATA_PATH + '/test_output/temp.fragment.part.*.h5'), clobber=True,
-                                        outfilename=os.path.join(DATA_PATH, 'test_output/temp.reconstituted.part.%d.h5' % filenum))
+                                        fragments=glob.glob(tmp_path + '/temp.fragment.part.*.h5'), clobber=True,
+                                        outfilename=os.path.join(tmp_path, '/temp.reconstituted.part.%d.h5' % filenum))
         # load in the reconstituted files.
-        hd_reconstituted = io.HERAData(glob.glob(DATA_PATH + '/test_output/temp.reconstituted.part.*.h5'))
+        hd_reconstituted = io.HERAData(glob.glob(tmp_path, '/temp.reconstituted.part.*.h5'))
         hd_reconstituted.read()
         # compare to xtalk filtering the whole file.
-        output_file = os.path.join(DATA_PATH, 'test_output/temp.h5')
-        xf.load_xtalk_filter_and_write(infilename=os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.uvh5"),
-                                       calfile=os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only"),
+        output_file = os.path.join(tmp_path, '/temp.h5')
+        xf.load_xtalk_filter_and_write(infilename=os.path.join(tmp_path, "/zen.2458101.46106.xx.HH.OCR_53x_54x_only.uvh5"),
+                                       calfile=os.path.join(tmp_path, "/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only"),
                                        res_outfilename=output_file, clobber=True, spw_range=[0, 20])
         hd = io.HERAData(output_file)
         hd.read()
         assert np.all(np.isclose(hd.data_array, hd_reconstituted.data_array))
         # clean up.
-        for file in glob.glob(DATA_PATH + "test_output/temp."):
+        for file in glob.glob(tmp_path, "/temp."):
             os.remove(file)

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -37,15 +37,17 @@ class Test_XTalkFilter(object):
         # test skip_wgt imposition of flags
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         k = (24, 25, 'ee')
-        xfil = xf.XTalkFilter(fname, filetype='miriad')
-        xfil.read(bls=[k])
-        wgts = {k: np.ones_like(xfil.flags[k], dtype=np.float)}
-        wgts[k][:, 0] = 0.0
-        xfil.run_xtalk_filter(to_filter=[k], weight_dict=wgts, tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
-        assert xfil.clean_info[k]['status']['axis_0'][0] == 'skipped'
-        np.testing.assert_array_equal(xfil.clean_flags[k][:, 0], np.ones_like(xfil.flags[k][:, 0]))
-        np.testing.assert_array_equal(xfil.clean_model[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))
-        np.testing.assert_array_equal(xfil.clean_resid[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))
+        # check successful run when round_up_bllens is True and when False. 
+        for round_up_bllens in [True, False]:
+            xfil = xf.XTalkFilter(fname, filetype='miriad', round_up_bllens=round_up_bllens)
+            xfil.read(bls=[k])
+            wgts = {k: np.ones_like(xfil.flags[k], dtype=np.float)}
+            wgts[k][:, 0] = 0.0
+            xfil.run_xtalk_filter(to_filter=[k], weight_dict=wgts, tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
+            assert xfil.clean_info[k]['status']['axis_0'][0] == 'skipped'
+            np.testing.assert_array_equal(xfil.clean_flags[k][:, 0], np.ones_like(xfil.flags[k][:, 0]))
+            np.testing.assert_array_equal(xfil.clean_model[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))
+            np.testing.assert_array_equal(xfil.clean_resid[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))
 
     def test_load_xtalk_filter_and_write_baseline_list(self):
         uvh5 = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.first.uvh5"),

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -193,6 +193,16 @@ class Test_XTalkFilter(object):
         assert a.max_frate_coeffs[0] == 0.024
         assert a.max_frate_coeffs[1] == -0.229
 
+    def test_reconstitute_xtalk_files_argparser(self):
+        sys.argv = [sys.argv[0], 'a', '--clobber', '--fragmentlist', 'a', 'b', 'c', 'd', '--outfilename', 'a.out']
+        parser = xf.reconstitute_xtalk_files_argparser()
+        a = parser.parse_args()
+        assert a.clobber
+        for char in ['a', 'b', 'c', 'd']:
+            assert char in a.fragmentlist
+        assert a.infilename == 'a'
+        assert a.outfilename == 'a.out'
+
     def test_reconstitute_xtalk_files(self):
         # First, construct some cross-talk baseline files.
         datafiles = [os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.first.uvh5"),

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1279,37 +1279,7 @@ def eq2top_m(ha, dec):
     if len(mat.shape) == 3:
         mat = mat.transpose([2, 0, 1])
     return mat
-
-
-def baselines_from_filelist_position(filename, filelist, polarizations):
-    """
-    Determine indices of baselines to process from the position of a filename within
-    a list of baselines in filelist.
-
-    Arguments:
-        filename, string
-            name of the file being processed.
-        filelist, list of strings
-            name of all files over which computations are being parallelized.
-        polarizations, list of strings
-            polarizations to include in baseline parallelization.
-    Returns:
-        list of baselines to process based on the position of the filename in the list of files.
-    """
-    # sanitize polarizations
-    for pol in polarizations:
-        assert pol in POL_STR2NUM_DICT or pol in ['ee', 'en', 'ne', 'nn'], "invalid polarization %s provided!"%pol
-    hd = HERAData(filename)
-    bls = [bl for bl in hd.bls if bl[-2] in polarizations]
-    file_index = filelist.index(filename)
-    nfiles = len(filelist)
-    # Determine chunk size
-    nbls = len(bls)
-    chunk_size = nbls // nfiles + 1
-    lower_index = file_index * chunk_size
-    upper_index = np.min([(file_index + 1) * chunk_size, nbls])
-    return bls[lower_index:upper_index]
-
+    
 
 def top2eq_m(ha, dec):
     """Return the 3x3 matrix converting topocentric coordinates to equatorial

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1279,7 +1279,7 @@ def eq2top_m(ha, dec):
     if len(mat.shape) == 3:
         mat = mat.transpose([2, 0, 1])
     return mat
-    
+
 
 def top2eq_m(ha, dec):
     """Return the 3x3 matrix converting topocentric coordinates to equatorial

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1281,6 +1281,36 @@ def eq2top_m(ha, dec):
     return mat
 
 
+def baselines_from_filelist_position(filename, filelist, polarizations):
+    """
+    Determine indices of baselines to process from the position of a filename within
+    a list of baselines in filelist.
+
+    Arguments:
+        filename, string
+            name of the file being processed.
+        filelist, list of strings
+            name of all files over which computations are being parallelized.
+        polarizations, list of strings
+            polarizations to include in baseline parallelization.
+    Returns:
+        list of baselines to process based on the position of the filename in the list of files.
+    """
+    # sanitize polarizations
+    for pol in polarizations:
+        assert pol in POL_STR2NUM_DICT or pol in ['ee', 'en', 'ne', 'nn'], "invalid polarization %s provided!"%pol
+    hd = HERAData(filename)
+    bls = [bl for bl in hd.bls if bl[-2] in polarizations]
+    file_index = filelist.index(filename)
+    nfiles = len(filelist)
+    # Determine chunk size
+    nbls = len(bls)
+    chunk_size = nbls // nfiles + 1
+    lower_index = file_index * chunk_size
+    upper_index = np.min([(file_index + 1) * chunk_size, nbls])
+    return bls[lower_index:upper_index]
+
+
 def top2eq_m(ha, dec):
     """Return the 3x3 matrix converting topocentric coordinates to equatorial
     at the given hour angle (ha) and declination (dec).

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1292,12 +1292,11 @@ def _filter_argparser(multifile=False):
     a.add_argument("--tol", type=float, default=1e-9, help='Threshold for foreground and xtalk subtraction (default 1e-9)')
     a.add_argument("infilename", type=str, help="path to visibility data file to delay filter")
     a.add_argument("--partial_load_Nbls", default=None, type=int, help="the number of baselines to load at once (default None means load full data")
-    if not multifile:
-        a.add_argument("--calfile", default=None, type=str, help="optional string path to calibration file to apply to data before delay filtering")
-    else:
+    if multifile:
         a.add_argument("--calfilelist", default=None, type=str, nargs="+", help="list of calibration files.")
         a.add_argument("--datafilelist", default=None, type=str, nargs="+", help="list of data files. Used to determine parallelization chunk.")
-
+    else:
+        a.add_argument("--calfile", default=None, type=str, help="optional string path to calibration file to apply to data before delay filtering")
     return a
 
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1292,6 +1292,7 @@ def _filter_argparser(multifile=False):
     a.add_argument("--tol", type=float, default=1e-9, help='Threshold for foreground and xtalk subtraction (default 1e-9)')
     a.add_argument("infilename", type=str, help="path to visibility data file to delay filter")
     a.add_argument("--partial_load_Nbls", default=None, type=int, help="the number of baselines to load at once (default None means load full data")
+    a.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering and flags times with unflagged fraction ~< skip_wgt (default 0.1)')
     if multifile:
         a.add_argument("--calfilelist", default=None, type=str, nargs="+", help="list of calibration files.")
         a.add_argument("--datafilelist", default=None, type=str, nargs="+", help="list of data files. Used to determine parallelization chunk.")
@@ -1323,7 +1324,6 @@ def _clean_argparser(multifile=False):
     clean_options = a.add_argument_group(title='Options for CLEAN')
     clean_options.add_argument("--window", type=str, default='blackman-harris', help='window function for frequency filtering (default "blackman-harris",\
                               see uvtools.dspec.gen_window for options')
-    clean_options.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering and flags times with unflagged fraction ~< skip_wgt (default 0.1)')
     clean_options.add_argument("--maxiter", type=int, default=100, help='maximum iterations for aipy.deconv.clean to converge (default 100)')
     clean_options.add_argument("--edgecut_low", default=0, type=int, help="Number of channels to flag on lower band edge and exclude from window function.")
     clean_options.add_argument("--edgecut_hi", default=0, type=int, help="Number of channels to flag on upper band edge and exclude from window function.")

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1273,11 +1273,12 @@ def noise_eq_bandwidth(window, axis=-1):
 # ------------------------------------------
 
 
-def _filter_argparser():
+def _filter_argparser(multifile=False):
     """
     Core Arg parser for commandline operation of hera_cal.delay_filter and hera_cal.xtalk_filter
     Parameters:
-        None
+        multifile, bool: optional. If True, add calfilelist and filelist
+                         arguments.
     Returns:
         Argparser with core (but not complete) functionality that is called by _linear_argparser and
         _clean_argparser.
@@ -1291,7 +1292,11 @@ def _filter_argparser():
     a.add_argument("--tol", type=float, default=1e-9, help='Threshold for foreground and xtalk subtraction (default 1e-9)')
     a.add_argument("infilename", type=str, help="path to visibility data file to delay filter")
     a.add_argument("--partial_load_Nbls", default=None, type=int, help="the number of baselines to load at once (default None means load full data")
-    a.add_argument("--calfile", default=None, type=str, help="optional string path to calibration file to apply to data before delay filtering")
+    if not multifile:
+        a.add_argument("--calfile", default=None, type=str, help="optional string path to calibration file to apply to data before delay filtering")
+    else:
+        a.add_argument("--calfilelist", default=None, type=str, nargs="+", help="list of calibration files.")
+        a.add_argument("--datafilelist", default=None, type=str, nargs="+", help="list of data files. Used to determine parallelization chunk.")
 
     return a
 
@@ -1302,15 +1307,18 @@ def _filter_argparser():
 # ------------------------------------------
 
 
-def _clean_argparser():
+def _clean_argparser(multifile=False):
     '''
     Arg parser for commandline operation of hera_cal.delay_filter in various clean modes.
-
+    Arguments
+    ---------
+        multifile, bool: optional. If True, add calfilelist and filelist
+                         arguments.
     Returns
     -------
         Arg-parser for linear filtering. Still needs domain specific args (delay versus xtalk).
     '''
-    a = _filter_argparser()
+    a = _filter_argparser(multifile=multifile)
     a.add_argument("--CLEAN_outfilename", default=None, type=str, help="path for writing the filtered model visibilities (with the same flags)")
     a.add_argument("--filled_outfilename", default=None, type=str, help="path for writing the original data but with flags unflagged and replaced with filtered models wherever possible")
     clean_options = a.add_argument_group(title='Options for CLEAN')
@@ -1330,15 +1338,18 @@ def _clean_argparser():
 # ------------------------------------------
 
 
-def _linear_argparser():
+def _linear_argparser(multifile=False):
     '''
     Arg parser for commandline operation of hera_cal.delay_filter in various linear modes.
-
+    Arguments
+    ---------
+        multifile, bool: optional. If True, add calfilelist and filelist
+                         arguments.
     Returns
     -------
         Arg-parser for linear filtering. Still needs domain specific args (delay versus xtalk)
     '''
-    a = _filter_argparser()
+    a = _filter_argparser(multifile=multifile)
     cache_options = a.add_argument_group(title='Options for caching')
     a.add_argument("--write_cache", default=False, action="store_true", help="if True, writes newly computed filter matrices to cache.")
     a.add_argument("--cache_dir", type=str, default=None, help="directory to store cached filtering matrices in.")

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -203,6 +203,41 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
                            extra_attrs={'Nfreqs': len(freqs), 'freq_array': np.asarray([freqs])})
 
 
+def reconstitute_xtalk_files(templatefile, fragments, outfilename):
+    """
+    Construct a new file based on templatefile that combines the files in file_fragments
+    over the times in template file.
+    Arguments
+    ---------
+    templatefile, string
+        name of the file to use as a template. Will reconstitute the file_fragments over the times in templatefile.
+    outfilename, string
+        name of the output file
+    file_fragments, list of strings
+        list of file names to use reconstitute.
+    Returns
+    -------
+        Nothing
+    """
+    hd_template = HERAData(templatefile)
+    hd_fragment = HERAData(fragments[0])
+    times = hd_template.times
+    freqs = hd_fragment.freqs
+    polarizations = hd_fragment.pols
+    # read in the template file, but only include polarizations, frequencies
+    # from the fragment files.
+    hd_template.read(times=times, freqs=freqs, polarizations=polarizations)
+    # for each fragment, read in only the times relevant to the templatefile.
+    # and update the data, flags, nsamples array of the template file
+    # with the fragment data.
+    for fragment in fragments:
+        hd_fragment = HERAData(fragment)
+        d, f, n = hd_fragment.read(times=times)
+        hd_template.update(flags=f, data=d, nsamples=n)
+    # now that we've updated everything, we write the output file.
+    hd_template.write_uvh5(outfilename)
+
+
 # ------------------------------------------
 # Here are arg-parsers for xtalk-filtering.
 # ------------------------------------------
@@ -228,3 +263,13 @@ def xtalk_filter_argparser(mode='clean', multifile=False):
     filt_options = a.add_argument_group(title='Options for the cross-talk filter')
     a.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2.")
     return a
+
+
+def reconstitute_xtalk_files_argparser():
+    """
+    Arg parser for file reconstitution.
+    """
+    a = argparse.ArgumentParser(description="Reconstitute fragmented baseline files.")
+    a.add_argument("infilename", type=str, help="name of template file.")
+    a.add_argument("--fragmentlist", type=str, nargs="+", help="list of file fragments to reconstitute")
+    a.add_argument("--outfilename", type=str, help="Name of output file. Provide the full path string.")

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -205,19 +205,22 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
 
 
 def reconstitute_xtalk_files(templatefile, fragments, outfilename, clobber=False):
-    """
+    """Recombine xtalk products into short-time files.
+
     Construct a new file based on templatefile that combines the files in file_fragments
     over the times in template file.
+
     Arguments
     ---------
-    templatefile, string
+    templatefile : string
         name of the file to use as a template. Will reconstitute the file_fragments over the times in templatefile.
-    outfilename, string
+    outfilename : string
         name of the output file
-    file_fragments, list of strings
+    file_fragments : list of strings
         list of file names to use reconstitute.
-    clobber, bool optional.
+    clobber : bool optional.
         If False, don't overwrite outfilename if it already exists. Default is False.
+
     Returns
     -------
         Nothing

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -18,6 +18,7 @@ import os
 import warnings
 from copy import deepcopy
 from pyuvdata import UVCal
+import argparse
 
 
 class XTalkFilter(VisClean):
@@ -216,7 +217,7 @@ def reconstitute_xtalk_files(templatefile, fragments, outfilename, clobber=False
     file_fragments, list of strings
         list of file names to use reconstitute.
     clobber, bool optional.
-        If False, don't overwrite outfilename if it already exists. Default is False. 
+        If False, don't overwrite outfilename if it already exists. Default is False.
     Returns
     -------
         Nothing
@@ -275,3 +276,5 @@ def reconstitute_xtalk_files_argparser():
     a.add_argument("infilename", type=str, help="name of template file.")
     a.add_argument("--fragmentlist", type=str, nargs="+", help="list of file fragments to reconstitute")
     a.add_argument("--outfilename", type=str, help="Name of output file. Provide the full path string.")
+    a.add_argument("--clobber", action="store_true", help="Include to overwrite old files.")
+    return a

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -208,21 +208,23 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
 # ------------------------------------------
 
 
-def xtalk_filter_argparser(mode='clean'):
+def xtalk_filter_argparser(mode='clean', multifile=False):
     '''
     Arg parser for commandline operation of xtalk filters.
     Parameters
     ----------
         mode, str : optional. Determines sets of arguments to load.
             can be 'clean', 'dayenu', or 'dpss_leastsq'.
+        multifile, bool: optional. If True, add calfilelist and filelist
+                         arguments.
     Returns
         argparser for xtalk (time-domain) filtering for specified filtering mode
     ----------
     '''
     if mode == 'clean':
-        a = vis_clean._clean_argparser()
+        a = vis_clean._clean_argparser(multifile=multifile)
     elif mode in ['linear', 'dayenu', 'dpss_leastsq']:
-        a = vis_clean._linear_argparser()
+        a = vis_clean._linear_argparser(multifile=multifile)
     filt_options = a.add_argument_group(title='Options for the cross-talk filter')
     a.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2.")
     return a

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -76,7 +76,10 @@ class XTalkFilter(VisClean):
         else:
             filter_cache = None
         # compute maximum fringe rate dict based on EW baseline lengths.
-        max_frate = io.DataContainer({k: np.max([max_frate_coeffs[0] * self.blvecs[k[:2]][0] + max_frate_coeffs[1], 0.0]) for k in self.data})
+        if self.round_up_bllens:
+            max_frate = io.DataContainer({k: np.max([max_frate_coeffs[0] * np.ceil(self.blvecs[k[:2]][0]) + max_frate_coeffs[1], 0.0]) for k in self.data})
+        else:
+            max_frate = io.DataContainer({k: np.max([max_frate_coeffs[0] * self.blvecs[k[:2]][0] + max_frate_coeffs[1], 0.0]) for k in self.data})
         # loop over all baselines in increments of Nbls
         self.vis_clean(keys=to_filter, data=self.data, flags=self.flags, wgts=weight_dict,
                        ax='time', x=(self.times - np.mean(self.times)) * 24. * 3600.,
@@ -90,7 +93,7 @@ class XTalkFilter(VisClean):
 def load_xtalk_filter_and_write(infilename, calfile=None, Nbls_per_load=None, spw_range=None, cache_dir=None,
                                 read_cache=False, write_cache=False, max_frate_coeffs=[0.024, -0.229],
                                 res_outfilename=None, CLEAN_outfilename=None, filled_outfilename=None,
-                                clobber=False, add_to_history='', **filter_kwargs):
+                                clobber=False, add_to_history='', round_up_bllens=False, **filter_kwargs):
     '''
     Uses partial data loading and writing to perform xtalk filtering.
 
@@ -113,6 +116,7 @@ def load_xtalk_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
             with CLEAN models wherever possible
         clobber: if True, overwrites existing file at the outfilename
         add_to_history: string appended to the history of the output file
+        round_up_bllens: bool, if True, round up baseline lengths. Default is False.
         filter_kwargs: additional keyword arguments to be passed to DelayFilter.run_filter()
     '''
     hd = io.HERAData(infilename, filetype='uvh5')
@@ -123,7 +127,7 @@ def load_xtalk_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
         spw_range = [0, hd.Nfreqs]
     freqs = hd.freqs[spw_range[0]:spw_range[1]]
     if Nbls_per_load is None:
-        xf = XTalkFilter(hd, input_cal=calfile)
+        xf = XTalkFilter(hd, input_cal=calfile, round_up_bllens=round_up_bllens)
         xf.read(frequencies=freqs)
         xf.run_xtalk_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache, **filter_kwargs)
         xf.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
@@ -132,7 +136,7 @@ def load_xtalk_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
                                extra_attrs={'Nfreqs': len(freqs), 'freq_array': np.asarray([freqs])})
     else:
         for i in range(0, hd.Nbls, Nbls_per_load):
-            xf = XTalkFilter(hd, input_cal=calfile)
+            xf = XTalkFilter(hd, input_cal=calfile, round_up_bllens=round_up_bllens)
             xf.read(bls=hd.bls[i:i + Nbls_per_load], frequencies=freqs)
             xf.run_xtalk_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache, **filter_kwargs)
             xf.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
@@ -145,7 +149,7 @@ def load_xtalk_filter_and_write(infilename, calfile=None, Nbls_per_load=None, sp
 def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calfile_list=None, spw_range=None, cache_dir=None,
                                               read_cache=False, write_cache=False, max_frate_coeffs=[0.024, -0.229],
                                               res_outfilename=None, CLEAN_outfilename=None, filled_outfilename=None,
-                                              clobber=False, add_to_history='', **filter_kwargs):
+                                              clobber=False, add_to_history='', round_up_bllens=False, **filter_kwargs):
     '''
     A xtalk filtering method that only simultaneously loads and writes user-provided
     list of baselines. This is to support parallelization over baseline (rather then time).
@@ -168,6 +172,7 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
             with CLEAN models wherever possible
         clobber: if True, overwrites existing file at the outfilename
         add_to_history: string appended to the history of the output file
+        round_up_bllens: bool, if True, round up baseline lengths. Default is False.
         filter_kwargs: additional keyword arguments to be passed to DelayFilter.run_filter()
     '''
     hd = io.HERAData(datafile_list, filetype='uvh5')
@@ -195,7 +200,7 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
         cals = io.to_HERACal(cals)
     else:
         cals = None
-    xf = XTalkFilter(hd, input_cal=cals)
+    xf = XTalkFilter(hd, input_cal=cals, round_up_bllens=round_up_bllens)
     xf.read(bls=baseline_list, frequencies=freqs)
     xf.run_xtalk_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache, **filter_kwargs)
     xf.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -203,7 +203,7 @@ def load_xtalk_filter_and_write_baseline_list(datafile_list, baseline_list, calf
                            extra_attrs={'Nfreqs': len(freqs), 'freq_array': np.asarray([freqs])})
 
 
-def reconstitute_xtalk_files(templatefile, fragments, outfilename):
+def reconstitute_xtalk_files(templatefile, fragments, outfilename, clobber=False):
     """
     Construct a new file based on templatefile that combines the files in file_fragments
     over the times in template file.
@@ -215,27 +215,29 @@ def reconstitute_xtalk_files(templatefile, fragments, outfilename):
         name of the output file
     file_fragments, list of strings
         list of file names to use reconstitute.
+    clobber, bool optional.
+        If False, don't overwrite outfilename if it already exists. Default is False. 
     Returns
     -------
         Nothing
     """
-    hd_template = HERAData(templatefile)
-    hd_fragment = HERAData(fragments[0])
+    hd_template = io.HERAData(templatefile)
+    hd_fragment = io.HERAData(fragments[0])
     times = hd_template.times
     freqs = hd_fragment.freqs
     polarizations = hd_fragment.pols
     # read in the template file, but only include polarizations, frequencies
     # from the fragment files.
-    hd_template.read(times=times, freqs=freqs, polarizations=polarizations)
+    hd_template.read(times=times, frequencies=freqs, polarizations=polarizations)
     # for each fragment, read in only the times relevant to the templatefile.
     # and update the data, flags, nsamples array of the template file
     # with the fragment data.
     for fragment in fragments:
-        hd_fragment = HERAData(fragment)
+        hd_fragment = io.HERAData(fragment)
         d, f, n = hd_fragment.read(times=times)
         hd_template.update(flags=f, data=d, nsamples=n)
     # now that we've updated everything, we write the output file.
-    hd_template.write_uvh5(outfilename)
+    hd_template.write_uvh5(outfilename, clobber=clobber)
 
 
 # ------------------------------------------

--- a/hera_cal/xtalk_filter.py
+++ b/hera_cal/xtalk_filter.py
@@ -247,17 +247,22 @@ def reconstitute_xtalk_files(templatefile, fragments, outfilename, clobber=False
 
 
 def xtalk_filter_argparser(mode='clean', multifile=False):
-    '''
-    Arg parser for commandline operation of xtalk filters.
+    '''Arg parser for commandline operation of xtalk filters.
+
     Parameters
     ----------
-        mode, str : optional. Determines sets of arguments to load.
-            can be 'clean', 'dayenu', or 'dpss_leastsq'.
-        multifile, bool: optional. If True, add calfilelist and filelist
-                         arguments.
+    mode : string, optional.
+        Determines sets of arguments to load.
+        Can be 'clean', 'dayenu', or 'dpss_leastsq'.
+    multifile: bool, optional.
+        If True, add calfilelist and filelist
+        arguments.
+
     Returns
+    -------
+    argparser
         argparser for xtalk (time-domain) filtering for specified filtering mode
-    ----------
+
     '''
     if mode == 'clean':
         a = vis_clean._clean_argparser(multifile=multifile)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/auto_reflection_run.py
+++ b/scripts/auto_reflection_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/baseline_chunker.py
+++ b/scripts/baseline_chunker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/dayenu_delay_filter_run.py
+++ b/scripts/dayenu_delay_filter_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/dayenu_delay_filter_run.py
+++ b/scripts/dayenu_delay_filter_run.py
@@ -15,7 +15,7 @@ a = parser.parse_args()
 filter_kwargs = {'standoff': a.standoff, 'horizon': a.horizon, 'tol': a.tol,
                  'skip_wgt': a.skip_wgt, 'min_dly': a.min_dly}
 # Run Delay Filter
-delay_filter.load_delay_filter_and_write(a.infilename, calfile=a.calfile,
+delay_filter.load_delay_filter_and_write(a.infilename, calfile=a.calfile, round_up_bllens=True, 
                                          Nbls_per_load=a.partial_load_Nbls, spw_range=a.spw_range,
                                          cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,
                                          clobber=a.clobber, write_cache=a.write_cache,

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/extract_autos.py
+++ b/scripts/extract_autos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/lstbin_run.py
+++ b/scripts/lstbin_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2018 the HERA Project
 # Licensed under the MIT License

--- a/scripts/noise_from_autos.py
+++ b/scripts/noise_from_autos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/post_redcal_abscal_run.py
+++ b/scripts/post_redcal_abscal_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2020 the HERA Project
 # Licensed under the MIT License

--- a/scripts/reconstitute_xtalk_filtered_files_run.py
+++ b/scripts/reconstitute_xtalk_filtered_files_run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+# Copyright 2019 the HERA Project
+# Licensed under the MIT License
+
+"Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"
+
+from hera_cal import xtalk_filter
+import sys
+import hera_cal.io as io
+
+parser = xtalk_filter.reconstitute_xtalk_files_argparser()
+
+a = parser.parse_args()
+
+
+# Run Delay Filter
+xtalk_filter.reconstitute_xtalk_files(templatefile=a.infilename,
+                                      fragments=a.fragmentlist,
+                                      outfilename=a.outfilename)

--- a/scripts/reconstitute_xtalk_filtered_files_run.py
+++ b/scripts/reconstitute_xtalk_filtered_files_run.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2019 the HERA Project
+# Copyright 2020 the HERA Project
 # Licensed under the MIT License
 
 "Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"

--- a/scripts/reconstitute_xtalk_filtered_files_run.py
+++ b/scripts/reconstitute_xtalk_filtered_files_run.py
@@ -6,15 +6,12 @@
 "Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"
 
 from hera_cal import xtalk_filter
-import sys
-import hera_cal.io as io
 
 parser = xtalk_filter.reconstitute_xtalk_files_argparser()
 
 a = parser.parse_args()
 
-
-# Run Delay Filter
+# Run Xtalk Filter
 xtalk_filter.reconstitute_xtalk_files(templatefile=a.infilename,
                                       fragments=a.fragmentlist,
                                       outfilename=a.outfilename)

--- a/scripts/redcal_run.py
+++ b/scripts/redcal_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/smooth_cal_run.py
+++ b/scripts/smooth_cal_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/xtalk_dayenu_filter_run.py
+++ b/scripts/xtalk_dayenu_filter_run.py
@@ -16,7 +16,7 @@ a = parser.parse_args()
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
 spw_range = a.spw_range
 # Run Delay Filter
-delay_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile,
+xtalk_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile,
                                          Nbls_per_load=a.partial_load_Nbls, spw_range=a.spw_range,
                                          cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,
                                          clobber=a.clobber, write_cache=a.write_cache,

--- a/scripts/xtalk_dayenu_filter_run.py
+++ b/scripts/xtalk_dayenu_filter_run.py
@@ -15,7 +15,7 @@ a = parser.parse_args()
 # set kwargs
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
 spw_range = a.spw_range
-# Run Delay Filter
+# Run Xtalk Filter
 xtalk_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile,
                                          Nbls_per_load=a.partial_load_Nbls, spw_range=a.spw_range,
                                          cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,

--- a/scripts/xtalk_dayenu_filter_run.py
+++ b/scripts/xtalk_dayenu_filter_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/scripts/xtalk_dayenu_filter_run.py
+++ b/scripts/xtalk_dayenu_filter_run.py
@@ -16,7 +16,7 @@ a = parser.parse_args()
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
 spw_range = a.spw_range
 # Run Xtalk Filter
-xtalk_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile,
+xtalk_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile, round_up_bllens=True,
                                          Nbls_per_load=a.partial_load_Nbls, spw_range=a.spw_range,
                                          cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,
                                          clobber=a.clobber, write_cache=a.write_cache,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -16,9 +16,8 @@ a = parser.parse_args()
 # set kwargs
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
 baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
-fileindex = a.datafilelist.index(a.infilename)
 # modify output file name to include index.
-outfilename = a.res_outfilename + ".part.%d" % fileindex
+outfilename = a.res_outfilename
 spw_range = a.spw_range
 # Run Xtalk Filter
 xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -21,9 +21,9 @@ fileindex = a.datafilelist.index(a.infilename)
 outfilename = a.res_outfilename + ".part.%d" % fileindex
 spw_range = a.spw_range
 # Run Delay Filter
-delay_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
-                                         baseline_list=baseline_list, spw_range=a.spw_range,
-                                         cache_dir=a.cache_dir, res_outfilename=outfilename,
-                                         clobber=a.clobber, write_cache=a.write_cache,
-                                         read_cache=a.read_cache, mode='dayenu',
-                                         add_to_history=' '.join(sys.argv), **filter_kwargs)
+xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
+                                                       baseline_list=baseline_list, spw_range=a.spw_range,
+                                                       cache_dir=a.cache_dir, res_outfilename=outfilename,
+                                                       clobber=a.clobber, write_cache=a.write_cache,
+                                                       read_cache=a.read_cache, mode='dayenu',
+                                                       add_to_history=' '.join(sys.argv), **filter_kwargs)

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+# Copyright 2019 the HERA Project
+# Licensed under the MIT License
+
+"Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"
+
+from hera_cal import xtalk_filter
+import sys
+
+parser = xtalk_filter.xtalk_filter_argparser(mode='dayenu', multifile=True)
+
+a = parser.parse_args()
+
+# set kwargs
+filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
+baseline_list = baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
+spw_range = a.spw_range
+# Run Delay Filter
+delay_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
+                                         baseline_list=baseline_list, spw_range=a.spw_range,
+                                         cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,
+                                         clobber=a.clobber, write_cache=a.write_cache,
+                                         read_cache=a.read_cache, mode='dayenu',
+                                         add_to_history=' '.join(sys.argv), **filter_kwargs)

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -15,7 +15,7 @@ a = parser.parse_args()
 
 # set kwargs
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
-baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
+baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist)
 # modify output file name to include index.
 outfilename = a.res_outfilename
 spw_range = a.spw_range

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -20,7 +20,7 @@ baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filel
 outfilename = a.res_outfilename
 spw_range = a.spw_range
 # Run Xtalk Filter
-xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
+xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist, round_up_bllens=True,
                                                        baseline_list=baseline_list, spw_range=a.spw_range,
                                                        cache_dir=a.cache_dir, res_outfilename=outfilename,
                                                        clobber=a.clobber, write_cache=a.write_cache,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2019 the HERA Project
+# Copyright 2020 the HERA Project
 # Licensed under the MIT License
 
 "Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -20,7 +20,7 @@ baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filel
 outfilename = a.res_outfilename
 spw_range = a.spw_range
 # Run Xtalk Filter
-xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist, round_up_bllens=True,
+xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.datafilelist, calfile_list=a.calfilelist, round_up_bllens=True,
                                                        baseline_list=baseline_list, spw_range=a.spw_range,
                                                        cache_dir=a.cache_dir, res_outfilename=outfilename,
                                                        clobber=a.clobber, write_cache=a.write_cache,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -3,7 +3,7 @@
 # Copyright 2020 the HERA Project
 # Licensed under the MIT License
 
-"Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"
+"""Command-line drive script for hera_cal.xtalk_filter. Only performs DAYENU Filtering"""
 
 from hera_cal import xtalk_filter
 import sys

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -20,7 +20,7 @@ fileindex = a.datafilelist.index(a.infilename)
 # modify output file name to include index.
 outfilename = a.res_outfilename + ".part.%d" % fileindex
 spw_range = a.spw_range
-# Run Delay Filter
+# Run Xtalk Filter
 xtalk_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
                                                        baseline_list=baseline_list, spw_range=a.spw_range,
                                                        cache_dir=a.cache_dir, res_outfilename=outfilename,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -7,6 +7,7 @@
 
 from hera_cal import xtalk_filter
 import sys
+import hera_cal.io as io
 
 parser = xtalk_filter.xtalk_filter_argparser(mode='dayenu', multifile=True)
 
@@ -14,7 +15,7 @@ a = parser.parse_args()
 
 # set kwargs
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
-baseline_list = baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
+baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
 spw_range = a.spw_range
 # Run Delay Filter
 delay_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,

--- a/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
+++ b/scripts/xtalk_dayenu_filter_run_baseline_parallelized.py
@@ -16,11 +16,14 @@ a = parser.parse_args()
 # set kwargs
 filter_kwargs = {'tol': a.tol, 'max_frate_coeffs': a.max_frate_coeffs}
 baseline_list = io.baselines_from_filelist_position(filename=a.infilename, filelist=a.datafilelist, polarizations=a.polarizations)
+fileindex = a.datafilelist.index(a.infilename)
+# modify output file name to include index.
+outfilename = a.res_outfilename + ".part.%d" % fileindex
 spw_range = a.spw_range
 # Run Delay Filter
 delay_filter.load_xtalk_filter_and_write_baseline_list(a.filelist, calfile_list=a.calfilelist,
                                          baseline_list=baseline_list, spw_range=a.spw_range,
-                                         cache_dir=a.cache_dir, res_outfilename=a.res_outfilename,
+                                         cache_dir=a.cache_dir, res_outfilename=outfilename,
                                          clobber=a.clobber, write_cache=a.write_cache,
                                          read_cache=a.read_cache, mode='dayenu',
                                          add_to_history=' '.join(sys.argv), **filter_kwargs)

--- a/scripts/xtalk_filter_run.py
+++ b/scripts/xtalk_filter_run.py
@@ -20,7 +20,7 @@ if a.window == 'tukey':
     filter_kwargs['alpha'] = a.alpha
 spw_range = a.spw_range
 # Run XTalk Filter
-delay_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile, Nbls_per_load=a.partial_load_Nbls,
+xtalk_filter.load_xtalk_filter_and_write(a.infilename, calfile=a.calfile, Nbls_per_load=a.partial_load_Nbls,
                                          res_outfilename=a.res_outfilename, CLEAN_outfilename=a.CLEAN_outfilename,
                                          filled_outfilename=a.filled_outfilename, clobber=a.clobber, spw_range=spw_range,
                                          add_to_history=' '.join(sys.argv), **filter_kwargs)

--- a/scripts/xtalk_filter_run.py
+++ b/scripts/xtalk_filter_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019 the HERA Project
 # Licensed under the MIT License

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_args = {
                 'scripts/query_ex_ants.py', 'scripts/xtalk_dayenu_filter_run.py',
                 'scripts/xtalk_dayenu_filter_run_baseline_parallelized.py',
                 'scripts/xtalk_filter_run.py',
-                'scripts/xtalk_dayenu_filter_run.py'],
+                'scripts/dayenu_delay_filter_run.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
     'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup_args = {
                 'scripts/query_ex_ants.py', 'scripts/xtalk_dayenu_filter_run.py',
                 'scripts/xtalk_dayenu_filter_run_baseline_parallelized.py',
                 'scripts/xtalk_filter_run.py',
-                'scripts/dayenu_delay_filter_run.py'],
+                'scripts/dayenu_delay_filter_run.py',
+                'scripts/reconstitute_xtalk_filtered_files_run.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
     'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup_args = {
                 'scripts/lstbin_run.py', 'scripts/extract_autos.py',
                 'scripts/smooth_cal_run.py', 'scripts/redcal_run.py',
                 'scripts/auto_reflection_run.py', 'scripts/noise_from_autos.py',
-                'scripts/query_ex_ants.py'],
+                'scripts/query_ex_ants.py', 'scripts/xtalk_dayenu_filter_run.py',
+                'scripts/xtalk_dayenu_filter_run_baseline_parallelized.py',
+                'scripts/xtalk_filter_run.py',
+                'scripts/xtalk_dayenu_filter_run.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
     'install_requires': [


### PR DESCRIPTION
Functionality for parallelizing cross-talk filtering over baselines to enable filtering many hours simultaneously. Parallelization is based on file-numbers so it can be performed within the existing OPM framework. Parallelized cross-talk filtering breaks out small chunks baselines into new files that contain all times in a night. After cross-talk filtering, these files are reconstituted into standard few-time, all baseline files.