### PR TITLE
Set filter residuals and models in skipped integrations / channels equal to zero.

### DIFF
--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -128,8 +128,8 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
@@ -149,8 +149,8 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
@@ -200,8 +200,8 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True)
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
@@ -210,8 +210,8 @@ class Test_VisClean(object):
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
         assert 'success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3]
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
@@ -221,8 +221,8 @@ class Test_VisClean(object):
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -127,6 +127,12 @@ class Test_VisClean(object):
                          ax='time', mode='dayenu', zeropad=10, max_contiguous_edge_flags=20)
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+
         # raise errors.
         assert pytest.raises(ValueError, V.fourier_filter, filter_centers=[fc, fc], ax='both',
                              filter_half_widths=[fwt, fw], suppression_factors=[ff, ff],
@@ -142,6 +148,11 @@ class Test_VisClean(object):
                          zeropad=[20, 10], ax='both', max_contiguous_edge_flags=100)
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
     @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean_dayenu(self):
@@ -188,17 +199,32 @@ class Test_VisClean(object):
         # basic freq clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True)
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
         assert 'success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3]
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,
                     filt2d_mode='plus')
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -175,8 +175,10 @@ class Test_VisClean(object):
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
+        # had to set atol=1e-6 here so it won't fail on travis (it runs fine on my laptop). There are some funny
+        # numpy issues.
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-15))
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
 
         assert pytest.raises(ValueError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', mode='dayenu')
@@ -195,7 +197,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-15))
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dayenu')
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
@@ -207,7 +209,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-15))
         # check whether dayenu filtering axis 1 and then axis 0 is the same as dayenu filtering axis 1 and then filtering the resid.
         # note that filtering axis orders do not commute, we filter axis 1 (foregrounds) before filtering cross-talk.
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dayenu')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -132,6 +132,9 @@ class Test_VisClean(object):
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
 
         # raise errors.
         assert pytest.raises(ValueError, V.fourier_filter, filter_centers=[fc, fc], ax='both',
@@ -153,6 +156,9 @@ class Test_VisClean(object):
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
 
     @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean_dayenu(self):
@@ -204,7 +210,9 @@ class Test_VisClean(object):
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
-
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
@@ -214,7 +222,9 @@ class Test_VisClean(object):
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
-
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,
                     filt2d_mode='plus')
@@ -225,6 +235,9 @@ class Test_VisClean(object):
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
         assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -134,7 +134,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-10, rtol=1e-10))
 
         # raise errors.
         assert pytest.raises(ValueError, V.fourier_filter, filter_centers=[fc, fc], ax='both',
@@ -158,7 +158,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                      V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-10, rtol=1e-10))
 
     @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean_dayenu(self):
@@ -169,6 +169,14 @@ class Test_VisClean(object):
         # most coverage is in dspec. Check that args go through here.
         # similar situation for test_vis_clean.
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='freq', overwrite=True, mode='dayenu')
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
 
         assert pytest.raises(ValueError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', mode='dayenu')
@@ -180,12 +188,26 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='time', overwrite=True, max_frate=1.0, mode='dayenu')
         assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3] == 'success'
-
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dayenu')
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3] == 'success'
-
+        # check that clean resid is equal to zero in flagged channels
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        # check that filtered_data is the same in channels that were not flagged
+        assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
         # check whether dayenu filtering axis 1 and then axis 0 is the same as dayenu filtering axis 1 and then filtering the resid.
         # note that filtering axis orders do not commute, we filter axis 1 (foregrounds) before filtering cross-talk.
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dayenu')
@@ -212,7 +234,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-10, rtol=1e-10))
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
@@ -237,7 +259,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]]))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-10, rtol=1e-10))
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -128,10 +128,10 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
-        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         # raise errors.
         assert pytest.raises(ValueError, V.fourier_filter, filter_centers=[fc, fc], ax='both',
@@ -149,10 +149,10 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
-        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
     @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean_dayenu(self):
@@ -200,20 +200,20 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True)
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
-        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
         assert 'success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3]
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
-        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,
@@ -221,10 +221,10 @@ class Test_VisClean(object):
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
-        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
-        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
+        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
+        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
+        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -236,7 +236,7 @@ class Test_VisClean(object):
         assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
