### PR TITLE
Flag NaNs in abscal solutions

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3428,6 +3428,9 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
                                 abscal_gains[ant][tinds, :] = rc_gains_subset[ant] * delta_gains[ant]
                                 # new flags are the OR of redcal flags and times/freqs totally flagged in the model
                                 abscal_flags[ant][tinds, :] = rc_flags_subset[ant] + model_flag_waterfall
+                                # flag any nans, infs, etc.
+                                abscal_flags[ant][~np.isfinite(abscal_gains[ant])] = True
+                                abscal_gains[ant][~np.isfinite(abscal_gains[ant])] = 1.0 + 0.0j
                             for antpol in total_qual.keys():
                                 abscal_chisq[antpol][tinds, :] = total_qual[antpol] / nObs[antpol]  # Note, not normalized for DoF
                                 abscal_chisq[antpol][tinds, :][~np.isfinite(abscal_chisq[antpol][tinds, :])] = 0.


### PR DESCRIPTION
With the recent abscal updates in #647, it seems that I've introduced the ability for abscal to insert NaNs in the the gain solutions. This happened with a single frequency, time, and polarization (but all ants) when running 2459122, which then caused smooth_cal to choke, spinning its wheels endlessly. I have verified that this fix makes smooth_cal converge in a reasonable amount of time.