### PR TITLE
Rephase abscal gains to smooth_cal reference antenna before computing relative difference

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -714,6 +714,8 @@ class CalibrationSmoother():
         for cal in self.cals:
             hc = io.HERACal(cal)
             gains, flags, _, _ = hc.read()
+            if hasattr(self, 'refant'):
+                rephase_to_refant(gains, self.refant)
             out_gains = {ant: self.gain_grids[ant][self.time_indices[cal], :] for ant in self.ants}
             out_flags = {ant: self.flag_grids[ant][self.time_indices[cal], :] for ant in self.ants}
             rel_diff, avg_rel_diff = utils.gain_relative_difference(gains, out_gains, out_flags)


### PR DESCRIPTION
Right now, the quals and total_quals field in smooth_cal calfits files contain the relative difference between abscal and smooth_cal using this function:

https://github.com/HERA-Team/hera_cal/blob/0257659aed6950a20808d1c8018f44c807d330e0/hera_cal/utils.py#L1094

This hasn't really been looked at before, but in the process of making a notebook to assess smooth_cal for H4C, I noticed that all the relative differences were very high. I tracked this down to the fact that there was no guarantee that the two sets of gains had the same reference antenna, which made subtracting the two more or less nonsense.

This PR fixes that.