### PR TITLE
add support for multiple redundant groups 

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -468,13 +468,14 @@ def apply_cal_argparser():
     a.add_argument("--filetype_in", type=str, default='uvh5', help='filetype of input data files')
     a.add_argument("--filetype_out", type=str, default='uvh5', help='filetype of output data files')
     a.add_argument("--nbl_per_load", type=int, default=None, help="Maximum number of baselines to load at once. uvh5 to uvh5 only."
-                                                                  "Default loads the whole file. If 0 is provided, also loads whole file.")
+                                                                  "Default loads the whole file. If 'none' is provided, also loads whole file.")
     a.add_argument("--redundant_groups", type=int, default=1, help="Number of subgroups to split each redundant baseline into for cross power spectra. ")
     a.add_argument("--gain_convention", type=str, default='divide',
                    help="'divide' means V_obs = gi gj* V_true, 'multiply' means V_true = gi gj* V_obs.")
     a.add_argument("--redundant_solution", default=False, action="store_true",
                    help="If True, average gain ratios in redundant groups to recalibrate e.g. redcal solutions.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
+    a.add_argument("--vis_units", default=None, type=str, help="String to insert into vis_units attribute of output visibility file.")
     a.add_argument("--redundant_average", default=False, action="store_true", help="Redundantly average calibrated data.")
     a.add_argument("--dont_red_average_flagged_data", default=False, action="store_true", help="Do not include flagged data in redundant averages. Prevents redundant groups where one subgroup is flagged.")
     a.add_argument("--spw_range", default=None, type=int, nargs=2, help="specify spw range to load.")

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -357,9 +357,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         if np.all(data_flags[bl]):
                             redundant_weights[bl][:] = 0.
                 # redundantly average
-                utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
-                                  reds=all_red_antpairs, wgts=redundant_weights, inplace=True,
-                                  propagate_flags=True)
+                data, data_flags, data_nsamples = utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
+                                                                    reds=all_red_antpairs, wgts=redundant_weights, inplace=False,
+                                                                    propagate_flags=True)
                 # update redundant data. Don't partial write.
                 hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -192,7 +192,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         data_infilename: filename of the data to be calibrated.
         data_outfilename: filename of the resultant data file with the new calibration and flags.
         new_calibration: filename of the calfits file (or a list of filenames) for the calibration
-        old_calibration: filename of the calfits file (or a list of filenames) for the calibration	        old_calibration: filename of the calfits file for the calibration
+            to be applied, along with its new flags (if any).
+        old_calibration: filename of the calfits file (or a list of filenames) for the calibration
             to be unapplied. Default None means that the input data is raw (i.e. uncalibrated).
         flag_file: optional path to file containing flags to be ORed with flags in input data. Must have
             the same shape as the data.

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -264,14 +264,14 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 freqs_to_load.append(f)
         if spw_range is not None:
             freqs_to_load = freqs_to_load[spw_range[0]:spw_range[1]]
-        old_hc.select(frequencies=np.asarray(freqs_to_load)) # match up frequencies with hc.freqs
+        old_hc.select(frequencies=np.asarray(freqs_to_load))  # match up frequencies with hc.freqs
         old_gains, old_flags, _, _ = old_hc.build_calcontainers()
         add_to_history += '\nOLD_CALFITS_HISTORY: ' + old_hc.history + '\n'
     else:
         old_gains, old_flags = None, None
     hd = io.HERAData(data_infilename, filetype=filetype_in)
     if spw_range is None:
-        spw_range=(0, hd.Nfreqs)
+        spw_range = (0, hd.Nfreqs)
     else:
         if filetype_in != 'uvh5':
             raise NotImplementedError("spw only implemented for uvh5 files.")
@@ -418,7 +418,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     # trim group to only include baselines with redundant weights not equal to zero.
                     grp0 = grp[0]
                     if dont_red_average_flagged_data:
-                        grp = [ap for ap in grp if np.any(np.abs([data_flags[ap + (pol,)] * redundant_weights[ap + (pol,)] for pol in hd.pols])>=0.)]
+                        grp = [ap for ap in grp if np.any(np.abs([data_flags[ap + (pol,)] * redundant_weights[ap + (pol,)] for pol in hd.pols]) >= 0.)]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
                         start = int(np.ceil(len(grp) / redundant_groups)) * red_chunk
@@ -445,7 +445,6 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         raise NotImplementedError("redundant averaging only supported for uvh5 outputs.")
                 else:
                     warnings.warn("No unflagged data so no calibration or outputs produced..")
-
 
 
 def apply_cal_argparser():

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -178,6 +178,7 @@ def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gai
                 else:
                     data_flags[(i, j, pol)] = np.ones_like(data[(i, j, pol)], dtype=np.bool)
 
+
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flag_file=None,
               flag_filetype='h5', a_priori_flags_yaml=None, flag_nchan_low=0, flag_nchan_high=0, filetype_in='uvh5', filetype_out='uvh5',
               nbl_per_load=None, gain_convention='divide', redundant_solution=False, bl_error_tol=1.0,
@@ -480,7 +481,7 @@ def apply_cal_argparser():
     a.add_argument("--flag_nchan_high", type=int, default=0, help="integer number of channels at the high frequency end of the band to always flag (default 0)")
     a.add_argument("--filetype_in", type=str, default='uvh5', help='filetype of input data files')
     a.add_argument("--filetype_out", type=str, default='uvh5', help='filetype of output data files')
