### PR TITLE
Fix abscal bias with new linearized abscal overall amplitude calibration

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -212,7 +212,7 @@ def abs_amp_lincal(model, data, wgts=None, verbose=True, return_gains=False, gai
         else:
             data_here[k] = data[k]
         if np.any(~np.isfinite(model[k])):
-            model_here[k] =copy.deepcopy(model[k])
+            model_here[k] = copy.deepcopy(model[k])
             fill_dict_nans(model_here[k], wgts=wgts[k], nan_fill=0.0, inf_fill=0.0, array=True)
         else:
             model_here[k] = model[k]

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -168,10 +168,10 @@ def abs_amp_lincal(model, data, wgts=None, verbose=True, return_gains=False, gai
                 Converegence is measured L2-norm of the change in the solution of the 
                 variables divided by the L2-norm of the solution itself.
                 Default: None (resolves to machine precision for inferred dtype).
-                N.B. Only used when data and model include cross-polarized visibilities.
+                Note: only used when data and model include cross-polarized visibilities.
     
     maxiter : Integer maximum number of iterations to perform LinProductSolver.
-              N.B. Only used when data and model include cross-polarized visibilities.    
+              Note: only used when data and model include cross-polarized visibilities.
 
     verbose : print output, type=boolean, [default=False]
 
@@ -3094,7 +3094,7 @@ def build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flag
                     df=None, data_is_redsol=False, gain_flags=None, tol=1.0, antpos=None):
     '''Build linear weights for data in abscal (or calculating chisq) defined as
     wgts = (noise variance * nsamples)^-1 * (0 if data or model is flagged).
-    N.B.: if there are discontinunities into the autocorrelations, the nsamples, etc., this maybe
+    Note: if there are discontinunities into the autocorrelations, the nsamples, etc., this may
     introduce spectral strucutre into the calibration soltuion.
 
     Arguments:

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -207,13 +207,13 @@ def abs_amp_lincal(model, data, wgts=None, verbose=True, return_gains=False, gai
     model_here = {}
     for k in keys:
         if np.any(~np.isfinite(data[k])):
-            data_here[k] = deepcopy(data[k])
-            fill_dict_nans(data_here[k], wgts=wgts, nan_fill=0.0, inf_fill=0.0, array=True)
+            data_here[k] = copy.deepcopy(data[k])
+            fill_dict_nans(data_here[k], wgts=wgts[k], nan_fill=0.0, inf_fill=0.0, array=True)
         else:
             data_here[k] = data[k]
         if np.any(~np.isfinite(model[k])):
-            model_here[k] = deepcopy(model[k])
-            fill_dict_nans(model_here[k], wgts=wgts, nan_fill=0.0, inf_fill=0.0, array=True)
+            model_here[k] =copy.deepcopy(model[k])
+            fill_dict_nans(model_here[k], wgts=wgts[k], nan_fill=0.0, inf_fill=0.0, array=True)
         else:
             model_here[k] = model[k]
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3199,7 +3199,7 @@ def post_redcal_abscal(model, data, data_wgts, rc_flags, edge_cut=0, tol=1.0, ke
                        '         Of them, {} is not flagged.\n').format(suspected_off_grid, not_flagged))
         idealized_antpos = {ant: pos[:2] for ant, pos in idealized_antpos.items()}
 
-    # Abscal Step 1: Per-Channel Absolute Amplitude Calibration
+    # Abscal Step 1: Per-Channel Logarithmic Absolute Amplitude Calibration
     gains_here = abs_amp_logcal(model, data, wgts=data_wgts, verbose=verbose, return_gains=True, gain_ants=ants)
     abscal_delta_gains = {ant: gains_here[ant] for ant in ants}
     apply_cal.calibrate_in_place(data, gains_here)
@@ -3242,6 +3242,10 @@ def post_redcal_abscal(model, data, data_wgts, rc_flags, edge_cut=0, tol=1.0, ke
         echo("TT_phs_logcal convergence criterion: " + str(crit), verbose=verbose)
         if crit < phs_conv_crit:
             break
+
+    # Abscal Step 5: Per-Channel Linear Absolute Amplitude Calibration
+    gains_here = abs_amp_lincal(model, data, wgts=data_wgts, verbose=verbose, return_gains=True, gain_ants=ants)
+    abscal_delta_gains = {ant: abscal_delta_gains[ant] * gains_here[ant] for ant in ants}
 
     return abscal_delta_gains
 

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -260,6 +260,8 @@ class Test_Abscal_Solvers(object):
         reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')
         model = {bl: np.ones((10, 5)) for red in reds for bl in red}
         data = {bl: 4.0 * np.ones((10, 5)) for red in reds for bl in red}
+        data[0, 1, 'ee'][0, 0] = np.nan
+        data[0, 1, 'ee'][0, 1] = np.inf
         fit = abscal.abs_amp_lincal(model, data)
         np.testing.assert_array_equal(fit['A_Jee'], 2.0)
         ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
@@ -272,6 +274,8 @@ class Test_Abscal_Solvers(object):
         model = {bl: np.ones((10, 5)) for red in reds for bl in red}
         gain_products = {'ee': 4.0, 'en': 6.0, 'ne': 6.0, 'nn': 9.0}
         data = {bl: gain_products[bl[2]] * np.ones((10, 5)) for red in reds for bl in red}
+        data[0, 1, 'ee'][0, 0] = np.nan
+        data[0, 1, 'ee'][0, 1] = np.inf
         fit = abscal.abs_amp_lincal(model, data)
         np.testing.assert_array_equal(fit['A_Jee'], 2.0)
         np.testing.assert_array_equal(fit['A_Jnn'], 3.0)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -262,6 +262,8 @@ class Test_Abscal_Solvers(object):
         data = {bl: 4.0 * np.ones((10, 5)) for red in reds for bl in red}
         data[0, 1, 'ee'][0, 0] = np.nan
         data[0, 1, 'ee'][0, 1] = np.inf
+        model[0, 1, 'ee'][0, 0] = np.nan
+        model[0, 1, 'ee'][0, 1] = np.inf
         fit = abscal.abs_amp_lincal(model, data)
         np.testing.assert_array_equal(fit['A_Jee'], 2.0)
         ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
@@ -276,6 +278,8 @@ class Test_Abscal_Solvers(object):
         data = {bl: gain_products[bl[2]] * np.ones((10, 5)) for red in reds for bl in red}
         data[0, 1, 'ee'][0, 0] = np.nan
         data[0, 1, 'ee'][0, 1] = np.inf
+        model[0, 1, 'ee'][0, 0] = np.nan
+        model[0, 1, 'ee'][0, 1] = np.inf
         fit = abscal.abs_amp_lincal(model, data)
         np.testing.assert_array_equal(fit['A_Jee'], 2.0)
         np.testing.assert_array_equal(fit['A_Jnn'], 3.0)


### PR DESCRIPTION
In #642, I explained how @nkern and I discovered a relatively small bias (though larger at low SNR) in absolute amplitude calibration in the process of performing validation for H1C IDR2. This effect arose because we were fitting for the absolute amplitude degeneracy of redundant calibration using the `abs_amp_logcal` solver that solves for amplitudes using a logarithmic linearization `ln|V_ij,xy^data / V_ij,xy^model| = eta_x + eta_y`. (Here x/y are variables standing in for pols and i/j are antenna indices.) This linearization is biased because Gaussian noise with equal variance in its real and imaginary components is always more likely to increase the amplitude of a complex number than decrease it. This effect is most pronounced at low SNR. 

This PR introduces a new solver, `abs_amp_lincal` that instead solves `V_ij,xy^data = A_x A_y * V_ij,xy^model`. When no cross-polarized visibilities are used, this is a simple linear optimization problem in `A^2`. When cross-polarized visibilities are used, this becomes non-linear, but using `abs_amp_logcal` as a starting point, one can still solve for A_x and A_y using `linsolve.LinProductSolver`.

This new function has to be run after phase calibration, since phase errors will cause decoherence that will itself lead to a bais. Here are my results with a the first 5 integrations of a single validation data file (`zen.2458098.40141.foregrounds.true.uvh5`) with manually added gains and noise (but no other systematics), following the procedure in https://github.com/HERA-Team/hera-validation/blob/master/test-series/2/test-2.0.0.ipynb :

![image](https://user-images.githubusercontent.com/5281139/94878881-8cea7f00-0413-11eb-9653-a0b44b7fc561.png)

This PR closes #642.