### PR TITLE
Data antpos attribute

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3301,7 +3301,7 @@ def build_data_wgts(data_flags, data_nsamples, model_flags, autocorrs, auto_flag
     # if data_is_redsol, get reds, using data_flags.antpos if antpos is unspecified
     if data_is_redsol:
         if antpos is None:
-            antpos = data_flags.antpos
+            antpos = data_flags.data_antpos
         reds = redcal.get_reds(antpos, bl_error_tol=tol, pols=data_flags.pols())
         reds = redcal.filter_reds(reds, ants=[split_bl(bl)[0] for bl in autocorrs])
 
@@ -3517,10 +3517,10 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
 
         # get model bls and antpos to use later in baseline matching
         model_bls = hdm.bls
-        model_antpos = hdm.antpos
+        model_antpos = hdm.data_antpos
         if len(matched_model_files) > 1:  # in this case, it's a dictionary
             model_bls = list(set([bl for bls in list(hdm.bls.values()) for bl in bls]))
-            model_antpos = {ant: pos for antpos in hdm.antpos.values() for ant, pos in antpos.items()}
+            model_antpos = {ant: pos for antpos in hdm.data_antpos.values() for ant, pos in antpos.items()}
 
         # match integrations in model to integrations in data
         all_data_times, all_data_lsts = get_all_times_and_lsts(hd, solar_horizon=data_solar_horizon, unwrap=True)
@@ -3542,7 +3542,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
                 # figure out which baselines to load from the data and the model and their correspondence (if one or both is redundantly averaged)
                 (data_bl_to_load,
                  model_bl_to_load,
-                 data_to_model_bl_map) = match_baselines(hd.bls, model_bls, hd.antpos, model_antpos=model_antpos, pols=[pol],
+                 data_to_model_bl_map) = match_baselines(hd.bls, model_bls, hd.data_antpos, model_antpos=model_antpos, pols=[pol],
                                                          data_is_redsol=data_is_redsol, model_is_redundant=model_is_redundant,
                                                          tol=tol, min_bl_cut=min_bl_cut, max_bl_cut=max_bl_cut, verbose=verbose)
                 if (len(data_bl_to_load) == 0) or (len(model_bl_to_load) == 0):
@@ -3589,7 +3589,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
                             # build data weights based on inverse noise variance and nsamples and flags
                             data_wgts = build_data_wgts(flags, nsamples, model_flags, autocorrs, auto_flags,
                                                         times_by_bl=hd.times_by_bl, df=np.median(np.ediff1d(data.freqs)),
-                                                        data_is_redsol=data_is_redsol, gain_flags=rc_flags_subset, antpos=hd.antpos)
+                                                        data_is_redsol=data_is_redsol, gain_flags=rc_flags_subset, antpos=hd.data_antpos)
 
                             # run absolute calibration to get the gain updates
                             delta_gains = post_redcal_abscal(model, data, data_wgts, rc_flags_subset, edge_cut=edge_cut, tol=tol,
@@ -3599,7 +3599,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
                             calibrate_in_place(autocorrs, delta_gains)
                             chisq_wgts = build_data_wgts(flags, nsamples, model_flags, autocorrs, auto_flags,
                                                          times_by_bl=hd.times_by_bl, df=np.median(np.ediff1d(data.freqs)),
-                                                         data_is_redsol=data_is_redsol, gain_flags=rc_flags_subset, antpos=hd.antpos)
+                                                         data_is_redsol=data_is_redsol, gain_flags=rc_flags_subset, antpos=hd.data_antpos)
                             total_qual, nObs, quals, nObs_per_ant = utils.chisq(data, model, chisq_wgts,
                                                                                 gain_flags=rc_flags_subset, split_by_antpol=True)
 

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -325,7 +325,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         for attribute, value in kwargs.items():
             hd.__setattr__(attribute, value)
         if redundant_average or redundant_solution:
