### PR TITLE
Fix ragged nested lists in io.get_file_times

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -939,11 +939,12 @@ def get_file_times(filepaths, filetype='uvh5'):
         filetype : str, options=['miriad', 'uvh5']
 
     Returns:
-        If input is a string, output are floats, otherwise outputs are ndarrays.
-        dlst : ndarray of lst bin width [radian]
-        dtime : ndarray of time bin width [Julian Date]
-        file_lst_arrays : ndarrays of unwrapped lst_array [radians]
-        file_time_arrays : ndarrays of time_array [Julian Date]
+        dlst : ndarray (or float if filepaths is a string) of lst bin width [radian]
+        dtime : ndarray (or float if filepaths is a string) of time bin width [Julian Date]
+        file_lst_arrays : list of ndarrays (or list of floats if filepaths is a string)
+            of unwrapped lst_array [radians]
+        file_time_arrays : list of ndarrays (or list of floats if filepaths is a string)
+            of time_array [Julian Date]
     """
     _array = True
     # check filepaths type
@@ -1002,8 +1003,6 @@ def get_file_times(filepaths, filetype='uvh5'):
 
     dlsts = np.asarray(dlsts)
     dtimes = np.asarray(dtimes)
-    file_lst_arrays = np.asarray(file_lst_arrays)
-    file_time_arrays = np.asarray(file_time_arrays)
 
     if _array is False:
         return dlsts[0], dtimes[0], file_lst_arrays[0], file_time_arrays[0]

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -1034,8 +1034,8 @@ def test_get_file_times():
     filepaths = sorted(glob.glob(DATA_PATH + "/zen.2458042.*.xx.HH.uvXA"))
     # test execution
     dlsts, dtimes, larrs, tarrs = io.get_file_times(filepaths, filetype='miriad')
-    assert np.isclose(larrs[0, 0], 4.7293432458811866)
-    assert np.isclose(larrs[0, -1], 4.7755393587036084)
+    assert np.isclose(larrs[0][0], 4.7293432458811866)
+    assert np.isclose(larrs[0][-1], 4.7755393587036084)
     assert np.isclose(dlsts[0], 0.00078298496309189868)
     assert len(dlsts) == 2
     assert len(dtimes) == 2


### PR DESCRIPTION
This function is creating a deprecation warning: `Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray`

This occurs when the files input don't all have the same number of integrations. Casting it as an object isn't really helpful since it doesn't let you do math on it as an array. It's best just to explicitly cast it as a list.

This change is already taken account of in the two notebooks that use this function, https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/stage_2_abscal.ipynb and https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/stage_2_smooth_cal.ipynb

@nkern I know you're busy, so no rush on this, but I just wanted to flag that this possibly affects `preprocess_data.py`. I believe you already account for the possibility of arrays of different lengths, but I thought you'd want to check if this is a problem.
https://github.com/HERA-Team/H1C_IDR2/blob/33a55ed22e65f47bc1261aa70ae04e08882bd088/pipeline/preprocess_data.py#L57-L61


