### PR TITLE
prevent dropping of integrations that straddle file boundaries.

### DIFF
--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1828,11 +1828,13 @@ def time_chunk_from_baseline_chunks(time_chunk_template, baseline_chunk_files, o
         hd_time_chunk.write_uvh5(outfilename, clobber=clobber)
     else:
         dt_time_chunk = np.mean(np.diff(hd_time_chunk.times)) / 2.
-        dt_baseline_chunk = np.mean(np.diff(hd_baseline_chunk.times)) / 2.
         tmax = hd_time_chunk.times.max() + dt_time_chunk
         tmin = hd_time_chunk.times.min() - dt_time_chunk
         hd_combined = io.HERAData(baseline_chunk_files)
-        t_select = (hd_baseline_chunk.times - dt_baseline_chunk / 2. >= tmin) & (hd_baseline_chunk.times + dt_baseline_chunk / 2. <= tmax)
+        # we only compare centers of baseline files to time limits of time-file.
+        # this is to prevent integrations that straddle file boundaries from being dropped.
+        # when we perform reconstitution.
+        t_select = (hd_baseline_chunk.times >= tmin) & (hd_baseline_chunk.times <= tmax)
         hd_combined.read(times=hd_baseline_chunk.times[t_select], axis='blt')
         hd_combined.write_uvh5(outfilename, clobber=clobber)
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1834,7 +1834,7 @@ def time_chunk_from_baseline_chunks(time_chunk_template, baseline_chunk_files, o
         # we only compare centers of baseline files to time limits of time-file.
         # this is to prevent integrations that straddle file boundaries from being dropped.
         # when we perform reconstitution.
-        t_select = (hd_baseline_chunk.times >= tmin) & (hd_baseline_chunk.times <= tmax)
+        t_select = (hd_baseline_chunk.times >= tmin) & (hd_baseline_chunk.times < tmax)
         hd_combined.read(times=hd_baseline_chunk.times[t_select], axis='blt')
         hd_combined.write_uvh5(outfilename, clobber=clobber)
 


### PR DESCRIPTION
The current implementation of `time_chunk_from_baseline_chunks` that uses the time boundaries of a file to perform the baseline -> time cornerturn; a mode that is necessary when we do the reverse cornerturn on time-averaged / fringe-rate-filtered files compares the edges of the template data and the edges of the baseline waterfall data bins to determine which data to keep in which files. This approach can actually lead to integrations that straddle file boundaries to not be included in any of the final data.

To avoid this, we instead compare the center times of the baseline file bins to the min/max times in the template files.