-    a.add_argument("--nbl_per_load", type=int, default=None, help="Maximum number of baselines to load at once. uvh5 to uvh5 only."
+    a.add_argument("--nbl_per_load", type=str, default=None, help="Maximum number of baselines to load at once. uvh5 to uvh5 only."
                                                                   "Default loads the whole file. If 'none' is provided, also loads whole file.")
     a.add_argument("--redundant_groups", type=int, default=1, help="Number of subgroups to split each redundant baseline into for cross power spectra. ")
     a.add_argument("--gain_convention", type=str, default='divide',

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -423,8 +423,11 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         grp = [ap for ap in grp if np.any(np.asarray([~data_flags[ap + (pol,)] for pol in data_flags.pols()]))]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
-                        start = int(np.ceil(len(grp) / redundant_groups)) * red_chunk
-                        end = int(np.min([np.ceil(len(grp) / redundant_groups) * (red_chunk + 1), len(grp)]))
+                        start = len(grp) // redundant_groups * red_chunk
+                        if red_chunk < redundant_groups - 1:
+                            end = len(grp) // redundant_groups * (red_chunk + 1)
+                        else:
+                            end = len(grp)
                         red_antpairs.append(grp[start:end])
                         reds_data_bls.append(grp0)
                 data_red, flags_red, nsamples_red = utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -181,18 +181,17 @@ def calibrate_in_place(data, new_gains, data_flags=None, cal_flags=None, old_gai
 
 def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibration=None, flag_file=None,
               flag_filetype='h5', a_priori_flags_yaml=None, flag_nchan_low=0, flag_nchan_high=0, filetype_in='uvh5', filetype_out='uvh5',
-              nbl_per_load=None, gain_convention='divide', redundant_solution=False, bl_error_tol=1.0, overwrite_data_flags=False,
+              nbl_per_load=None, gain_convention='divide', redundant_solution=False, bl_error_tol=1.0,
               add_to_history='', clobber=False, redundant_average=False, redundant_weights=None,
-              redundant_groups=1, dont_red_average_flagged_data=False, spw_range=None, **kwargs):
+              freq_atol=1., redundant_groups=1, dont_red_average_flagged_data=False, spw_range=None, **kwargs):
     '''Update the calibration solution and flags on the data, writing to a new file. Takes out old calibration
     and puts in new calibration solution, including its flags. Also enables appending to history.
 
     Arguments:
         data_infilename: filename of the data to be calibrated.
         data_outfilename: filename of the resultant data file with the new calibration and flags.
-        new_calibration: filename of the calfits file for the calibration
-            to be applied, along with its new flags (if any).
-        old_calibration: filename of the calfits file for the calibration
+        new_calibration: filename of the calfits file (or a list of filenames) for the calibration
+        old_calibration: filename of the calfits file (or a list of filenames) for the calibration	        old_calibration: filename of the calfits file for the calibration
             to be unapplied. Default None means that the input data is raw (i.e. uncalibrated).
         flag_file: optional path to file containing flags to be ORed with flags in input data. Must have
             the same shape as the data.
@@ -209,6 +208,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         filetype_out: type of data outfile. Supports 'miriad', 'uvfits', and 'uvh5'.
         nbl_per_load: maximum number of baselines to load at once. Default (None) is to load the whole file at once.
             Enables partial reading and writing, but only for uvh5 to uvh5.
+            nbl_per_load is only supported if filetype_in is .uvh5.
         gain_convention: str, either 'divide' or 'multiply'. 'divide' means V_obs = gi gj* V_true,
             'multiply' means V_true = gi gj* V_obs. Assumed to be the same for new_gains and old_gains.
         redundant_solution: If True, average gain ratios in redundant groups to recalibrate e.g. redcal solutions.
@@ -225,13 +225,19 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             Datacontainer containing weights to use in redundant averaging.
             only used if redundant_average is True.
             Default is None. If None is passed, then nsamples are used as the redundant weights.
+        tol_factor: float, optional
+            Float specifying the tolerance (as a fraction of channel width) within which cal frequencies must be matched in calibration solution to apply.
         redundant_groups : int, optional.
             Integer specifying how many different subsets of each redundant group to write to an independent file.
+            If more then one redundant subgroup is specified, then output files will have label .uvh5 -> .n.uvh5
+            redundant_groups>1 not supported with partial I/O yet.
         dont_red_average_flagged_data : bool, optional.
             If True, baselines within a redundant group with all pols flagged do not count towards the number of baselines
             in that group above the number of groups to output. This lets us throw away groups that in principal have greater
             then the minimum number of baselines to allow for a split into different output groups but could result in one of
-            the subgroups being entirely flagged.
+            the subgroups being entirely flagged. This option is only used when redundant_groups > 1.
+            Not supported for partial I/O.
+        spw_range : 2-tuple specifying range of channels to select and redundantly average.
         kwargs: dictionary mapping updated UVData attributes to their new values.
             See pyuvdata.UVData documentation for more info.
     '''
@@ -260,7 +266,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         # determine frequencies to load in old_hc that are close to hc
         freqs_to_load = []
         for f in old_hc.freqs:
-            if np.any(np.isclose(hc.freqs, f)):
+            # set atol to be 1/10th of a channel
+            if np.any(np.isclose(hc.freqs, f, rtol=0., atol=freq_atol)):
                 freqs_to_load.append(f)
         if spw_range is not None:
             freqs_to_load = freqs_to_load[spw_range[0]:spw_range[1]]
@@ -278,7 +285,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     if filetype_in == 'uvh5':
         freqs_to_load = []
         for f in hd.freqs[spw_range[0]:spw_range[1]]:
-            if np.any(np.isclose(hc.freqs, f)):
+            if np.any(np.isclose(hc.freqs, f, rtol=0., atol=freq_atol)):
                 freqs_to_load.append(f)
     else:
         freqs_to_load = None
@@ -357,9 +364,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         if np.all(data_flags[bl]):
                             redundant_weights[bl][:] = 0.
                 # redundantly average
-                data, data_flags, data_nsamples = utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
-                                                                    reds=all_red_antpairs, wgts=redundant_weights, inplace=False,
-                                                                    propagate_flags=True)
+                utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
+                                  reds=all_red_antpairs, wgts=redundant_weights, inplace=True,
+                                  propagate_flags=True)
                 # update redundant data. Don't partial write.
                 hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:
@@ -378,15 +385,10 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         else:
             all_reds = []
         if redundant_average:
