### PR TITLE
Create simple redundant averaging script

### DIFF
--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -7,7 +7,7 @@
 
 import sys
 import argparse
-from hera_cal import io, utils
+from hera_cal import io, utils, redcal
 
 # Parse arguments
 a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")

--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2019 the HERA Project
+# Licensed under the MIT License
+
+"""Command-line script for redundant averaging of (calibrated) data. To calibrate and then average, try apply_cal.py"""
+
+import sys
+import argparse
+from hera_cal import io, utils
+
+# Parse arguments
+a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")
+a.add_argument("infilename", type=str, help="path to visibility data file to calibrate") 
+a.add_argument("outfilename", type=str, help="path to new visibility results file")
+a.add_argument("--bl_error_tol", type=float, default=1.0, help="Baseline redundancy tolerance in meters.")
+a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
+args = a.parse_args()
+
+# Load data
+hd = io.HERAData(args.infilename)
+hd.read()
+
+# Redundantly average
+reds = redcal.get_reds(hd.data_antpos, pols=hd.pols[0], bl_error_tol=args.bl_error_tol, include_autos=True)
+utils.red_average(hd, reds=reds, inplace=True)
+
+# Write data
+hd.write_uvh5(args.outfilename, clobber=args.clobber)

--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -22,7 +22,7 @@ hd = io.HERAData(args.infilename)
 hd.read()
 
 # Redundantly average
-reds = redcal.get_reds(hd.data_antpos, pols=[hd.pols[0]], bl_error_tol=args.bl_error_tol, include_autos=True)
+reds = redcal.get_pos_reds(hd.data_antpos, bl_error_tol=args.bl_error_tol, include_autos=True)
 utils.red_average(hd, reds=reds, inplace=True)
 
 # Write data

--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2019 the HERA Project
+# Copyright 2021 the HERA Project
 # Licensed under the MIT License
 
 """Command-line script for redundant averaging of (calibrated) data. To calibrate and then average, try apply_cal.py"""
@@ -10,12 +10,12 @@ import argparse
 from hera_cal import io, utils, redcal
 
 # Parse arguments
-a = argparse.ArgumentParser(description="Redundantly average a data file that's already been calibrated.")
-a.add_argument("infilename", type=str, help="path to visibility data file to redundantly average") 
-a.add_argument("outfilename", type=str, help="path to new visibility results file")
-a.add_argument("--bl_error_tol", type=float, default=1.0, help="Baseline redundancy tolerance in meters.")
-a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
-args = a.parse_args()
+ap = argparse.ArgumentParser(description="Redundantly average a data file that's already been calibrated.")
+ap.add_argument("infilename", type=str, help="path to visibility data file to redundantly average") 
+ap.add_argument("outfilename", type=str, help="path to new visibility results file")
+ap.add_argument("--bl_error_tol", type=float, default=1.0, help="Baseline redundancy tolerance in meters.")
+ap.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
+args = ap.parse_args()
 
 # Load data
 hd = io.HERAData(args.infilename)

--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -22,7 +22,7 @@ hd = io.HERAData(args.infilename)
 hd.read()
 
 # Redundantly average
-reds = redcal.get_reds(hd.data_antpos, pols=hd.pols[0], bl_error_tol=args.bl_error_tol, include_autos=True)
+reds = redcal.get_reds(hd.data_antpos, pols=[hd.pols[0]], bl_error_tol=args.bl_error_tol, include_autos=True)
 utils.red_average(hd, reds=reds, inplace=True)
 
 # Write data

--- a/scripts/red_average.py
+++ b/scripts/red_average.py
@@ -10,8 +10,8 @@ import argparse
 from hera_cal import io, utils, redcal
 
 # Parse arguments
-a = argparse.ArgumentParser(description="Apply (and optionally, also unapply) a calfits file to visibility file.")
-a.add_argument("infilename", type=str, help="path to visibility data file to calibrate") 
+a = argparse.ArgumentParser(description="Redundantly average a data file that's already been calibrated.")
+a.add_argument("infilename", type=str, help="path to visibility data file to redundantly average") 
 a.add_argument("outfilename", type=str, help="path to new visibility results file")
 a.add_argument("--bl_error_tol", type=float, default=1.0, help="Baseline redundancy tolerance in meters.")
 a.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_args = {
                 'scripts/lstbin_run.py', 'scripts/extract_autos.py',
                 'scripts/smooth_cal_run.py', 'scripts/redcal_run.py',
                 'scripts/auto_reflection_run.py', 'scripts/noise_from_autos.py',
-                'scripts/query_ex_ants.py',
+                'scripts/query_ex_ants.py', 'scripts/red_average.py',
                 'scripts/xtalk_filter_run.py',
                 'scripts/time_chunk_from_baseline_chunks_run.py', 'scripts/chunk_files.py'],
     'version': version.version,


### PR DESCRIPTION
This PR creates a very simple script for redundantly averaging data that's already been calibrated. Possible future improvements include better memory management via partial i/o and/or moving parts of this script into its own unit-tested module.