-                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],atol=1e-6))
+                                 V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-6))
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
 
         assert pytest.raises(ValueError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', mode='dpss_leastsq')

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -128,10 +128,10 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
-        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
-        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
+        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
 
         # raise errors.
         assert pytest.raises(ValueError, V.fourier_filter, filter_centers=[fc, fc], ax='both',
@@ -149,10 +149,10 @@ class Test_VisClean(object):
         assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
         assert V.clean_info[k]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
-        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
-        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
+        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
 
     @pytest.mark.filterwarnings("ignore:.*dspec.vis_filter will soon be deprecated")
     def test_vis_clean_dayenu(self):
@@ -200,20 +200,20 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True)
         assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
-        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
-        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
+        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
 
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
         assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
         assert 'success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3]
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
-        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
-        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
+        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
 
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,
@@ -221,10 +221,10 @@ class Test_VisClean(object):
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
         assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
-        assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')]] == 0.)
-        assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])] != 0.)
-        assert np.all(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]] == 0.)
-        assert np.any(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]] != 0.)
+        assert np.all(np.isclose(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24,25,'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25,'ee')] | V.flags[(24,25,'ee')])],0.))
+        assert np.all(np.isclose(V.clean_model[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')]], 0.))
+        assert np.any(~np.isclose(V.clean_model[(24, 25, 'ee')][~V.clean_flags[(24, 25, 'ee')]], 0.))
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -695,9 +695,9 @@ class VisClean(object):
                             elif dim == 1:
                                 flgs[i] = True
 
-            filtered_model[k] = mdl
-            filtered_resid[k] = res
-            filtered_data[k] = mdl + res * fw
+            filtered_model[k] = mdl * ~flgs
+            filtered_resid[k] = res * (~flgs | ~f)
+            filtered_data[k] = filtered_model[k] + filtered_resid[k]
             filtered_flags[k] = flgs
             filtered_info[k] = info
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -695,8 +695,10 @@ class VisClean(object):
                             elif dim == 1:
                                 flgs[i] = True
 
-            filtered_model[k] = mdl * ~flgs
-            filtered_resid[k] = res * (~flgs | ~f)
+            filtered_model[k] = mdl
+            filtered_model[k][flgs] = 0.
+            filtered_resid[k] = res
+            filtered_resid[k][flgs | f] = 0.
             filtered_data[k] = filtered_model[k] + filtered_resid[k]
             filtered_flags[k] = flgs
             filtered_info[k] = info

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -685,22 +685,22 @@ class VisClean(object):
                         res, _ = zeropad_array(res, zeropad=zeropad[i], axis=i, undo=True)
                     _trim_status(info, i, zeropad[i - 1])
 
-            flgs = np.zeros_like(mdl, dtype=np.bool)
+            skipped = np.zeros_like(mdl, dtype=np.bool)
             for dim in range(2):
                 if len(info['status']['axis_%d' % dim]) > 0:
                     for i in range(len(info['status']['axis_%d' % dim])):
                         if info['status']['axis_%d' % dim][i] == 'skipped':
                             if dim == 0:
-                                flgs[:, i] = True
+                                skipped[:, i] = True
                             elif dim == 1:
-                                flgs[i] = True
+                                skipped[i] = True
 
             filtered_model[k] = mdl
-            filtered_model[k][flgs] = 0.
-            filtered_resid[k] = res
-            filtered_resid[k][flgs | f] = 0.
+            filtered_model[k][skipped] = 0.
+            filtered_resid[k] = res * fw
+            filtered_resid[k][skipped] = 0.
             filtered_data[k] = filtered_model[k] + filtered_resid[k]
-            filtered_flags[k] = flgs
+            filtered_flags[k] = skipped
             filtered_info[k] = info
 
         if hasattr(data, 'times'):


### PR DESCRIPTION
Closes #618 Depends on #625 