-            # initialize a redunantly averaged HERAData on disk
             all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == pols[0]]
             data_antpairs = hd.get_antpairs()
             reds_data = [[bl for bl in blg if bl in data_antpairs] for blg in all_red_antpairs]
             reds_data = [blg for blg in reds_data if len(blg) > 0]
-        if overwrite_data_flags:
-            for bl in data_flags:
-                data_flags[bl][:] = False
-                data_nsamples[bl][:] = 1.
         for bl in data_flags.keys():
             # apply band edge flags
             data_flags[bl][:, 0:flag_nchan_low] = True
@@ -419,7 +421,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 for grp in reds_data:
                     # trim group to only include baselines with redundant weights not equal to zero.
                     grp0 = grp[0]
-                    if dont_red_average_flagged_data:
+                    if dont_red_average_flagged_data and redundant_groups > 1:
                         grp = [ap for ap in grp if np.any(np.asarray([~data_flags[ap + (pol,)] for pol in data_flags.pols()]))]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
@@ -449,7 +451,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     else:
                         raise NotImplementedError("redundant averaging only supported for uvh5 outputs.")
                 else:
-                    warnings.warn("No unflagged data so no calibration or outputs produced..")
+                    warnings.warn("No unflagged data so no calibration or outputs produced.")
 
 
 def apply_cal_argparser():
@@ -474,7 +476,6 @@ def apply_cal_argparser():
                    help="If True, average gain ratios in redundant groups to recalibrate e.g. redcal solutions.")
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
     a.add_argument("--redundant_average", default=False, action="store_true", help="Redundantly average calibrated data.")
-    a.add_argument("--overwrite_data_flags", default=False, action="store_true", help="Completely overwrite data flags with calibration flags.")
-    a.add_argument("--dont_red_average_flagged_data", default=False, action="store_true", help="Completely overwrite data flags with calibration flags.")
+    a.add_argument("--dont_red_average_flagged_data", default=False, action="store_true", help="Do not include flagged data in redundant averages. Prevents redundant groups where one subgroup is flagged.")
     a.add_argument("--spw_range", default=None, type=int, nargs=2, help="specify spw range to load.")
     return a

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -304,6 +304,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             raise NotImplementedError('Partial writing is not implemented for non-uvh5 I/O.')
         if not redundant_groups == 1:
             raise NotImplementedError("Splitting redundant groups into subgroups is not yet implemented for partial I/O!")
+        if dont_red_average_flagged_data:
+            raise NotImplementedError("Completely skipping flagged data in redundantly averaged data not implemented for partial I/O!")
         for attribute, value in kwargs.items():
             hd.__setattr__(attribute, value)
         if redundant_average or redundant_solution:
@@ -418,7 +420,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     # trim group to only include baselines with redundant weights not equal to zero.
                     grp0 = grp[0]
                     if dont_red_average_flagged_data:
-                        grp = [ap for ap in grp if np.any(np.abs([data_flags[ap + (pol,)] * redundant_weights[ap + (pol,)] for pol in hd.pols]) >= 0.)]
+                        grp = [ap for ap in grp if np.any(np.asarray([~data_flags[ap + (pol,)] for pol in data_flags.pols()]))]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
                         start = int(np.ceil(len(grp) / redundant_groups)) * red_chunk

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -425,12 +425,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         grp = [ap for ap in grp if np.any(np.asarray([~data_flags[ap + (pol,)] for pol in data_flags.pols()]))]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
-                        start = len(grp) // redundant_groups * red_chunk
-                        if red_chunk < redundant_groups - 1:
-                            end = len(grp) // redundant_groups * (red_chunk + 1)
-                        else:
-                            end = len(grp)
-                        red_antpairs.append(grp[start:end])
+                        red_antpairs.append(grp[red_chunk:: redundant_groups])
                         reds_data_bls.append(grp0)
                 data_red, flags_red, nsamples_red = utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
                                                                       reds=red_antpairs, red_bl_keys=reds_data_bls, wgts=redundant_weights, inplace=False,

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -183,7 +183,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
               flag_filetype='h5', a_priori_flags_yaml=None, flag_nchan_low=0, flag_nchan_high=0, filetype_in='uvh5', filetype_out='uvh5',
               nbl_per_load=None, gain_convention='divide', redundant_solution=False, bl_error_tol=1.0, overwrite_data_flags=False,
               add_to_history='', clobber=False, redundant_average=False, redundant_weights=None,
-              redundant_groups=1, spw_range=None, **kwargs):
+              redundant_groups=1, dont_red_average_flagged_data=False, spw_range=None, **kwargs):
     '''Update the calibration solution and flags on the data, writing to a new file. Takes out old calibration
     and puts in new calibration solution, including its flags. Also enables appending to history.
 
@@ -227,6 +227,11 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             Default is None. If None is passed, then nsamples are used as the redundant weights.
         redundant_groups : int, optional.
             Integer specifying how many different subsets of each redundant group to write to an independent file.
+        dont_red_average_flagged_data : bool, optional.
+            If True, baselines within a redundant group with all pols flagged do not count towards the number of baselines
+            in that group above the number of groups to output. This lets us throw away groups that in principal have greater
+            then the minimum number of baselines to allow for a split into different output groups but could result in one of
+            the subgroups being entirely flagged.
         kwargs: dictionary mapping updated UVData attributes to their new values.
             See pyuvdata.UVData documentation for more info.
     '''
@@ -239,9 +244,6 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     # load new calibration solution
     hc = io.HERACal(new_calibration)
     new_gains, new_flags, _, _ = hc.read()
-    #if spw_range is not None:
-    #    hc.select(frequencies=hc.freq_array[0][spw_range[0]:spw_range[1]])
-    #    new_gains, new_flags, _, _ = hc.build_calcontainers()
     if a_priori_flags_yaml is not None:
         from hera_qm.utils import apply_yaml_flags
         # flag hc
@@ -250,6 +252,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         # and rebuild data containers.
         new_gains, new_flags, _, _ = hc.build_calcontainers()
     add_to_history += '\nNEW_CALFITS_HISTORY: ' + hc.history + '\n'
