### PR TITLE
Allow abscal in arbitrary dimensions to account for multiple tip/tilt degeneracies

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -344,7 +344,7 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
 
     # angle of phs ratio is ydata independent variable
     # angle after divide
-    ydata = {k : np.angle(data[k] / model[k]) for k in keys}
+    ydata = {k: np.angle(data[k] / model[k]) for k in keys}
 
     # make unit weights if None
     if wgts is None:

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -418,7 +418,7 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
                 Phis = [fit[f'Phi_{d}'] for d in range((nDims, 2)[assume_2D])]
             else:
                 Phis = [fit[f'Phi_{d}_{ant[1]}'] for d in range((nDims, 2)[assume_2D])]
-            gains[ant] *= np.exp(1.0j * (np.einsum('i,ijk->jk', antpos[ant[0]], Phis)))
+            gains[ant] *= np.exp(1.0j * (np.einsum('i,ijk->jk', antpos[ant[0]][0:len(Phis)], Phis)))
         return gains
 
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -949,21 +949,22 @@ def ndim_fft_phase_slope_solver(data, bl_vecs, zero_pad=2, bl_error_tol=1.0):
     '''Find phase slopes across the array in the data. Similar to utils.fft_dly,
     but can grid arbitarary bl_vecs in N dimensions (for example, when using
     generealized antenna positions from redcal.reds_to_antpos in arrays with 
-    extra degeneracies).
+    extra degeneracies). 
     
     Parameters:
     -----------
-    data : dictionary or DataContainer mapping keys to (complex) ndarrays
-    
+    data : dictionary or DataContainer mapping keys to (complex) ndarrays.
+           All polarizations are treated equally and solved for together.
+
     bl_vecs : dictionary mapping keys in data to vectors in N dimensions
     
     zero_pad : float factor by which to expand the grid onto which the data is binned. 
                Increases resolution in Fourier space at the cost of runtime/memory.
                Must be >= 1.
-    
+
     bl_error_tol : float used to define non-zero elements of baseline vectors.
                    This helps set the fundamental resolution of the grid.
-                   
+
     Output:
     -------
     phase_slopes : list of length N dimensions. Each element is the same shape

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -945,7 +945,7 @@ def dft_phase_slope_solver(xs, ys, data, flags=None):
     return slope_x.reshape(data.shape[1:]), slope_y.reshape(data.shape[1:])
 
 
-def ndim_fft_phase_slope_solver(data, bl_vecs, zero_pad=2, bl_error_tol=1.0):
+def ndim_fft_phase_slope_solver(data, bl_vecs, assume_2D=True, zero_pad=2, bl_error_tol=1.0):
     '''Find phase slopes across the array in the data. Similar to utils.fft_dly,
     but can grid arbitarary bl_vecs in N dimensions (for example, when using
     generealized antenna positions from redcal.reds_to_antpos in arrays with 
@@ -957,6 +957,8 @@ def ndim_fft_phase_slope_solver(data, bl_vecs, zero_pad=2, bl_error_tol=1.0):
            All polarizations are treated equally and solved for together.
 
     bl_vecs : dictionary mapping keys in data to vectors in N dimensions
+
+    assume_2D : if True, assume N == 2 and only use the first two dimensions of bl_vecs.
     
     zero_pad : float factor by which to expand the grid onto which the data is binned. 
                Increases resolution in Fourier space at the cost of runtime/memory.

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -260,6 +260,16 @@ def abs_amp_lincal(model, data, wgts=None, verbose=True, return_gains=False, gai
         return {ant: np.abs(fit[f'A_{ant[1]}']).astype(np.complex) for ant in gain_ants}
 
 
+def _count_nDims(antpos, assume_2D=True):
+    '''Antenna position dimension counter helper function used in solvers that support higher-dim abscal.'''
+    nDims = len(list(antpos.values())[0])
+    for k in antpos.keys():
+        assert len(antpos[k]) == nDims, 'Not all antenna positions have the same dimensionality.'
+        if assume_2D:
+            assert len(antpos[k]) >= 2, 'Since assume_2D is True, all antenna positions must 2D or higher.'
+    return nDims
+
+
 def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True, 
                   zero_psi=True, four_pol=False, verbose=True, return_gains=False, gain_ants=[]):
     """
@@ -360,11 +370,7 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
     antpos = {k: antpos[k] - antpos[refant] for k in antpos.keys()}
     
     # count dimensions of antenna positions, figure out how many to solve for
-    nDims = len(list(antpos.values())[0])
-    for k in antpos.keys():
-        assert len(antpos[k]) == nDims, 'Not all antenna positions have the same dimensionality.'
-        if assume_2D:
-            assert len(antpos[k]) >= 2, 'Since assume_2D is True, all antenna positions must 2D or higher.'
+    nDims = _count_nDims(antpos, assume_2D=assume_2D)
 
     # setup linsolve equations
     eqns = {}

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3360,14 +3360,6 @@ def post_redcal_abscal(model, data, data_wgts, rc_flags, edge_cut=0, tol=1.0, ke
     ants = list(rc_flags.keys())
     idealized_antpos = redcal.reds_to_antpos(redcal.get_reds(data.antpos, bl_error_tol=tol), tol=redcal.IDEALIZED_BL_TOL)
 
-    # If the array is not redundant (i.e. extra degeneracies), lop off extra dimensions and warn user
-    if np.max([len(pos) for pos in idealized_antpos.values()]) > 2:
-        suspected_off_grid = [ant for ant, pos in idealized_antpos.items() if np.any(np.abs(pos[2:]) > redcal.IDEALIZED_BL_TOL)]
-        not_flagged = [ant for ant in suspected_off_grid if not np.all([np.all(f) for a, f in rc_flags.items() if ant in a])]
-        warnings.warn(('WARNING: The following antennas appear not to be redundant with the main array:\n         {}\n'
-                       '         Of them, {} is not flagged.\n').format(suspected_off_grid, not_flagged))
-        idealized_antpos = {ant: pos[:2] for ant, pos in idealized_antpos.items()}
-
     # Abscal Step 1: Per-Channel Logarithmic Absolute Amplitude Calibration
     gains_here = abs_amp_logcal(model, data, wgts=data_wgts, verbose=verbose, return_gains=True, gain_ants=ants)
     abscal_delta_gains = {ant: gains_here[ant] for ant in ants}

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -299,13 +299,13 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
            matching shape of model and data
 
     refant : antenna number integer to use as a reference,
-        The antenna position coordaintes are centered at the reference, such that its phase
-        is identically zero across all frequencies. If None, use the first key in data as refant.
+             The antenna position coordaintes are centered at the reference, such that its phase
+             is identically zero across all frequencies. If None, use the first key in data as refant.
 
     antpos : antenna position vectors, type=dictionary
-          keys are antenna integers, values are antenna positions vectors
-          (preferably centered at center of array). If assume_2D is True, it is assumed that the 
-          [0] index contains the east-west separation and [1] index the north-south separation
+             keys are antenna integers, values are antenna positions vectors
+             (preferably centered at center of array). If assume_2D is True, it is assumed that the 
+             [0] index contains the east-west separation and [1] index the north-south separation
           
     assume_2D : type=boolean, [default=False]
                 If this is true, all dimensions of antpos beyond the first two will be ignored.
@@ -315,8 +315,8 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
     zero_psi : set psi to be identically zero in linsolve eqns, type=boolean, [default=False]
 
     four_pol : type=boolean, even if multiple polarizations are present in data, make free
-                variables polarization un-aware: i.e. one solution across all polarizations.
-                This is the same assumption as 4-polarization calibration in omnical.
+               variables polarization un-aware: i.e. one solution across all polarizations.
+               This is the same assumption as 4-polarization calibration in omnical.
 
     verbose : print output, type=boolean, [default=False]
 

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -309,7 +309,7 @@ def TT_phs_logcal(model, data, antpos, wgts=None, refant=None, assume_2D=True,
           
     assume_2D : type=boolean, [default=False]
                 If this is true, all dimensions of antpos beyond the first two will be ignored.
-                If return_gains is False and assume_2D is True, then the returned variables will
+                If return_gains is False and assume_2D is False, then the returned variables will
                 look like Phi_0, Phi_1, Phi_2, etc. corresponding to the dimensions in antpos.
 
     zero_psi : set psi to be identically zero in linsolve eqns, type=boolean, [default=False]

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -911,7 +911,7 @@ def dft_phase_slope_solver(xs, ys, data, flags=None):
         flags: optional array of flags of data not to include in the phase slope solver.
 
     Returns:
-        slope_x, slope_y: phase slopes in units of 1/[xs] where the best fit phase slope plane
+        slope_x, slope_y: phase slopes in units of radians/[xs] where the best fit phase slope plane
             is np.exp(2.0j * np.pi * (xs * slope_x + ys * slope_y)). Both have the same shape
             the data after collapsing along the first dimension.
     '''
@@ -942,7 +942,7 @@ def dft_phase_slope_solver(xs, ys, data, flags=None):
                               dflat[:, i][~fflat[:, i]]), finish=minimize)
             slope_x[i] = dft_peak[0]
             slope_y[i] = dft_peak[1]
-    return slope_x.reshape(data.shape[1:]), slope_y.reshape(data.shape[1:])
+    return 2 * np.pi * slope_x.reshape(data.shape[1:]), 2 * np.pi * slope_y.reshape(data.shape[1:])
 
 
 def ndim_fft_phase_slope_solver(data, bl_vecs, assume_2D=True, zero_pad=2, bl_error_tol=1.0):

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -47,7 +47,7 @@ from . import apply_cal
 from .datacontainer import DataContainer
 from .utils import echo, polnum2str, polstr2num, reverse_bl, split_pol, split_bl, join_bl, join_pol
 
-PHASE_SLOPE_SOLVERS = ['linfit', 'dft']  # list of valid solvers for global_phase_slope_logcal
+PHASE_SLOPE_SOLVERS = ['linfit', 'dft', 'ndim_fft']  # list of valid solvers for global_phase_slope_logcal
 
 
 def abs_amp_logcal(model, data, wgts=None, verbose=True, return_gains=False, gain_ants=[]):

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -151,15 +151,19 @@ class DataContainer:
             raise ValueError('only supports setting (ant1, ant2, pol) keys')
 
     def __delitem__(self, key):
-        '''Deletes the input key and corresponding data. Only supports the form (0,1,'nn').
-        Abstracts away both baseline ordering and polarization capitalization.'''
-        if len(key) == 3:
-            key = comply_bl(key)
-            del self._data[key]
-            self._antpairs = set([k[:2] for k in self._data.keys()])
-            self._pols = set([k[-1] for k in self._data.keys()])
-        else:
-            raise ValueError('only supports setting (ant1, ant2, pol) keys')
+        '''Deletes the input key(s) and corresponding data. Only supports tuples of form (0,1,'nn')
+        or lists or ndarrays of tuples of that form. Abstracts away both baseline ordering and
+        polarization capitalization.'''
+        if isinstance(key, tuple):
+            key = [key]
+        for k in key:
+            if isinstance(k, tuple) and (len(k) == 3):
+                k = comply_bl(k)
+                del self._data[k]
+            else:
+                raise ValueError(f'Tuple keys to delete must be in the format (ant1, ant2, pol), {k} is not.')
+        self._antpairs = set([k[:2] for k in self._data.keys()])
+        self._pols = set([k[-1] for k in self._data.keys()])
 
     def concatenate(self, D, axis=0):
         '''Concatenates D, a DataContainer or a list of DCs, with self along an axis'''

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -424,6 +424,36 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
 
+    def test_delay_slope_lincal_1pol_nDim(self):
+        antpos = hex_array(2, split_core=False, outriggers=0)
+        antpos2 = hex_array(2, split_core=False, outriggers=0)
+        antpos.update({len(antpos) + ant: antpos2[ant] + np.array([100, 0, 0]) for ant in antpos2})
+        reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        antpos = redcal.reds_to_antpos(reds)
+        reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol', bl_error_tol=1e-10)
+        model = {bl: np.ones((2, 1024), dtype=complex) for red in reds for bl in red}
+        data = {bl: np.ones((2, 1024), dtype=complex) for red in reds for bl in red}
+        freqs = np.linspace(100e6, 200e6, 1024)
+        df = np.median(np.diff(freqs))
+
+        ants = sorted(list(set([ant for bl in data for ant in utils.split_bl(bl)])))
+        true_dlys = {ant: np.dot([1e-9, 2e-9, 3e-9], antpos[ant[0]]) for ant in ants}
+        true_gains = {ant: np.outer(np.ones(2), np.exp(2.0j * np.pi * true_dlys[ant] * (freqs))) for ant in ants}
+
+        for bl in data:
+            ant0, ant1 = utils.split_bl(bl)
+            data[bl] *= true_gains[ant0] * np.conj(true_gains[ant1])
+
+        fit = abscal.delay_slope_lincal(model, data, antpos, df=df, assume_2D=False)
+        np.testing.assert_array_almost_equal(1e9 * fit['T_0_Jee'], 1.0, decimal=3)
+        np.testing.assert_array_almost_equal(1e9 * fit['T_1_Jee'], 2.0, decimal=3)
+        np.testing.assert_array_almost_equal(1e9 * fit['T_2_Jee'], 3.0, decimal=3)
+
+        gains = abscal.delay_slope_lincal(model, data, antpos, df=df, f0=freqs[0], assume_2D=False, return_gains=True, gain_ants=ants)
+        rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
+        rephased_true_gains = {ant: true_gains[ant] / true_gains[ants[0]] * np.abs(true_gains[ants[0]]) for ant in ants}
+        for ant in ants:
+            np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -312,6 +312,14 @@ class Test_Abscal_Solvers(object):
         np.testing.assert_array_almost_equal(fit['Phi_ew_Jee'], .01)
         np.testing.assert_array_almost_equal(fit['Phi_ns_Jee'], .02)
 
+        ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
+        gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, return_gains=True, gain_ants=ants)
+        rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
+        true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
+        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        for ant in ants:
+            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
+
         # test 4 pol, assume_2D
         reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
         model = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
@@ -326,6 +334,14 @@ class Test_Abscal_Solvers(object):
         fit = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, four_pol=True)
         np.testing.assert_array_almost_equal(fit['Phi_ew'], .01)
         np.testing.assert_array_almost_equal(fit['Phi_ns'], .02)
+
+        ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
+        gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, four_pol=True, return_gains=True, gain_ants=ants)
+        rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
+        true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
+        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        for ant in ants:
+            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
 
         # test assume_2D=False by introducing another 6 element hex 100 m away
         antpos2 = hex_array(2, split_core=False, outriggers=0)
@@ -347,6 +363,14 @@ class Test_Abscal_Solvers(object):
         np.testing.assert_array_almost_equal(fit['Phi_0_Jee'], .01)
         np.testing.assert_array_almost_equal(fit['Phi_1_Jee'], .02)
         np.testing.assert_array_almost_equal(fit['Phi_2_Jee'], .03)
+
+        ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
+        gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=False, return_gains=True, gain_ants=ants)
+        rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
+        true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
+        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        for ant in ants:
+            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
 
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -316,7 +316,7 @@ class Test_Abscal_Solvers(object):
         gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, return_gains=True, gain_ants=ants)
         rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
         true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
-        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        rephased_true_gains = {ant: true_gains[ant] / true_gains[ants[0]] * np.abs(true_gains[ants[0]]) for ant in ants}
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
@@ -339,7 +339,7 @@ class Test_Abscal_Solvers(object):
         gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, four_pol=True, return_gains=True, gain_ants=ants)
         rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
         true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
-        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        rephased_true_gains = {ant: true_gains[ant] / true_gains[ants[0]] * np.abs(true_gains[ants[0]]) for ant in ants}
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
@@ -367,8 +367,8 @@ class Test_Abscal_Solvers(object):
         ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
         gains = abscal.TT_phs_logcal(model, data, antpos, assume_2D=False, return_gains=True, gain_ants=ants)
         rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
-        true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
-        rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
+        true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, .03])) for ant in ants}
+        rephased_true_gains = {ant: true_gains[ant] / true_gains[ants[0]] * np.abs(true_gains[ants[0]]) for ant in ants}
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -398,6 +398,32 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
 
+    def test_delay_slope_lincal_4pol_assume_2D(self):
+        antpos = hex_array(2, split_core=False, outriggers=0)
+        reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
+        model = {bl: np.ones((2, 1024), dtype=complex) for red in reds for bl in red}
+        data = {bl: np.ones((2, 1024), dtype=complex) for red in reds for bl in red}
+        freqs = np.linspace(100e6, 200e6, 1024)
+        df = np.median(np.diff(freqs))
+
+        ants = sorted(list(set([ant for bl in data for ant in utils.split_bl(bl)])))
+        true_dlys = {ant: np.dot([1e-9, 2e-9, 0], antpos[ant[0]]) for ant in ants}
+        true_gains = {ant: np.outer(np.ones(2), np.exp(2.0j * np.pi * true_dlys[ant] * (freqs))) for ant in ants}
+
+        for bl in data:
+            ant0, ant1 = utils.split_bl(bl)
+            data[bl] *= true_gains[ant0] * np.conj(true_gains[ant1])
+
+        fit = abscal.delay_slope_lincal(model, data, antpos, df=df, assume_2D=True, four_pol=True)
+        np.testing.assert_array_almost_equal(1e9 * fit['T_ew'], 1.0, decimal=3)
+        np.testing.assert_array_almost_equal(1e9 * fit['T_ns'], 2.0, decimal=3)
+
+        gains = abscal.delay_slope_lincal(model, data, antpos, df=df, f0=freqs[0], assume_2D=True, four_pol=True, return_gains=True, gain_ants=ants)
+        rephased_gains = {ant: gains[ant] / gains[ants[0]] * np.abs(gains[ants[0]]) for ant in ants}
+        rephased_true_gains = {ant: true_gains[ant] / true_gains[ants[0]] * np.abs(true_gains[ants[0]]) for ant in ants}
+        for ant in ants:
+            np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
+
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -455,6 +455,7 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
 
+
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -470,7 +470,6 @@ class Test_Abscal_Solvers(object):
             assert ps.shape == (2, 3)
             np.testing.assert_array_less(np.abs(ps - answer), .1)
 
-
     def test_ndim_fft_phase_slope_solver_2D_ideal_antpos(self):
         antpos = hex_array(6, split_core=False, outriggers=0)
         reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')
@@ -517,8 +516,6 @@ class Test_Abscal_Solvers(object):
         for ps, answer in zip(phase_slopes, [-.02, .03]):
             assert ps.shape == (2, 3)
             np.testing.assert_array_less(np.abs(ps - answer), .003)
-
-
 
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -312,6 +312,21 @@ class Test_Abscal_Solvers(object):
         np.testing.assert_array_almost_equal(fit['Phi_ew_Jee'], .01)
         np.testing.assert_array_almost_equal(fit['Phi_ns_Jee'], .02)
 
+        # test 4 pol, assume_2D
+        reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
+        model = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
+        data = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
+        bl_vecs = {bl: antpos[bl[0]] - antpos[bl[1]] for bl in data}
+        for bl in data:
+            data[bl] *= np.exp(1.0j * np.dot(bl_vecs[bl], [.01, .02, 0]))
+        data[0, 1, 'ee'][0, 0] = np.nan
+        data[0, 1, 'ee'][0, 1] = np.inf
+        model[0, 1, 'ee'][0, 0] = np.nan
+        model[0, 1, 'ee'][0, 1] = np.inf
+        fit = abscal.TT_phs_logcal(model, data, antpos, assume_2D=True, four_pol=True)
+        np.testing.assert_array_almost_equal(fit['Phi_ew'], .01)
+        np.testing.assert_array_almost_equal(fit['Phi_ns'], .02)
+
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -455,6 +455,22 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant], decimal=3)
 
+    def test_ndim_fft_phase_slope_solver_1D(self):
+        pass
+
+
+    def test_ndim_fft_phase_slope_solver_2D(self):
+        pass
+
+    def test_ndim_fft_phase_slope_solver_3D(self):
+        antpos = hex_array(4, split_core=False, outriggers=0)
+        antpos2 = hex_array(4, split_core=False, outriggers=0)
+        antpos.update({len(antpos) + ant: antpos2[ant] + np.array([100.0, 0, 0]) for ant in antpos2})
+        antpos.update({len(antpos) + ant: antpos2[ant] + np.array([200.0, 0, 0]) for ant in antpos2})
+        antpos.update({len(antpos) + ant: antpos2[ant] + np.array([300.0, 0, 0]) for ant in antpos2})
+
+
+
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -244,8 +244,8 @@ class Test_AbsCal_Funcs(object):
 
         phase_slopes_x = (.2 * np.random.rand(5, 2) - .1)  # not too many phase wraps over the array
         phase_slopes_y = (.2 * np.random.rand(5, 2) - .1)  # (i.e. avoid undersampling of very fast slopes)
-        data = np.array([np.exp(2.0j * np.pi * x * phase_slopes_x
-                                + 2.0j * np.pi * y * phase_slopes_y) for x, y in zip(xs, ys)])
+        data = np.array([np.exp(1.0j * x * phase_slopes_x
+                                + 1.0j * y * phase_slopes_y) for x, y in zip(xs, ys)])
 
         x_slope_est, y_slope_est = abscal.dft_phase_slope_solver(xs, ys, data)
         np.testing.assert_array_almost_equal(phase_slopes_x - x_slope_est, 0, decimal=7)

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -318,7 +318,7 @@ class Test_Abscal_Solvers(object):
         true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
         rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
         for ant in ants:
-            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
+            np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
         # test 4 pol, assume_2D
         reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
@@ -341,7 +341,7 @@ class Test_Abscal_Solvers(object):
         true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
         rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
         for ant in ants:
-            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
+            np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
         # test assume_2D=False by introducing another 6 element hex 100 m away
         antpos2 = hex_array(2, split_core=False, outriggers=0)
@@ -370,7 +370,7 @@ class Test_Abscal_Solvers(object):
         true_gains = {ant: np.exp(1.0j * np.dot(antpos[ant[0]], [.01, .02, 0])) for ant in ants}
         rephased_true_gains = {ant: rephased_gains[ant] / rephased_gains[ants[0]] * np.abs(rephased_gains[ants[0]]) for ant in ants}
         for ant in ants:
-            np.testing.assert_array_equal(rephased_gains[ant], rephased_true_gains[ant])
+            np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -256,10 +256,8 @@ class Test_AbsCal_Funcs(object):
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered in log")
 class Test_Abscal_Solvers(object):
-    def test_abs_amp_lincal(self):
+    def test_abs_amp_lincal_1pol(self):
         antpos = hex_array(2, split_core=False, outriggers=0)
-        
-        # test 1 pol
         reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')
         model = {bl: np.ones((10, 5)) for red in reds for bl in red}
         data = {bl: 4.0 * np.ones((10, 5)) for red in reds for bl in red}
@@ -274,7 +272,8 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_equal(gains[ant], 2.0) 
 
-        # test 4 pol
+    def test_abs_amp_lincal_4pol(self):
+        antpos = hex_array(2, split_core=False, outriggers=0)
         reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
         model = {bl: np.ones((10, 5)) for red in reds for bl in red}
         gain_products = {'ee': 4.0, 'en': 6.0, 'ne': 6.0, 'nn': 9.0}
@@ -294,10 +293,8 @@ class Test_Abscal_Solvers(object):
             elif ant[1] == 'Jnn':
                 np.testing.assert_array_equal(gains[ant], 3.0)
 
-    def test_TT_phs_logcal(self):
+    def test_TT_phs_logcal_1pol_assume_2D(self):
         antpos = hex_array(2, split_core=False, outriggers=0)
-        
-        # test 1 pol, assume_2D
         reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')
         model = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
         data = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
@@ -320,7 +317,8 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
-        # test 4 pol, assume_2D
+    def test_TT_phs_logcal_4pol_assume_2D(self):
+        antpos = hex_array(2, split_core=False, outriggers=0)
         reds = redcal.get_reds(antpos, pols=['ee', 'en', 'ne', 'nn'], pol_mode='4pol')
         model = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
         data = {bl: np.ones((10, 5), dtype=complex) for red in reds for bl in red}
@@ -343,7 +341,9 @@ class Test_Abscal_Solvers(object):
         for ant in ants:
             np.testing.assert_array_almost_equal(rephased_gains[ant], rephased_true_gains[ant])
 
+    def test_TT_phs_logcal_1pol_nDim(self):
         # test assume_2D=False by introducing another 6 element hex 100 m away
+        antpos = hex_array(2, split_core=False, outriggers=0)
         antpos2 = hex_array(2, split_core=False, outriggers=0)
         antpos.update({len(antpos) + ant: antpos2[ant] + np.array([100, 0, 0]) for ant in antpos2})
         reds = redcal.get_reds(antpos, pols=['ee'], pol_mode='1pol')

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -160,6 +160,14 @@ class TestDataContainer(object):
         assert 'xx' in dc.pols()
         assert (2, 3) in dc.antpairs()
 
+        dc = datacontainer.DataContainer(self.blpol)
+        del dc[[(1, 2, 'xx'), (1, 2, 'yy')]]
+        assert (1, 2, 'xx') not in dc
+        assert (1, 2, 'yy') not in dc
+        assert (1, 2) not in dc.antpairs()
+        assert 'xx' in dc.pols()
+        assert 'yy' in dc.pols()
+
     def test_getitem(self):
         dc = datacontainer.DataContainer(self.blpol)
         assert dc[(1, 2, 'xx')] == 1j

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1280,9 +1280,8 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     # select out averaged bls
     bls = [blg[0] + (pol,) for pol in pols for blg in reds]
     if fed_container:
-        for bl in list(data.keys()):
-            if bl not in bls:
-                del data[bl], flags[bl], nsamples[bl]
+        to_del = [bl for bl in data.keys() if bl not in bls]
+        del data[to_del], flags[to_del], nsamples[to_del]
     else:
         data.select(bls=bls)
 


### PR DESCRIPTION
This PR generalizes the post-redcal phase solvers, namely `TT_phs_logcal`, `delay_slope_lincal`, and `global_phase_slope_logcal` to take antenna positions in more than 2 dimensions and thus to solve for phase/delay slopes in more than 2 dimensions. This is useful for arrays with extra degeneracies, since converting antenna positions to "idealized/generalized positions" with `redcal.reds_to_antpos` will make positions with higher numbers of dimensions if there are extra redcal degeneracies. 

The new solvers default to 2D and thus return keys that look like `Phi_ew_Jee`, but by turning off `assume_2D` they return keys like `Phi_0_Jee`, etc. 

The most challenging part of this was generalizing `dft_phase_slope_solver` to N-dimensions. (See #453 for background.) That relied on a brute force whose complexity scaled to the power of the number of dimensions in the search. 2 was OK, but 3 was already pretty unbearably slow and we want to be able to do 4 as well if necessary. So I decided to write an entirely new version of this function that uses gridded FFTs rather than DFTs. The basic idea is that you grid the complex visibility (ratios) by baseline vector, FFT, and look for a peak which should correspond to a phase slope. I just use the peak voxel rather than some sort of fancy quadratic/Quinn's method, since I didn't want to bother generalizing those to N dimensions (I tried doing Quinn's along each dimension individually, but it didn't improve the accuracy appreciably). Anyway, since this solver is just to get out the phase wraps so `TT_phs_logcal` can do its job, I think we're OK without more accuracy. 

Additionally, I found a bottleneck in some of my unit testing of global_phase_slope_logcal which I traced back to repeated re-counting of baselines in data containers caused by `utils.red_average`. I've implemented a fast multi-item `del` in DataContainer to fix this. Perhaps you can think of other places in hera_cal where this would be useful, @nick?

This PR closes #592.