### PR TITLE
Pass through new uvcal params

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -398,5 +398,6 @@ def apply_cal_argparser():
     a.add_argument("--redundant_solution", default=False, action="store_true",
                    help="If True, average gain ratios in redundant groups to recalibrate e.g. redcal solutions.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
+    a.add_argument("--vis_units", default=None, type=str, help="String to insert into vis_units attribute of output visibility file.")
     a.add_argument("--redundant_average", default=False, action="store_true", help="Redundantly average calibrated data.")
     return a

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1692,12 +1692,18 @@ def write_cal(fname, gains, freqs, times, flags=None, quality=None, total_qual=N
     # enforce 'gain' cal_type
     uvc.cal_type = "gain"
 
+    # optional calfits parameters to get overwritten via kwargs
+    telescope_location = None 
+    antenna_positions = None
+    lst_array = None
+
     # create parameter list
     params = ["Nants_data", "Nants_telescope", "Nfreqs", "Ntimes", "Nspws", "Njones",
               "ant_array", "antenna_numbers", "antenna_names", "cal_style", "history",
               "channel_width", "flag_array", "gain_array", "quality_array", "jones_array",
               "time_array", "spw_array", "freq_array", "history", "integration_time",
-              "time_range", "x_orientation", "telescope_name", "gain_convention", "total_quality_array"]
+              "time_range", "x_orientation", "telescope_name", "gain_convention", "total_quality_array",
+              "telescope_location", "antenna_positions", "lst_array"]
 
     # create local parameter dict
     local_params = locals()

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1736,20 +1736,27 @@ def _redcal_run_write_results(cal, hd, fistcal_filename, omnical_filename, omniv
     '''Helper function for writing the results of redcal_run.'''
     # get antnums2antnames dictionary
     antnums2antnames = dict(zip(hd.antenna_numbers, hd.antenna_names))
+    
+    # Build UVCal metadata that might be different from UVData metadata
+    cal_antnums = sorted(set([ant[0] for ant in cal['g_omnical']]))
+    antenna_positions = np.array([hd.antenna_positions[hd.antenna_numbers == antnum].flatten() for antnum in cal_antnums])
+    lst_array = np.unique(hd.lsts)
 
     if verbose:
         print('\nNow saving firstcal gains to', os.path.join(outdir, fistcal_filename))
     write_cal(fistcal_filename, cal['g_firstcal'], hd.freqs, hd.times,
               flags=cal['gf_firstcal'], outdir=outdir, overwrite=clobber,
-              x_orientation=hd.x_orientation, history=version.history_string(add_to_history),
-              antnums2antnames=antnums2antnames)
+              x_orientation=hd.x_orientation, telescope_location=hd.telescope_location,
+              antenna_positions=antenna_positions, lst_array=lst_array,
+              history=version.history_string(add_to_history), antnums2antnames=antnums2antnames)
 
     if verbose:
         print('Now saving omnical gains to', os.path.join(outdir, omnical_filename))
     write_cal(omnical_filename, cal['g_omnical'], hd.freqs, hd.times, flags=cal['gf_omnical'],
               quality=cal['chisq_per_ant'], total_qual=cal['chisq'], outdir=outdir, overwrite=clobber,
-              x_orientation=hd.x_orientation, history=version.history_string(add_to_history),
-              antnums2antnames=antnums2antnames)
+              x_orientation=hd.x_orientation, telescope_location=hd.telescope_location,
+              antenna_positions=antenna_positions, lst_array=lst_array,
+              history=version.history_string(add_to_history), antnums2antnames=antnums2antnames)
 
     if verbose:
         print('Now saving omnical visibilities to', os.path.join(outdir, omnivis_filename))

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1517,6 +1517,10 @@ class TestRunMethods(object):
             # bad_ants is based on experiments with this particular file
             hc = io.HERACal(os.path.splitext(input_data)[0] + prefix + '.first.calfits')
             gains, flags, quals, total_qual = hc.read()
+            np.testing.assert_almost_equal(np.unique(hc.lst_array), np.unique(hd.lst_array))
+            np.testing.assert_almost_equal(hc.telescope_location, hd.telescope_location)
+            for antnum, antpos in zip(hc.antenna_numbers, hc.antenna_positions):
+                np.testing.assert_almost_equal(antpos, hd.antenna_positions[hd.antenna_numbers == antnum].flatten())
             for ant in gains.keys():
                 np.testing.assert_almost_equal(gains[ant], cal_here['g_firstcal'][ant])
                 np.testing.assert_almost_equal(flags[ant], cal_here['gf_firstcal'][ant])
@@ -1532,6 +1536,10 @@ class TestRunMethods(object):
 
             hc = io.HERACal(os.path.splitext(input_data)[0] + prefix + '.omni.calfits')
             gains, flags, quals, total_qual = hc.read()
+            np.testing.assert_almost_equal(np.unique(hc.lst_array), np.unique(hd.lst_array))
+            np.testing.assert_almost_equal(hc.telescope_location, hd.telescope_location)
+            for antnum, antpos in zip(hc.antenna_numbers, hc.antenna_positions):
+                np.testing.assert_almost_equal(antpos, hd.antenna_positions[hd.antenna_numbers == antnum].flatten())
             for ant in gains.keys():
                 zero_check = np.isclose(cal_here['g_omnical'][ant], 0, rtol=1e-10, atol=1e-10)
                 np.testing.assert_array_almost_equal(gains[ant][~zero_check], cal_here['g_omnical'][ant][~zero_check])

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -19,7 +19,7 @@ if args.vis_units is not None:
 
 if args.nbl_per_load == "none":
     args.nbl_per_load = None
-else:
+if args.nbl_per_load is not None:
     args.nbl_per_load = int(args.nbl_per_load)
 
 ac.apply_cal(args.infilename, args.outfilename, args.new_cal, old_calibration=args.old_cal, flag_file=args.flag_file,


### PR DESCRIPTION
This PR handles the new UVCal parameters, `telescope_location`, `antenna_positions` and `lst_array`, https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md in the creation of calfits files in redcal.