+
     # load old calibration solution
     if old_calibration is not None:
         old_hc = io.HERACal(old_calibration)
@@ -267,53 +270,67 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     else:
         old_gains, old_flags = None, None
     hd = io.HERAData(data_infilename, filetype=filetype_in)
-    freqs_to_load = []
     if spw_range is None:
         spw_range=(0, hd.Nfreqs)
-    for f in hd.freqs[spw_range[0]:spw_range[1]]:
-        if np.any(np.isclose(hc.freqs, f)):
-            freqs_to_load.append(f)
+    else:
+        if filetype_in != 'uvh5':
+            raise NotImplementedError("spw only implemented for uvh5 files.")
+    if filetype_in == 'uvh5':
+        freqs_to_load = []
+        for f in hd.freqs[spw_range[0]:spw_range[1]]:
+            if np.any(np.isclose(hc.freqs, f)):
+                freqs_to_load.append(f)
+    else:
+        freqs_to_load = None
     # reselect cals to match hd freqs_to_load
-    calfreqs = []
-    calfreqsold = []
-    for f in hc.freqs:
-        if np.any(np.isclose(freqs_to_load, f)):
-            calfreqs.append(f)
-        if old_calibration is not None and p.any(np.isclose(hc_old.freqs, f)):
-            calfreqsold.append(f)
-    hc.select(frequencies=calfreqs)
-    new_gains, new_flags, _, _ = hc.build_calcontainers()
-    if old_calibration is not None:
-        hc_old.select(frequencies=calfreqsold)
-        old_gains, old_flags, _, _ = hc_old.build_calcontainers()
+    if freqs_to_load is not None:
+        calfreqs = []
+        calfreqsold = []
+        for f in hc.freqs:
+            if np.any(np.isclose(freqs_to_load, f)):
+                calfreqs.append(f)
+            if old_calibration is not None and np.any(np.isclose(old_hc.freqs, f)):
+                calfreqsold.append(f)
+        hc.select(frequencies=calfreqs)
+        new_gains, new_flags, _, _ = hc.build_calcontainers()
+        if old_calibration is not None:
+            old_hc.select(frequencies=calfreqsold)
+            old_gains, old_flags, _, _ = old_hc.build_calcontainers()
 
     add_to_history = version.history_string(add_to_history)
     no_red_weights = redundant_weights is None
-    # partial loading and writing using uvh5
-    if redundant_average or redundant_solution:
-        all_reds = redcal.get_reds(hd.antpos, pols=hd.pols, bl_error_tol=bl_error_tol, include_autos=True)
-    else:
-        all_reds = []
-    if redundant_average:
-        # initialize a redunantly averaged HERAData on disk
-        all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == hd.pols[0]]
-        data_antpairs = hd.get_antpairs()
-        reds_data = [[bl for bl in blg if bl in data_antpairs] for blg in all_red_antpairs]
-        reds_data = [blg for blg in reds_data if len(blg) > 0]
-
     if nbl_per_load is not None:
         if not ((filetype_in == 'uvh5') and (filetype_out == 'uvh5')):
             raise NotImplementedError('Partial writing is not implemented for non-uvh5 I/O.')
+        if not redundant_groups == 1:
+            raise NotImplementedError("Splitting redundant groups into subgroups is not yet implemented for partial I/O!")
         for attribute, value in kwargs.items():
             hd.__setattr__(attribute, value)
+        if redundant_average or redundant_solution:
+            all_reds = redcal.get_reds(hd.antpos, pols=hd.pols, bl_error_tol=bl_error_tol, include_autos=True)
+        else:
+            all_reds = []
+        if redundant_average:
+            # initialize a redunantly averaged HERAData on disk
+            # first copy the original HERAData
+            all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == hd.pols[0]]
+            hd_red = io.HERAData(data_infilename)
+            # go through all redundant groups and remove the groups that do not
+            # have baselines in the data. Each group is still labeled by the
+            # first baseline of each group regardless if that baseline is in
+            # the data file.
+            reds_data = redcal.filter_reds(all_reds, bls=hd.bls)
+            reds_data_bls = []
+            for grp in reds_data:
+                reds_data_bls.append(grp[0])
+            # couldn't get a system working where we just read in the outputs one at a time.
+            # so unfortunately, we have to load one baseline per redundant group.
+            hd_red.read(bls=reds_data_bls, frequencies=freqs_to_load)
+
         # consider calucate reds here instead and pass in (to avoid computing it multiple times)
         # I'll look into generators and whether the reds calc is being repeated.
         for data, data_flags, data_nsamples in hd.iterate_over_bls(Nbls=nbl_per_load, chunk_by_redundant_group=redundant_average,
-                                                                   reds=all_reds, freqs_to_load=freqs_to_load):
-            if overwrite_data_flags:
-                for bl in data_flags:
-                    data_flags[bl][:] = False
-                    data_nsamples[bl][:] = 1.
+                                                                   reds=all_reds, frequencies=freqs_to_load):
             for bl in data_flags.keys():
                 # apply band edge flags
                 data_flags[bl][:, 0:flag_nchan_low] = True
@@ -327,52 +344,43 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             else:
                 calibrate_in_place(data, new_gains, data_flags=data_flags, cal_flags=new_flags,
                                    old_gains=old_gains, gain_convention=gain_convention)
-            hd.update(data=data, flags=data_flags, nsamples=data_nsamples)
+            hd.update(data=data, flags=data_flags)
 
             if redundant_average:
