### PR TITLE
Fix edge case in firstcal with antennas that only appear in length-1 redundant groups

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1539,7 +1539,6 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     '''
     rv = {}  # dictionary of return values
     filtered_reds = filter_reds(reds, max_dims=max_dims)
-    filtered_reds = [red for red in filtered_reds if len(red) > 1]  # remove length-1 reds which can't be firstcaled
     rc = RedundantCalibrator(filtered_reds)
     if freqs is None:
         freqs = data.freqs

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -846,6 +846,10 @@ class RedundantCalibrator:
         sol = ls.solve(mode=mode)
         dly_sol = {self.unpack_sol_key(k): v[0] for k, v in sol.items()}
         off_sol = {self.unpack_sol_key(k): v[1] for k, v in sol.items()}
+        # add back in antennas in reds but not in the system of equations
+        ants = set([ant for red in self.reds for bl in red for ant in utils.split_bl(bl)])
+        dly_sol = {ant: dly_sol.get(ant, (np.zeros_like(list(dly_sol.values())[0]))) for ant in ants}
+        off_sol = {ant: off_sol.get(ant, (np.zeros_like(list(off_sol.values())[0]))) for ant in ants}
         return dly_sol, off_sol
 
     def firstcal(self, data, freqs, wgts={}, maxiter=25, conv_crit=1e-6,

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1539,6 +1539,7 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     '''
     rv = {}  # dictionary of return values
     filtered_reds = filter_reds(reds, max_dims=max_dims)
+    filtered_reds = [red for red in filtered_reds if len(red) > 1]  # remove length-1 reds which can't be firstcaled
     rc = RedundantCalibrator(filtered_reds)
     if freqs is None:
         freqs = data.freqs


### PR DESCRIPTION
Generally speaking, we pick `max_dims` so that antennas that aren't redundant with anything get flagged (since otherwise they'd introduce an extraneous extra dimension). While we're in the middle of expanding the array over the sector gap, this is a bit tricky to get right.

Today I found an edge case in RTP where an antenna wasn't getting flagged, but never participated in any redundant groups of length greater than 1. In this case, firstcal fails to find a solution for the antenna delay, though logcal and omnical can solve for it. This creates key errors in the pipeline. 

This PR solves that problem by setting the antenna's delay and delay offset to 0. We are free to do this, because both are completely degenerate and unsolvable with redcal. In theory, we could solve for them with abscal, though in the future we'll probably just want to flag the antenna.