### PR TITLE
Add zeropad kwarg to filter scripts

### DIFF
--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1684,6 +1684,7 @@ def _filter_argparser():
                                                                     "Warning: Providing this file will result in outputs with significantly different structure "
                                                                     "then inputs. Only use it if you know what you are doing. Default is None.")
     a.add_argument("--partial_load_Nbls", default=None, type=int, help="the number of baselines to load at once (default None means load full data")
+    a.add_argument("--zeropad", default=None, type=int, help="number of bins to zeropad on both sides of FFT axis")
     a.add_argument("--skip_wgt", type=float, default=0.1, help='skips filtering and flags times with unflagged fraction ~< skip_wgt (default 0.1)')
     a.add_argument("--factorize_flags", default=False, action="store_true", help="Factorize flags.")
     a.add_argument("--time_thresh", type=float, default=0.05, help="time threshold above which to completely flag channels and below which to flag times with flagged channel.")

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -13,7 +13,7 @@ a = parser.parse_args()
 
 # set kwargs
 if a.mode == 'clean':
-    filter_kwargs = {'window': a.window,
+    filter_kwargs = {'window': a.window, 
                      'maxiter': a.maxiter, 'edgecut_hi': a.edgecut_hi,
                      'edgecut_low': a.edgecut_low, 'min_dly': a.min_dly, 'gain': a.gain}
     if a.window == 'tukey':
@@ -38,7 +38,7 @@ elif a.mode == 'dpss_leastsq':
     flag_model_rms_outliers = True
 else:
     raise ValueError(f"mode {mode} not supported.")
-
+filter_kwargs['zeropad'] = a.zeropad
 
 if args.cornerturnfile is not None:
     baseline_list = io.baselines_from_filelist_position(filename=a.cornerturnfile, filelist=a.datafilelist)

--- a/scripts/xtalk_filter_run.py
+++ b/scripts/xtalk_filter_run.py
@@ -39,7 +39,7 @@ elif a.mode == 'dpss_leastsq':
     skip_flagged_edges = True
     max_contiguous_edge_flags = 1
     flag_model_rms_outliers = True
-
+filter_kwargs['zeropad'] = a.zeropad
 
 if args.cornerturnfile is not None:
     baseline_list = io.baselines_from_filelist_position(filename=a.cornerturnfile, filelist=a.datafilelist)


### PR DESCRIPTION
This PR allows the `zeropad` kwarg for delay/xtalk filtering to be accessed via the command line (though only as a single integer, not as a tuple).