### PR TITLE
[vis_clean] fixes apply_cal bug in freq selection

### DIFF
--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -276,6 +276,14 @@ class Test_ReflectionFitter_Cables(object):
         uvc = RF.write_auto_reflections("./ex.calfits", time_array=RF.avg_times, input_calfits='./ex.calfits', overwrite=True)
         assert uvc.Ntimes == 100
 
+        # test input calibration with slightly shifted frequencies
+        uvc.read_calfits("./ex.calfits")
+        uvc.freq_array += 1e-5  # assert this doesn't fail
+        T = reflections.ReflectionFitter(self.uvd, input_cal=uvc)
+        assert isinstance(T.hc, io.HERACal)
+        uvc.freq_array += 1e2  # now test it fails with a large shift
+        pytest.raises(ValueError, reflections.ReflectionFitter, self.uvd, input_cal=uvc)
+
         os.remove('./ex.calfits')
         os.remove('./ex2.calfits')
         os.remove('./ex.npz')

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -282,7 +282,7 @@ class Test_ReflectionFitter_Cables(object):
         T = reflections.ReflectionFitter(self.uvd, input_cal=uvc)
         assert isinstance(T.hc, io.HERACal)
         uvc.freq_array += 1e2  # now test it fails with a large shift
-        pytest.raises(ValueError, reflections.ReflectionFitter, self.uvd, input_cal=uvc)
+        pytest.raises(AssertionError, reflections.ReflectionFitter, self.uvd, input_cal=uvc)
 
         os.remove('./ex.calfits')
         os.remove('./ex2.calfits')

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -192,6 +192,8 @@ class VisClean(object):
             match = np.isclose(hc.freqs, f, rtol=1e-10)
             if True in match:
                 cal_freqs_in_data.append(np.argmax(match))
+        # assert all frequencies in data are found in uvcal
+        assert len(cal_freqs_in_data) == len(self.freqs), "Not all freqs in uvd are in uvc"
 
         for ant in cal_gains:
             cal_gains[ant] = cal_gains[ant][:, cal_freqs_in_data]

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -186,7 +186,13 @@ class VisClean(object):
         hc = io.to_HERACal(input_cal)
         # load gains
         cal_gains, cal_flags, cal_quals, cal_tquals = hc.read()
-        cal_freqs_in_data = np.logical_and(hc.freqs >= self.data.freqs.min(), hc.freqs <= self.data.freqs.max())
+        # get overlapping frequency bins
+        cal_freqs_in_data = []
+        for f in self.freqs:
+            match = np.isclose(hc.freqs, f, rtol=1e-10)
+            if True in match:
+                cal_freqs_in_data.append(np.argmax(match))
+
         for ant in cal_gains:
             cal_gains[ant] = cal_gains[ant][:, cal_freqs_in_data]
             cal_flags[ant] = cal_flags[ant][:, cal_freqs_in_data]


### PR DESCRIPTION
A few months ago a line was inserted into `VisClean.apply_calibration` that selected out a range of frequencies. However, this was done using float-to-float comparison, which has caused some parts of the preprocessing pipeline to fail. For reasons that are not entirely clear, the calibration has negligibly offset frequencies from the data (1e-10 dynamic range). I updated this to use safer `isclose` comparison with a 1e-10 dynamic range. A test is included for this.