### PR TITLE
Enable select on read for HERACal

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -134,12 +134,11 @@ class HERACal(UVCal):
             # load data
             self.read_calfits(self.filepaths[0])
 
-
             if pols is not None:
                 pols = [jstr2num(ap, x_orientation=self.x_orientation) for ap in pols]
 
             select_dict = {'antenna_nums': antenna_nums, 'frequencies': frequencies, 
-                           'freq_chans':freq_chans, 'jones': pols}
+                           'freq_chans': freq_chans, 'jones': pols}
             if np.any([s is not None for s in select_dict.values()]):
                 self.select(inplace=True, **select_dict)
             

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -76,15 +76,15 @@ class Test_HERACal(object):
         hc = io.HERACal([self.fname_t0, self.fname_t1, self.fname_t2])
         g, _, _, _ = hc.read()
         g2, _, _, _ = hc.read(times=hc.times[30:90])
-        np.testing.assert_array_equal(g2[54,'Jee'], g[54,'Jee'][30:90, :])
+        np.testing.assert_array_equal(g2[54, 'Jee'], g[54, 'Jee'][30:90, :])
 
         # test read multiple files and select freqs/chans
         hc = io.HERACal([self.fname_t0, self.fname_t1, self.fname_t2])
         g, _, _, _ = hc.read()
         g2, _, _, _ = hc.read(frequencies=hc.freqs[0:100])
         g3, _, _, _ = hc.read(freq_chans=np.arange(100))
-        np.testing.assert_array_equal(g2[54,'Jee'], g[54,'Jee'][:, 0:100])
-        np.testing.assert_array_equal(g3[54,'Jee'], g[54,'Jee'][:, 0:100])
+        np.testing.assert_array_equal(g2[54, 'Jee'], g[54, 'Jee'][:, 0:100])
+        np.testing.assert_array_equal(g3[54, 'Jee'], g[54, 'Jee'][:, 0:100])
 
         # test select on antenna numbers
         hc = io.HERACal([self.fname_xx, self.fname_yy])


### PR DESCRIPTION
This is essentially the same as UVCal.read_calfits() and then UVCal.select() when loading a single file, but it saves memory if you want to load a list of calibration files, downselecting them as you go.

This came up as a useful feature in a review of #629, specifically this comment: https://github.com/HERA-Team/hera_cal/pull/629#discussion_r529113146