-                for red_chunk in range(redundant_groups):
-                    # by default, weight by nsamples (but not flags). This prevents spectral structure from being introduced
-                    # and also allows us to compute redundant averaged vis in flagged channels (in case flags are spurious).
-                    if no_red_weights:
-                        redundant_weights = copy.deepcopy(data_nsamples)
-                        for bl in data_flags:
-                            if np.all(data_flags[bl]):
-                                redundant_weights[bl][:] = 0.
-                    # redundantly average
-                    # select chunk antpairs
-                    red_antpairs = []
-                    for grp in reds_data:
-                        # trim group to only include baselines with redundant weights not equal to zero.
-                        grp0 = grp[0]
-                        grp = [ap for ap in grp if not np.all(redundant_weights[ap+(hd.pols[0],)] == 0.)]
-                        # only include groups with more elements then redundant groups!
-                        if len(grp) >= redundant_groups:
-                            start = int(np.ceil(len(grp) / redundant_groups)) * red_chunk
-                            end = int(np.min([np.ceil(len(grp) / redundant_groups) * (red_chunk + 1), len(grp)]))
-                            red_antpairs.append(grp[start:end])
-                            reds_data_bls.append(grp0)
-
-                    data_red, flags_red, nsamples_red = utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
-                                                                          reds=red_antpairs, red_bl_keys=reds_data_bls, wgts=redundant_weights, inplace=False,
-                                                                          propagate_flags=True)
-                    hd_red = io.HERAData(data_infilename)
-                    hd_red.read(bls=reds_data_bls, frequencies=freqs_to_load)
-                    # update redundant data. Don't partial write.
-                    hd_red.update(nsamples=nsamples_red, flags=flags_red, data=data_red)
+                # by default, weight by nsamples (but not flags). This prevents spectral structure from being introduced
+                # and also allows us to compute redundant averaged vis in flagged channels (in case flags are spurious).
+                if no_red_weights:
+                    redundant_weights = copy.deepcopy(data_nsamples)
+                    for bl in data_flags:
+                        if np.all(data_flags[bl]):
+                            redundant_weights[bl][:] = 0.
+                # redundantly average
+                utils.red_average(data=data, flags=data_flags, nsamples=data_nsamples,
+                                  reds=all_red_antpairs, wgts=redundant_weights, inplace=True,
+                                  propagate_flags=True)
+                # update redundant data. Don't partial write.
+                hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:
                 # partial write works for no redundant averaging.
                 hd.partial_write(data_outfilename, inplace=True, clobber=clobber, add_to_history=add_to_history, **kwargs)
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
-            for red_chunk, hd_red in enumerate(hd_reds):
-                if redundant_groups > 1:
-                    outfile = data_outfilename.replace('.uvh5', f'.{red_chunk}.uvh5')
-                else:
-                    outfile = data_outfilename
-                hd_red.write_uvh5(outfile, clobber=clobber)
+            hd_red.write_uvh5(data_outfilename, clobber=clobber)
     # full data loading and writing
     else:
         data, data_flags, data_nsamples = hd.read(frequencies=freqs_to_load)
+        antpos = hd.get_metadata_dict()['antpos']
+        pols = hd.get_metadata_dict()['pols']
+        if redundant_average or redundant_solution:
+            all_reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol, include_autos=True)
+        else:
+            all_reds = []
+        if redundant_average:
+            # initialize a redunantly averaged HERAData on disk
+            all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == pols[0]]
+            data_antpairs = hd.get_antpairs()
+            reds_data = [[bl for bl in blg if bl in data_antpairs] for blg in all_red_antpairs]
+            reds_data = [blg for blg in reds_data if len(blg) > 0]
         if overwrite_data_flags:
             for bl in data_flags:
                 data_flags[bl][:] = False
@@ -409,7 +417,8 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 for grp in reds_data:
                     # trim group to only include baselines with redundant weights not equal to zero.
                     grp0 = grp[0]
-                    grp = [ap for ap in grp if not np.all(redundant_weights[ap+(hd.pols[0],)] == 0.)]
+                    if dont_red_average_flagged_data:
+                        grp = [ap for ap in grp if np.any(np.abs([data_flags[ap + (pol,)] * redundant_weights[ap + (pol,)] for pol in hd.pols])>=0.)]
                     # only include groups with more elements then redundant groups!
                     if len(grp) >= redundant_groups:
                         start = int(np.ceil(len(grp) / redundant_groups)) * red_chunk
@@ -444,7 +453,7 @@ def apply_cal_argparser():
     a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")
     a.add_argument("infilename", type=str, help="path to visibility data file to calibrate")
     a.add_argument("outfilename", type=str, help="path to new visibility results file")
-    a.add_argument("--new_cal", type=str, default=None, help="path to new calibration calfits file (or files for cross-pol)")
+    a.add_argument("--new_cal", type=str, default=None, nargs="+", help="path to new calibration calfits file (or files for cross-pol)")
     a.add_argument("--old_cal", type=str, default=None, nargs="+", help="path to old calibration calfits file to unapply (or files for cross-pol)")
     a.add_argument("--flag_file", type=str, default=None, help="path to file of flags to OR with data flags")
     a.add_argument("--flag_filetype", type=str, default='h5', help="filetype of flag_file (either 'h5' or legacy 'npz'")
@@ -462,5 +471,6 @@ def apply_cal_argparser():
     a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
     a.add_argument("--redundant_average", default=False, action="store_true", help="Redundantly average calibrated data.")
     a.add_argument("--overwrite_data_flags", default=False, action="store_true", help="Completely overwrite data flags with calibration flags.")
+    a.add_argument("--dont_red_average_flagged_data", default=False, action="store_true", help="Completely overwrite data flags with calibration flags.")
     a.add_argument("--spw_range", default=None, type=int, nargs=2, help="specify spw range to load.")
     return a

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -293,14 +293,14 @@ class Test_Update_Cal(object):
                 wgts[bl][:] = 0.
         hda_calibrated = utils.red_average(hd_calibrated, reds, inplace=False, wgts=wgts, propagate_flags=True)
         dcal, fcal, ncal = hda_calibrated.build_datacontainers()
-        #bls_2_keep = []
-        #for bl in hda_calibrated.antpairs:
+        # bls_2_keep = []
+        # for bl in hda_calibrated.antpairs:
         #    anypols = False
         #    for p, pol in enumerate(hda_calibrated.pols):
         #        anypols = anypols or np.any(fcal[bl + (pol, )])
         #    if anypols:
         #        bls_2_keep.append(bl)