-            all_reds = redcal.get_reds(hd.antpos, pols=hd.pols, bl_error_tol=bl_error_tol, include_autos=True)
+            all_reds = redcal.get_reds(hd.data_antpos, pols=hd.pols, bl_error_tol=bl_error_tol, include_autos=True)
         else:
             all_reds = []
         if redundant_average:
@@ -391,10 +391,10 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
     # full data loading and writing
     else:
         data, data_flags, data_nsamples = hd.read(frequencies=freqs_to_load)
-        antpos = hd.get_metadata_dict()['antpos']
+        data_antpos = hd.get_metadata_dict()['data_antpos']
         pols = hd.get_metadata_dict()['pols']
         if redundant_average or redundant_solution:
-            all_reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol, include_autos=True)
+            all_reds = redcal.get_reds(data_antpos, pols=pols, bl_error_tol=bl_error_tol, include_autos=True)
         else:
             all_reds = []
         if redundant_average:

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -61,7 +61,8 @@ class DataContainer:
             self._pols = set([k[-1] for k in self._data.keys()])
 
             # placeholders for metadata (or get them from data, if possible)
-            for attr in ['antpos', 'freqs', 'times', 'lsts', 'times_by_bl', 'lsts_by_bl']:
+            for attr in ['ants', 'data_ants', 'antpos', 'data_antpos', 
+                         'freqs', 'times', 'lsts', 'times_by_bl', 'lsts_by_bl']:
                 if hasattr(data, attr):
                     setattr(self, attr, getattr(data, attr))
                 else:

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -695,23 +695,23 @@ class HERAData(UVData):
                     raise NotImplementedError('Redundant group iteration without explicitly setting antpos for filetype ' + self.filetype
                                               + ' without setting antpos has not been implemented.')
 
-                # generate antpos dict to feed into get_reds
+                # generate data_antpos dict to feed into get_reds
                 # that accounts for possibility that
                 # HERAData was initialized from multiple
-                # files in which case self.antpos is a dict of dicts.
+                # files in which case self.data_antpos is a dict of dicts.
                 if len(self.filepaths) > 1:
-                    antpos = {}
-                    for k in self.antpos:
-                        antpos.update(self.antpos[k])
+                    data_antpos = {}
+                    for k in self.data_antpos:
+                        data_antpos.update(self.data_antpos[k])
                     pols = set({})
                     for k in self.pols:
                         pols.union(set(self.pols[k]))
                     pols = list(pols)
                 else:
-                    antpos = self.antpos
+                    data_antpos = self.data_antpos
                     pols = self.pols
 
-                reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol,
+                reds = redcal.get_reds(data_antpos, pols=pols, bl_error_tol=bl_error_tol,
                                        include_autos=include_autos)
             # filter reds by baselines
             reds = redcal.filter_reds(reds, bls=bls)

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -239,11 +239,12 @@ class HERAData(UVData):
     spaced in the underlying data_array.
     '''
     # static list of useful metadata to calculate and save
-    HERAData_metas = ['ants', 'data_ants', 'antpos', 'freqs', 'times', 'lsts',
+    HERAData_metas = ['ants', 'data_ants', 'antpos', 'data_antpos', 'freqs', 'times', 'lsts',
                       'pols', 'antpairs', 'bls', 'times_by_bl', 'lsts_by_bl']
     # ants: list of antenna numbers in the array
     # data_ants: list of antenna numbers in the data file
     # antpos: dictionary mapping all antenna numbers in the telescope to np.arrays of position in meters
+    # data_antpos: dictionary mapping all antenna numbers in the data to np.arrays of position in meters
     # freqs: np.arrray of frequencies (Hz)
     # times: np.array of unique times in the data file (JD)
     # lsts: np.array of unique LSTs in the data file (radians)
@@ -321,8 +322,9 @@ class HERAData(UVData):
             metadata_dict: dictionary of all items in self.HERAData_metas
         '''
         antpos, ants = self.get_ENU_antpos(pick_data_ants=False)
