### PR TITLE
Fix bug in logic for lst_stop in config_lst_bin_files

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -468,9 +468,6 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
         lst_arrays.append(larrs)
         time_arrays.append(tarrs)
 
-    lst_arrays = np.asarray(lst_arrays)
-    time_arrays = np.asarray(time_arrays)
-
     # get starting LST for output binning
     if lst_start is None:
         lst_start = lmin

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -638,9 +638,9 @@ def lst_bin_files(data_files, input_cals=None, dlst=None, verbose=True, ntimes_p
                     larr[larr < larr[0]] += 2 * np.pi
 
                     # phase wrap larr to get it to fall within 2pi of file_lists
-                    while larr[-1] < fmin - 2 * np.pi:
+                    while larr[0] + 2 * np.pi < fmax:
                         larr += 2 * np.pi
-                    while larr[0] > fmax + 2 * np.pi:
+                    while larr[-1] - 2 * np.pi > fmin:
                         larr -= 2 * np.pi
 
                     # check if this file has overlap with output file

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -490,9 +490,8 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
     # get stopping LST for output binning
     if lst_stop is None:
         lst_stop = lmax
-    else:
-        if lst_stop < begin_lst:
-            lst_stop += 2 * np.pi
+    if lst_stop < begin_lst:
+        lst_stop += 2 * np.pi
 
     # make LST grid
     lst_grid = make_lst_grid(dlst, begin_lst=begin_lst, verbose=verbose)

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -637,6 +637,12 @@ def lst_bin_files(data_files, input_cals=None, dlst=None, verbose=True, ntimes_p
                     tarr = time_arrs[j][k]
                     larr[larr < larr[0]] += 2 * np.pi
 
+                    # phase wrap larr to get it to fall within 2pi of file_lists
+                    while larr[-1] < fmin - 2 * np.pi:
+                        larr += 2 * np.pi
+                    while larr[0] > fmax + 2 * np.pi:
+                        larr -= 2 * np.pi
+
                     # check if this file has overlap with output file
                     if larr[-1] < fmin or larr[0] > fmax:
                         continue
@@ -671,7 +677,7 @@ def lst_bin_files(data_files, input_cals=None, dlst=None, verbose=True, ntimes_p
                     file_list.append(data_files[j][k])
                     nightly_data_list.append(data)  # this is data
                     nightly_flgs_list.append(flags)  # this is flgs
-                    nightly_lst_list.append(larr[tinds])  # this is lsts
+                    nightly_lst_list.append(data.lsts)  # this is lsts
 
                 # skip if nothing accumulated in nightly files
                 if len(nightly_data_list) == 0:


### PR DESCRIPTION
When `lst_stop < begin_lst` but `lst_stop` is inferred from the files instead of provided directly (as is the case in using a lstbin toml in hera_opm), then there's no opportunity to increment lst_stop by 2pi. 

In trying to LST-bin h1c_idr3 epoch 2, this lead to lst_stop being before lst_start, and thus no wrapper scripts being produced by build_makeflow_from_config.sh.

I've also removed an unnecessary casting of a list to an array that produces the following deprecation warning:
```VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray```

EDIT:
The above didn't quite work, I think because now the `file_lsts` and the `lst_arrays` are over 2 pi out of phase. I think this PR also fixes that, but it's tricky to unittest and so I'm trying it with real data.