### PR TITLE
Fix bug in chunk_baselines_by_redundant_groups where baseline_chunks are not necessarily initialized 

### DIFF
--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -315,6 +315,16 @@ class Test_Update_Cal(object):
         assert np.all(np.isclose(hda_calibrated.flag_array, hda_calibrated_with_apply_cal.flag_array))
         assert np.all(np.isclose(hda_calibrated.data_array, hda_calibrated_with_apply_cal.data_array))
 
+        # now do chunked redundant groups with a large group size to catch a bug.
+        ac.apply_cal(uncalibrated_file, calibrated_redundant_averaged_file, calfile,
+                     gain_convention='divide', redundant_average=True, nbl_per_load=1000000, clobber=True)
+        hda_calibrated_with_apply_cal = io.HERAData(calibrated_redundant_averaged_file)
+        hda_calibrated_with_apply_cal.read()
+        # check that the data, flags, and nsamples arrays are close
+        assert np.all(np.isclose(hda_calibrated.nsample_array, hda_calibrated_with_apply_cal.nsample_array))
+        assert np.all(np.isclose(hda_calibrated.flag_array, hda_calibrated_with_apply_cal.flag_array))
+        assert np.all(np.isclose(hda_calibrated.data_array, hda_calibrated_with_apply_cal.data_array))
+
     def test_apply_cal_argparser(self):
         sys.argv = [sys.argv[0], 'a', 'b', '--new_cal', 'd']
         a = ac.apply_cal_argparser()

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1261,7 +1261,7 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
                 favg = np.all(np.isclose(w * f, 0), axis=0)
             else:
                 favg = np.all(np.isclose(w, 0), axis=0)
-                
+
             # replace with new data
             if fed_container:
                 blkey = blg[0] + (pol,)
@@ -1359,6 +1359,9 @@ def chunk_baselines_by_redundant_groups(reds, max_chunk_size):
                           " Loading group anyways." % (len(reds[group_index]), max_chunk_size, str(reds[group_index][0])))
             baseline_chunks.append(grp)
         else:
+            # if baseline_chunks is empty, initialize the first chunk.
+            if len(baseline_chunks) == 0:
+                baseline_chunks.append([])
             if len(baseline_chunks[-1]) + len(grp) <= max_chunk_size:
                 baseline_chunks[-1].extend(grp)
             else:


### PR DESCRIPTION
If the first chunk is less than max_chunk_size, then baseline_chunks are not initialized. This PR fixes this bug. 