-        antpos = odict(zip(ants, antpos))
+        antpos = dict(zip(ants, antpos))
         data_ants = np.unique(np.concatenate((self.ant_1_array, self.ant_2_array)))
+        data_antpos = {ant: antpos[ant] for ant in data_ants}
 
         freqs = np.unique(self.freq_array)
         times = np.unique(self.time_array)
@@ -431,7 +433,7 @@ class HERAData(UVData):
 
         # store useful metadata inside the DataContainers
         for dc in [data, flags, nsamples]:
-            for attr in ['antpos', 'freqs', 'times', 'lsts', 'times_by_bl', 'lsts_by_bl']:
+            for attr in ['ants', 'data_ants', 'antpos', 'data_antpos', 'freqs', 'times', 'lsts', 'times_by_bl', 'lsts_by_bl']:
                 setattr(dc, attr, copy.deepcopy(meta[attr]))
 
         return data, flags, nsamples

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -1084,6 +1084,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         data_flags.times_by_bl = {bl[:2]: np.arange(3) / 86400 for bl in bls}
         data_flags.freqs = np.arange(4)
         data_flags.antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0])}
+        data_flags.data_antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0])}
         data_nsamples = DataContainer({bl: np.ones((3, 4), dtype=float) for bl in bls})
         data_nsamples[(0, 1, 'ee')][1, 1] = 2
         model_flags = data_flags
@@ -1113,6 +1114,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         data_flags.times_by_bl = {bl[:2]: np.arange(3) / 86400 for bl in bls}
         data_flags.freqs = np.arange(4)
         data_flags.antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0]), 3: np.array([30, 0, 0])}
+        data_flags.data_antpos = {0: np.array([0, 0, 0]), 1: np.array([10, 0, 0]), 2: np.array([20, 0, 0]), 3: np.array([30, 0, 0])}
         data_nsamples = DataContainer({bl: np.ones((3, 4), dtype=float) for bl in bls})
         data_nsamples[(0, 1, 'ee')] *= 3
         data_nsamples[(0, 2, 'ee')] *= 2

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -331,8 +331,12 @@ class Test_HERAData(object):
             assert isinstance(dc, DataContainer)
             for k in dc.antpos.keys():
                 assert np.all(dc.antpos[k] == hd.antpos[k])
+            assert len(dc.antpos) == 52
+            assert len(hd.antpos) == 52
             for k in dc.data_antpos.keys():
                 assert np.all(dc.data_antpos[k] == hd.data_antpos[k])
+            assert len(dc.data_antpos) == 2
+            assert len(hd.data_antpos) == 2
             assert np.all(dc.freqs == hd.freqs)
             assert np.all(dc.times == hd.times)
             assert np.all(dc.lsts == hd.lsts)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -331,6 +331,8 @@ class Test_HERAData(object):
             assert isinstance(dc, DataContainer)
             for k in dc.antpos.keys():
                 assert np.all(dc.antpos[k] == hd.antpos[k])
+            for k in dc.data_antpos.keys():
+                assert np.all(dc.data_antpos[k] == hd.data_antpos[k])
             assert np.all(dc.freqs == hd.freqs)
             assert np.all(dc.times == hd.times)
             assert np.all(dc.lsts == hd.lsts)


### PR DESCRIPTION
This PR follows up on #691, adding a new attribute `data_antpos` to HERAData and DataContainer objects. `data_antpos` is to `antpos` as `data_ants` is to `ants`.

This PR also fixes a number of places in the repo where antenna positions were used (most notably to get a list of lists of redundant baselines) where we really meant to use just the antennas in the data.

 I'm not 100% sure that I've found all the problems introduced by the change in the correlator, since a lot of our testing files have antpos matching data_antpos. I think It's probably best to just give things a shot and see if anything breaks.

Also, I accidentally committed all these changes to master instead of to this branch. So I reverted all the changes on master and then re-reverted them on this branch.