-        #hda_calibrated.select(bls=bls_2_keep)
+        # hda_calibrated.select(bls=bls_2_keep)
         ac.apply_cal(uncalibrated_file, calibrated_redundant_averaged_file, calfile,
                      gain_convention='divide', redundant_average=True)
 

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -399,11 +399,11 @@ class Test_Update_Cal(object):
             equal_times = []
             equal_baselines = []
             equal_data = []
-            for m in range(ngrps-1):
-                equal_flags.append(np.all(np.isclose(hda_calibrated_groups[m].flag_array, hda_calibrated_groups[m+1].flag_array)))
-                equal_times.append(np.all(np.isclose(hda_calibrated_groups[m].time_array, hda_calibrated_groups[m+1].time_array)))
-                equal_data.append(np.all(np.isclose(hda_calibrated_groups[m].data_array, hda_calibrated_groups[m+1].data_array)))
-                equal_baselines.append(np.all(np.isclose(hda_calibrated_groups[m].baseline_array, hda_calibrated_groups[m+1].baseline_array)))
+            for m in range(ngrps - 1):
+                equal_flags.append(np.all(np.isclose(hda_calibrated_groups[m].flag_array, hda_calibrated_groups[m + 1].flag_array)))
+                equal_times.append(np.all(np.isclose(hda_calibrated_groups[m].time_array, hda_calibrated_groups[m + 1].time_array)))
+                equal_data.append(np.all(np.isclose(hda_calibrated_groups[m].data_array, hda_calibrated_groups[m + 1].data_array)))
+                equal_baselines.append(np.all(np.isclose(hda_calibrated_groups[m].baseline_array, hda_calibrated_groups[m + 1].baseline_array)))
             # check all flag arrays are equal
             assert np.all(equal_flags)
             # check that all baseline and time arrays are equal
@@ -411,8 +411,6 @@ class Test_Update_Cal(object):
             assert np.all(equal_times)
             # check that data is not equal.
             assert not np.any(equal_data)
-
-
 
     def test_apply_cal_argparser(self):
         sys.argv = [sys.argv[0], 'a', 'b', '--new_cal', 'd']

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -326,29 +326,9 @@ class Test_Update_Cal(object):
         assert np.all(np.isclose(hda_calibrated.data_array, hda_calibrated_with_apply_cal.data_array))
         dcal, fcal, ncal = hd_calibrated.build_datacontainers()
 
-        # now try out the dont_red_average_flagged_data keyword
-        bls_2_keep = []
-        for bl in hd_calibrated.antpairs:
-            anypols = False
-            for p, pol in enumerate(hd_calibrated.pols):
-                anypols = anypols or np.any(~fcal[bl + (pol, )])
-            if anypols:
-                bls_2_keep.append(bl)
-        hd_calibrated_selection = hd_calibrated.select(bls=bls_2_keep, inplace=False)
-        hda_calibrated = utils.red_average(hd_calibrated_selection, reds, inplace=False, wgts=wgts, propagate_flags=True)
-        # check not impelemented error
         with pytest.raises(NotImplementedError):
             ac.apply_cal(uncalibrated_file, calibrated_redundant_averaged_file, calfile, dont_red_average_flagged_data=True,
                          gain_convention='divide', redundant_average=True, nbl_per_load=2, clobber=True)
-        # check skipping flagged data.
-        ac.apply_cal(uncalibrated_file, calibrated_redundant_averaged_file, calfile, dont_red_average_flagged_data=True,
-                     gain_convention='divide', redundant_average=True, nbl_per_load=None, clobber=True)
-        hda_calibrated_with_apply_cal = io.HERAData(calibrated_redundant_averaged_file)
-        hda_calibrated_with_apply_cal.read()
-        # check that the data, flags, and nsamples arrays are close
-        assert np.all(np.isclose(hda_calibrated.nsample_array, hda_calibrated_with_apply_cal.nsample_array))
-        assert np.all(np.isclose(hda_calibrated.flag_array, hda_calibrated_with_apply_cal.flag_array))
-        assert np.all(np.isclose(hda_calibrated.data_array, hda_calibrated_with_apply_cal.data_array))
 
         # prepare calibrated file where all baselines have the same nsamples and the same flagging pattern if they are not all flagged.
         hdt = io.HERAData(uncalibrated_file)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -292,7 +292,15 @@ class Test_Update_Cal(object):
             if np.all(f[bl]):
                 wgts[bl][:] = 0.
         hda_calibrated = utils.red_average(hd_calibrated, reds, inplace=False, wgts=wgts, propagate_flags=True)
-
+        dcal, fcal, ncal = hda_calibrated.build_datacontainers()
+        #bls_2_keep = []
+        #for bl in hda_calibrated.antpairs:
+        #    anypols = False
+        #    for p, pol in enumerate(hda_calibrated.pols):
+        #        anypols = anypols or np.any(fcal[bl + (pol, )])
+        #    if anypols:
+        #        bls_2_keep.append(bl)
+        #hda_calibrated.select(bls=bls_2_keep)
         ac.apply_cal(uncalibrated_file, calibrated_redundant_averaged_file, calfile,
                      gain_convention='divide', redundant_average=True)
 

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -589,7 +589,7 @@ def test_red_average():
 
     # try with DataContainer
     data_avg, flag_avg, _ = utils.red_average(data, reds, flags=flags, inplace=False)
-    assert isinstance(data_avg, datacontainer.DataContainer)
+    assert isinstance(data_avg, (datacontainer.DataContainer, dict))
     assert len(data_avg) == len(reds)
     assert np.isclose(data_avg[blkey], davg).all()
     assert np.isclose(flag_avg[blkey], hda.get_flags(blkey)).all()

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1173,9 +1173,9 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
             are propagated to the output flags. Default = False.
     Returns:
         if fed a DataContainer:
