### PR TITLE
Bring over per_antenna_modified_z_scores from hera_qm

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -12,7 +12,7 @@ from . import utils
 from . import version
 from .noise import predict_noise_variance_from_autos
 from .datacontainer import DataContainer
-from .utils import split_pol, conj_pol, split_bl, reverse_bl, join_bl, join_pol, comply_pol
+from .utils import split_pol, conj_pol, split_bl, reverse_bl, join_bl, join_pol, comply_pol, per_antenna_modified_z_scores
 from .io import HERAData, HERACal, write_cal, save_redcal_meta
 from .apply_cal import calibrate_in_place
 
@@ -1863,7 +1863,6 @@ def redcal_run(input_data, filetype='uvh5', firstcal_ext='.first.calfits', omnic
         outdir = os.path.dirname(input_data)
 
     # loop over calibration, removing bad antennas and re-running if necessary
-    from hera_qm.ant_metrics import per_antenna_modified_z_scores
     run_number = 0
     while True:
         # Run redundant calibration

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -506,6 +506,15 @@ def test_chisq():
     assert len(chisq_per_ant) == 0
 
 
+def test_per_antenna_modified_z_scores():
+    metric = {(0, 'Jnn'): 1, (50, 'Jnn'): 0, (2, 'Jnn'): 2,
+              (2, 'Jee'): 2000, (0, 'Jee'): -300}
+    zscores = ant_metrics.per_antenna_modified_z_scores(metric)
+    np.testing.assert_almost_equal(zscores[0, 'Jnn'], 0, 10)
+    np.testing.assert_almost_equal(zscores[50, 'Jnn'], -0.6745, 10)
+    np.testing.assert_almost_equal(zscores[2, 'Jnn'], 0.6745, 10)
+
+
 def test_gp_interp1d():
     # load data
     dfiles = glob.glob(os.path.join(DATA_PATH, "zen.2458043.4*.xx.HH.XRAA.uvh5"))

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -509,7 +509,7 @@ def test_chisq():
 def test_per_antenna_modified_z_scores():
     metric = {(0, 'Jnn'): 1, (50, 'Jnn'): 0, (2, 'Jnn'): 2,
               (2, 'Jee'): 2000, (0, 'Jee'): -300}
-    zscores = ant_metrics.per_antenna_modified_z_scores(metric)
+    zscores = utils.per_antenna_modified_z_scores(metric)
     np.testing.assert_almost_equal(zscores[0, 'Jnn'], 0, 10)
     np.testing.assert_almost_equal(zscores[50, 'Jnn'], -0.6745, 10)
     np.testing.assert_almost_equal(zscores[2, 'Jnn'], 0.6745, 10)

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -955,6 +955,36 @@ def chisq(data, model, data_wgts=None, gains=None, gain_flags=None, split_by_ant
     return chisq, nObs, chisq_per_ant, nObs_per_ant
 
 
+def per_antenna_modified_z_scores(metric):
+    """Compute modified Z-Score over antennas for each antenna polarization.
+    This function computes the per-pol modified z-score of the given metric
+    dictionary for each antenna.
+    The modified Z-score is defined as:
+        0.6745 * (metric - median(all_metrics))/ median_absoulte_deviation
+    
+    Parameters:
+        metric : dict
+            Dictionary of metric data to compute z-score. Keys are expected to
+            have the form: (ant, antpol)
+    Returns:
+        zscores : dict
+            Dictionary of z-scores for the given data.
+    """
+    zscores = {}
+    antpols = set([key[1] for key in metric])
+    for antpol in antpols:
+        values = np.array([val for (key, val) in metric.items()
+                           if key[1] == antpol])
+        median = np.nanmedian(values)
+        medAbsDev = np.nanmedian(np.abs(values - median))
+        for (key, val) in metric.items():
+            if key[1] == antpol:
+                # this factor makes it comparable to a
+                # standard z-score for gaussian data
+                zscores[key] = 0.6745 * (val - median) / medAbsDev
+    return zscores
+
+
 def gp_interp1d(x, y, x_eval=None, flags=None, length_scale=1.0, nl=1e-10,
                 kernel=None, Nmirror=0, optimizer=None, xthin=None):
     """


### PR DESCRIPTION
This function is being eliminated in https://github.com/HERA-Team/hera_qm/pull/393 and since it's only used in hera_cal, it should live here.