### PR TITLE
Handle baseline -> time cornerturn when on data falls within the time limits of the template file.

### DIFF
--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -935,3 +935,6 @@ class Test_VisClean(object):
         assert np.all(np.isclose(hd.data_array, hd_reconstituted.data_array))
         assert np.all(np.isclose(hd.flag_array, hd_reconstituted.flag_array))
         assert np.all(np.isclose(hd.nsample_array, hd_reconstituted.nsample_array))
+        # check warning.
+        with pytest.warns(RuntimeWarning):
+            vis_clean.time_chunk_from_baseline_chunks(datafiles[0], baseline_chunk_files=datafiles[1:], clobber=True, outfilename=str(tmp_path / fname), time_bounds=True)

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1835,8 +1835,12 @@ def time_chunk_from_baseline_chunks(time_chunk_template, baseline_chunk_files, o
         # this is to prevent integrations that straddle file boundaries from being dropped.
         # when we perform reconstitution.
         t_select = (hd_baseline_chunk.times >= tmin) & (hd_baseline_chunk.times < tmax)
-        hd_combined.read(times=hd_baseline_chunk.times[t_select], axis='blt')
-        hd_combined.write_uvh5(outfilename, clobber=clobber)
+        if np.count_nonzero(t_select) > 0:
+            hd_combined.read(times=hd_baseline_chunk.times[t_select], axis='blt')
+            hd_combined.write_uvh5(outfilename, clobber=clobber)
+        else:
+            warnings.warn("no times selected. No outputfile produced.", RuntimeWarning)
+
 
 
 def time_chunk_from_baseline_chunks_argparser():

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1835,7 +1835,7 @@ def time_chunk_from_baseline_chunks(time_chunk_template, baseline_chunk_files, o
         # this is to prevent integrations that straddle file boundaries from being dropped.
         # when we perform reconstitution.
         t_select = (hd_baseline_chunk.times >= tmin) & (hd_baseline_chunk.times < tmax)
-        if np.count_nonzero(t_select) > 0:
+        if np.any(t_select):
             hd_combined.read(times=hd_baseline_chunk.times[t_select], axis='blt')
             hd_combined.write_uvh5(outfilename, clobber=clobber)
         else:


### PR DESCRIPTION
Handle situation in baseline_chunk_to_time_chunk where the baseline chunk has no times within the bounds of the template time chunk file by raising a warning and not writing any output.