-            DataContainer, averaged data
-            DataContainer, averaged flags
-            DataContainer, summed nsamples
+            Dict, averaged data
+            Dict, averaged flags
+            Dict, summed nsamples
         elif fed a HERAData or UVData:
             HERAData or UVData object, averaged data
 
@@ -1290,14 +1290,26 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
         new_data = {}
         new_flags = {}
         new_nsamples = {}
-        for bl in list(data.keys()):
-            if bl in bls:
-                new_data[bl] = data[bl]
-                new_flags[bl] = flags[bl]
-                new_nsamples[bl] = nsamples[bl]
-        data = new_data
-        flags = new_flags
-        nsamples = new_nsamples
+        # its much faster to assign a new dict then
+        # delete items from an existing dict for
+        # large data sets where number of red keys
+        # much smaller the original keys.
+        if not inplace:
+            for bl in list(data.keys()):
+                if bl in bls:
+                    new_data[bl] = data[bl]
+                    new_flags[bl] = flags[bl]
+                    new_nsamples[bl] = nsamples[bl]
+            data = new_data
+            flags = new_flags
+            nsamples = new_nsamples
+        else:
+            # can't think of how to avoid this inplace.
+            for bl in list(data.keys()):
+                if bl not in bls:
+                    del data[bl]
+                    del flags[bl]
+                    del nsamples[bl]
     else:
         data.select(bls=bls)
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1287,9 +1287,17 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     # select out averaged bls
     bls = [blk + (pol,) for pol in pols for blk in red_bl_keys]
     if fed_container:
+        new_data = {}
+        new_flags = {}
+        new_nsamples = {}
         for bl in list(data.keys()):
