### PR TITLE
Improve performance and memory requirements of expand_omni_sol 

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1400,13 +1400,14 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
     # Solve for unsolved-for unique baselines whose antennas are both in cal['g_omnical']
     good_ants_reds = filter_reds(all_reds, ants=list(cal['g_omnical'].keys()))
     good_ants_bls = [bl for red in good_ants_reds for bl in red]
-    bls_to_use = [bl for red in good_ants_reds for bl in red if not np.any([bl in cal['v_omnical'] for bl in red])]
-    if len(bls_to_use) > 0:
-        new_vis = linear_cal_update(bls_to_use, cal, data, good_ants_reds, weight_by_flags=True)
+    reds_to_solve_for = [red for red in good_ants_reds if not np.any([bl in cal['v_omnical'] for bl in red])]
+    for red in reds_to_solve_for:
+        new_vis = linear_cal_update(red, cal, data, [red], weight_by_flags=True)
         for ubl, vis in new_vis.items():
             cal['v_omnical'][ubl] = vis
             cal['vf_omnical'][ubl] = ~np.isfinite(vis)
-        make_sol_finite(cal['v_omnical'])
+    make_sol_finite(cal['v_omnical'])
+
 
     # Update chisq and chisq per ant to include all baselines between working antennas
     rekey_vis_sols(cal, good_ants_reds)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1436,8 +1436,13 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
             break  # iterate to also solve for ants only found in bls with other ex_ants
 
         # solve for new gains and update cal
-        new_gains = linear_cal_update(bls_to_use, cal, data, all_reds,
-                                      weight_by_nsamples=True, weight_by_flags=(i == 0))
+        new_gains = {}
+        new_gain_ants = set([ant for bl in bls_to_use for ant in split_bl(bl) 
+                             if ant not in cal['g_omnical']])
+        for ant in new_gain_ants:
+            new_gains.update(linear_cal_update([bl for bl in bls_to_use if ant in split_bl(bl)], 
+                                               cal, data, all_reds, 
+                                               weight_by_nsamples=True, weight_by_flags=(i == 0)))
         make_sol_finite(new_gains)
         for ant, g in new_gains.items():
             cal['g_omnical'][ant] = g

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1410,7 +1410,6 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
             cal['vf_omnical'][ubl] = ~np.isfinite(vis)
     make_sol_finite(cal['v_omnical'])
 
-
     # Update chisq and chisq per ant to include all baselines between working antennas
     rekey_vis_sols(cal, good_ants_reds)
     dts_by_bl = {bl: np.median(np.ediff1d(data.times_by_bl[bl[:2]])) * SEC_PER_DAY for bl in good_ants_bls}

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1315,8 +1315,10 @@ def linear_cal_update(bls, cal, data, all_reds, weight_by_nsamples=False, weight
     # use RedundantCalibrator to build up constants and equations
     rc_all = RedundantCalibrator(all_reds)
     consts = {rc_all.pack_sol_key(ant): cal['g_omnical'][ant] for ant in cal['g_omnical']}
-    consts.update({rc_all.pack_sol_key([red[0] for red in all_reds if bl in red][0]):
-                   cal['v_omnical'][bl] for bl in cal['v_omnical']})
+    for bl in cal['v_omnical']:
+        matched_reds = [red[0] for red in all_reds if bl in red]
+        if len(matched_reds) > 0:
+            consts.update({rc_all.pack_sol_key(matched_reds[0]): cal['v_omnical'][bl]})
     eqs = {eq_str: bl for eq_str, bl in rc_all.build_eqs().items() if bl in bls}
 
     # map baselines to ubls

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1465,12 +1465,18 @@ def expand_omni_sol(cal, all_reds, data, nsamples):
                 cal['chisq_per_ant'][ant][~np.isfinite(cspa)] = np.zeros_like(cspa[~np.isfinite(cspa)])
 
     # Solve for unsolved-for unique baselines visbility solutions
-    bls_to_use = [bl for red in all_reds for bl in red
-                  if ((red[0] not in cal['v_omnical'])
-                      and ((split_bl(bl)[0] in cal['g_omnical'])
-                      and (split_bl(bl)[1] in cal['g_omnical'])))]
-    if len(bls_to_use) > 0:
-        new_vis = linear_cal_update(bls_to_use, cal, data, all_reds)
+    reds_to_solve_for = []
+    for red in all_reds:
+        if red[0] in cal['v_omnical']:
+            continue
+        red_to_solve_for = []
+        for bl in red:
+            if (split_bl(bl)[0] in cal['g_omnical']) and (split_bl(bl)[1] in cal['g_omnical']):
+                red_to_solve_for.append(bl)
+        if len(red_to_solve_for) > 0:
+            reds_to_solve_for.append(red_to_solve_for)
+    for red in reds_to_solve_for:
+        new_vis = linear_cal_update(red, cal, data, all_reds)
         make_sol_finite(new_vis)
         for bl, vis in new_vis.items():
             cal['v_omnical'][bl] = vis


### PR DESCRIPTION
Among other things, `redcal.expand_omni_sol()`'s job is to come up with reasonable gains and visibility solutions for flagged antennas and unused baselines in redcal. This was done in a big system of equations, but when there's lots of excluded antennas or baselines, this because very big, very slow, and quite the memory hog. This was often causing RTP to run out of memory, which then prevents notebooks from being run, etc.

Turns out that the way this was written, that big matrix was block diagonal by construction and the algorithms being used to write it down and invert it didn't take that into account. Oddly, the solution was turn turn this vectorized operation for solving for visibilities/gains into python loops, which is almost always the wrong answer... but not today! 

I have verified that it produces the same answer as before this edit with real H4C data.


Memory usage before:
<img width="1160" alt="Screen Shot 2020-08-25 at 5 55 32 PM" src="https://user-images.githubusercontent.com/5281139/91242730-05676d00-e6fd-11ea-86f8-862fb5573240.png">

Memory usage after:
![Screen Shot 2020-08-25 at 6 01 19 PM](https://user-images.githubusercontent.com/5281139/91242733-08faf400-e6fd-11ea-8280-f59b53ba12ff.png)