### PR TITLE
Update Iterable imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ installing `hera_cal`:
 (note that `h5py` is a dependency of `hera_qm`, not `hera_cal`).
 
 Other dependencies that will be installed from PyPI on-the-fly are:
-* pyephem
 * [linsolve](https://github.com/HERA-Team/linsolve)
 * [hera_qm](https://github.com/HERA-Team/hera_qm)
 

--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -16,7 +16,6 @@ dependencies:
   - pycodestyle
   - psutil
   - astropy-healpix
-  - pyephem
   - future
   - pytest-cov
   - coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ['omnical', 'numpy', 'ephem', 'aipy', 'scipy', 'pyuvdata',
+MOCK_MODULES = ['omnical', 'numpy', 'aipy', 'scipy', 'pyuvdata',
                 'astropy', 'numpy.linalg', 'pylab', 'scipy.sparse', 'aipy.miriad', 'scipy.signal']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,6 @@ First Install all dependencies.
 -  numpy >= 1.10
 -  scipy
 -  astropy >=1.2
--  pyephem
 -  aipy
 -  pyuvdata >= 1.1
 -  omnical >= 5.0.2

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -9,7 +9,7 @@ import os
 import copy
 import warnings
 from functools import reduce
-import collections
+from collections.abc import Iterable
 from pyuvdata import UVCal, UVData
 from pyuvdata import utils as uvutils
 from astropy import units
@@ -53,7 +53,7 @@ class HERACal(UVCal):
         if isinstance(input_cal, str):
             assert os.path.exists(input_cal), '{} does not exist.'.format(input_cal)
             self.filepaths = [input_cal]
-        elif isinstance(input_cal, collections.Iterable):  # List loading
+        elif isinstance(input_cal, Iterable):  # List loading
             if np.all([isinstance(i, str) for i in input_cal]):  # List of visibility data paths
                 for ic in input_cal:
                     assert os.path.exists(ic), '{} does not exist.'.format(ic)
@@ -269,7 +269,7 @@ class HERAData(UVData):
         # parse input_data as filepath(s)
         if isinstance(input_data, str):
             self.filepaths = [input_data]
-        elif isinstance(input_data, collections.Iterable):  # List loading
+        elif isinstance(input_data, Iterable):  # List loading
             if np.all([isinstance(i, str) for i in input_data]):  # List of visibility data paths
                 self.filepaths = list(input_data)
             else:
@@ -1105,11 +1105,11 @@ def read_redcal_meta(meta_filename):
         lsts = infile['header']['lsts'][:]
         antpos = {ant: pos for ant, pos in zip(infile['header']['antpos'].attrs['antnums'],
                                                infile['header']['antpos'][:, :])}
-        history = infile['header']['history'][()].tostring().decode('utf8')
+        history = infile['header']['history'][()].tobytes().decode('utf8')
 
         # reconstruct firstcal metadata
         fc_meta = {}
-        ants = [(int(num.tostring().decode('utf8')), pol.tostring().decode('utf8'))
+        ants = [(int(num.tobytes().decode('utf8')), pol.tobytes().decode('utf8'))
                 for num, pol in infile['fc_meta']['dlys'].attrs['ants']]
         fc_meta['dlys'] = {ant: dly for ant, dly in zip(ants, infile['fc_meta']['dlys'][:, :])}
         fc_meta['polarity_flips'] = {ant: flips for ant, flips in zip(ants, infile['fc_meta']['polarity_flips'][:, :])}
@@ -1156,7 +1156,7 @@ def to_HERAData(input_data, filetype='miriad', **read_kwargs):
         hd._determine_pol_indexing()
         hd.filepaths = None
         return hd
-    elif isinstance(input_data, collections.Iterable):  # List loading
+    elif isinstance(input_data, Iterable):  # List loading
         if np.all([isinstance(i, str) for i in input_data]):  # List of visibility data paths
             return HERAData(input_data, filetype=filetype, **read_kwargs)
         elif np.all([isinstance(i, (UVData, HERAData)) for i in input_data]):  # List of uvdata objects
@@ -1522,7 +1522,7 @@ def to_HERACal(input_cal):
         input_cal.__class__ = HERACal
         input_cal.filepaths = None
         return input_cal
-    elif isinstance(input_cal, collections.Iterable):  # List loading
+    elif isinstance(input_cal, Iterable):  # List loading
         if np.all([isinstance(ic, str) for ic in input_cal]):  # List of calfits paths
             return HERACal(input_cal)
         elif np.all([isinstance(ic, (UVCal, HERACal)) for ic in input_cal]):  # List of UVCal/HERACal objects

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import warnings
 import argparse
 import pyuvdata
-from collections import Iterable
+from collections.abc import Iterable
 
 try:
     import uvtools

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1071,7 +1071,7 @@ def gp_interp1d(x, y, x_eval=None, flags=None, length_scale=1.0, nl=1e-10,
     flag_indices = {}
     for i in range(flags.shape[1]):
         # hash the flag pattern
-        h = hash(flags[:, i].tostring())
+        h = hash(flags[:, i].tobytes())
         # append to list
         if h not in flag_hashes:
             flag_hashes.append(h)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup_args = {
         'scipy',
         'astropy',
         'pyuvdata',
-        'pyephem',
         'linsolve @ git+git://github.com/HERA-Team/linsolve',
         'hera_qm @ git+git://github.com/HERA-Team/hera_qm',
         'scikit-learn'


### PR DESCRIPTION
Since python3.3, the `Iterable` object should be imported from `collections.abc`, rather than `collections`. The `DeprecationWarning` issued suggests this will no longer be supported in python3.9, so this updates how things are imported to make sure it still works going into the future. There is also a small change to how numpy strings are handled in `io.py` and `utils.py`.