-            if bl not in bls:
-                del data[bl], flags[bl], nsamples[bl]
+            if bl in bls:
+                new_data[bl] = data[bl]
+                new_flags[bl] = flags[bl]
+                new_nsamples[bl] = nsamples[bl]
+        data = new_data
+        flags = new_flags
+        nsamples = new_nsamples
     else:
         data.select(bls=bls)
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1135,6 +1135,7 @@ def gain_relative_difference(old_gains, new_gains, flags, denom=None):
 
 def red_average(data, reds=None, bl_tol=1.0, inplace=False,
                 wgts=None, flags=None, nsamples=None,
+                red_bl_keys=None,
                 propagate_flags=False):
     """
     Redundantly average visibilities in a DataContainer, HERAData or UVData object.
@@ -1162,6 +1163,10 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
             If data is a DataContainer, these are its nsamples. Default (None) is 1.0 for all pixels.
             Furthermore, if data is a DataContainer, integration_time is 1.0 for all pixels.
             If data is a UVData, then data.nsample_array is used regardless of nsamples input.
+        red_bl_keys : list, optional
+            Optional list of keys to use for each redundantly averaged group. If None,
+            use the first key from each group.
+            Default is None.
         propagate_flags : bool, optional
             If True, propagate input flags to the average flag, even if wgts are provided.
             Note, if wgts are provided, the input flags are NOT used for weighting, but
@@ -1233,8 +1238,10 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     reds = [blg for blg in reds if len(blg) > 0]
 
     # iterate over redundant groups and polarizations
+    if red_bl_keys is None:
+        red_bl_keys = [blg[0] for blg in reds]
     for pol in pols:
-        for blg in reds:
+        for blg, blk in zip(reds, red_bl_keys):
             # get data and weighting for this pol-blgroup
             if fed_container:
                 d = np.asarray([data[bl + (pol,)] for bl in blg])
@@ -1264,13 +1271,13 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
 
             # replace with new data
             if fed_container:
-                blkey = blg[0] + (pol,)
+                blkey = blk + (pol,)
                 data[blkey] = davg
                 flags[blkey] = favg
                 nsamples[blkey] = navg
 
             else:
-                blinds = data.antpair2ind(blg[0])
+                blinds = data.antpair2ind(blk)
                 polind = pols.index(pol)
                 data.data_array[blinds, 0, :, polind] = davg
                 data.flag_array[blinds, 0, :, polind] = favg
@@ -1278,10 +1285,11 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
                 data.integration_time[blinds] = iavg
 
     # select out averaged bls
-    bls = [blg[0] + (pol,) for pol in pols for blg in reds]
+    bls = [blk + (pol,) for pol in pols for blk in red_bl_keys]
     if fed_container:
-        to_del = [bl for bl in data.keys() if bl not in bls]
-        del data[to_del], flags[to_del], nsamples[to_del]
+        for bl in list(data.keys()):
+            if bl not in bls:
+                del data[bl], flags[bl], nsamples[bl]
     else:
         data.select(bls=bls)
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1287,14 +1287,14 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     # select out averaged bls
     bls = [blk + (pol,) for pol in pols for blk in red_bl_keys]
     if fed_container:
-        new_data = {}
-        new_flags = {}
-        new_nsamples = {}
         # its much faster to assign a new dict then
         # delete items from an existing dict for
         # large data sets where number of red keys
         # much smaller the original keys.
         if not inplace:
+            new_data = {}
+            new_flags = {}
+            new_nsamples = {}
             for bl in list(data.keys()):
                 if bl in bls:
                     new_data[bl] = data[bl]

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1287,29 +1287,8 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     # select out averaged bls
     bls = [blk + (pol,) for pol in pols for blk in red_bl_keys]
     if fed_container:
-        # its much faster to assign a new dict then
-        # delete items from an existing dict for
-        # large data sets where number of red keys
-        # much smaller the original keys.
-        if not inplace:
-            new_data = {}
-            new_flags = {}
-            new_nsamples = {}
-            for bl in list(data.keys()):
-                if bl in bls:
-                    new_data[bl] = data[bl]
-                    new_flags[bl] = flags[bl]
-                    new_nsamples[bl] = nsamples[bl]
-            data = new_data
-            flags = new_flags
-            nsamples = new_nsamples
-        else:
-            # can't think of how to avoid this inplace.
-            for bl in list(data.keys()):
-                if bl not in bls:
-                    del data[bl]
-                    del flags[bl]
-                    del nsamples[bl]
+        to_del = [bl for bl in data.keys() if bl not in bls]
+        del data[to_del], flags[to_del], nsamples[to_del]
     else:
         data.select(bls=bls)
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -510,7 +510,6 @@ class VisClean(object):
                         if 2dfilter: should be a 2-list or 2-tuple. Each element should
                         be a list or tuple or np.ndarray of floats that include centers
                         of rectangular bins.
-                    ax: str, axis to filter, options=['freq', 'time', 'both']
                 * 'dpss':
                     'eigenval_cutoff': array-like
                         list of sinc_matrix eigenvalue cutoffs to use for included dpss modes.
@@ -533,7 +532,6 @@ class VisClean(object):
                         if 2dfilter: should be a 2-list or 2-tuple. Each element should
                         be a list or tuple or np.ndarray of floats that include centers
                         of rectangular bins.
-                    ax: str, axis to filter, options=['freq', 'time', 'both']
                 *'clean':
                      'tol': float,
                         clean tolerance. 1e-9 is standard.

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -10,6 +10,7 @@ import argparse
 from hera_cal import apply_cal as ac
 import sys
 
+kwargs = {}
 a = ac.apply_cal_argparser()
 args = a.parse_args()
 

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -13,7 +13,7 @@ import sys
 a = ac.apply_cal_argparser()
 args = a.parse_args()
 
-if args.vis_units is not None:	
+if args.vis_units is not None:
     kwargs['vis_units'] = args.vis_units
 
 if args.nbl_per_load == "none":
@@ -26,4 +26,4 @@ ac.apply_cal(args.infilename, args.outfilename, args.new_cal, old_calibration=ar
              filetype_in=args.filetype_in, filetype_out=args.filetype_out, nbl_per_load=args.nbl_per_load, redundant_groups=args.redundant_groups,
              gain_convention=args.gain_convention, redundant_solution=args.redundant_solution, redundant_average=args.redundant_average,
              add_to_history=' '.join(sys.argv), clobber=args.clobber, overwrite_data_flags=args.overwrite_data_flags,
-             dont_red_average_flagged_data=args.dont_red_average_flagged_data, **kwargs)
+             dont_red_average_flagged_data=args.dont_red_average_flagged_data, exclude_from_redundant_mode=args.exclude_from_redundant_mode, **kwargs)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -13,9 +13,13 @@ import sys
 a = ac.apply_cal_argparser()
 args = a.parse_args()
 
-kwargs = {}
-if args.nbl_per_load == 0:
+if args.vis_units is not None:	
+    kwargs['vis_units'] = args.vis_units
+
+if args.nbl_per_load == "none":
     args.nbl_per_load = None
+if args.nbl_per_load is not None:
+    args.nbl_per_load = int(args.nbl_per_load)
 
 ac.apply_cal(args.infilename, args.outfilename, args.new_cal, old_calibration=args.old_cal, flag_file=args.flag_file,
              flag_filetype=args.flag_filetype, flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, spw_range=args.spw_range,

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -21,4 +21,5 @@ ac.apply_cal(args.infilename, args.outfilename, args.new_cal, old_calibration=ar
              flag_filetype=args.flag_filetype, flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, spw_range=args.spw_range,
              filetype_in=args.filetype_in, filetype_out=args.filetype_out, nbl_per_load=args.nbl_per_load, redundant_groups=args.redundant_groups,
              gain_convention=args.gain_convention, redundant_solution=args.redundant_solution, redundant_average=args.redundant_average,
-             add_to_history=' '.join(sys.argv), clobber=args.clobber, overwrite_data_flags=args.overwrite_data_flags, **kwargs)
+             add_to_history=' '.join(sys.argv), clobber=args.clobber, overwrite_data_flags=args.overwrite_data_flags,
+             dont_red_average_flagged_data=args.dont_red_average_flagged_data, **kwargs)

--- a/scripts/apply_cal.py
+++ b/scripts/apply_cal.py
@@ -14,16 +14,11 @@ a = ac.apply_cal_argparser()
 args = a.parse_args()
 
 kwargs = {}
-if args.vis_units is not None:
-    kwargs['vis_units'] = args.vis_units
-
-if args.nbl_per_load == "none":
+if args.nbl_per_load == 0:
     args.nbl_per_load = None
-if args.nbl_per_load is not None:
-    args.nbl_per_load = int(args.nbl_per_load)
 
 ac.apply_cal(args.infilename, args.outfilename, args.new_cal, old_calibration=args.old_cal, flag_file=args.flag_file,
-             flag_filetype=args.flag_filetype, flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high,
-             filetype_in=args.filetype_in, filetype_out=args.filetype_out, nbl_per_load=args.nbl_per_load,
+             flag_filetype=args.flag_filetype, flag_nchan_low=args.flag_nchan_low, flag_nchan_high=args.flag_nchan_high, spw_range=args.spw_range,
+             filetype_in=args.filetype_in, filetype_out=args.filetype_out, nbl_per_load=args.nbl_per_load, redundant_groups=args.redundant_groups,
              gain_convention=args.gain_convention, redundant_solution=args.redundant_solution, redundant_average=args.redundant_average,
-             add_to_history=' '.join(sys.argv), clobber=args.clobber, **kwargs)
+             add_to_history=' '.join(sys.argv), clobber=args.clobber, overwrite_data_flags=args.overwrite_data_flags, **kwargs)


### PR DESCRIPTION
apply_cal currently supports averaging over redundant baselines to create a calibrated, redundantly averaged data set. For purposes of systematics mitigation and jackknife tests, it is advantageous for us to produce multiple averaged subsets of baselines from each redundant group that we can compare and cross-correlate. I have added a `redundant_groups` argument to `apply_cal` that allows the user to specify the number of subgroups to split redundant averages into. Only groups in which the number of baselines is greater then the number of redundant groups are ultimately saved.