### PR TITLE
Fix delay filter script to not pass in certain arguments in CLEAN mode

### DIFF
--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -19,23 +19,21 @@ if ap.mode == 'clean':
     if ap.window == 'tukey':
         filter_kwargs['alpha'] = ap.alpha
     avg_red_bllens = False
-    skip_gaps_larger_then_filter_period = False
     skip_flagged_edges = False
-    max_contiguous_edge_flags = 10000
     flag_model_rms_outliers = False
 elif ap.mode == 'dayenu':
     filter_kwargs = {}
     avg_red_bllens = True
-    skip_gaps_larger_then_filter_period = False
-    max_contiguous_edge_flags = 10000
-    flag_model_rms_outliers = False
+    filter_kwargs['skip_gaps_larger_then_filter_period'] = False
+    filter_kwargs['max_contiguous_edge_flags'] = 10000
+    filter_kwargs['flag_model_rms_outliers'] = False
 elif ap.mode == 'dpss_leastsq':
     filter_kwargs = {}
     avg_red_bllens = True
-    skip_gaps_larger_then_filter_period = True
+    filter_kwargs['skip_gaps_larger_then_filter_period'] = True
     skip_flagged_edges = True
-    max_contiguous_edge_flags = 1
-    flag_model_rms_outliers = True
+    filter_kwargs['max_contiguous_edge_flags'] = 1
+    filter_kwargs['flag_model_rms_outliers'] = True
 else:
     raise ValueError(f"mode {mode} not supported.")
 
@@ -54,15 +52,12 @@ delay_filter.load_delay_filter_and_write(ap.datafilelist, calfile_list=ap.calfil
                                          clobber=ap.clobber, write_cache=ap.write_cache, external_flags=ap.external_flags,
                                          read_cache=ap.read_cache, mode=ap.mode, overwrite_flags=ap.overwrite_flags,
                                          factorize_flags=ap.factorize_flags, time_thresh=ap.time_thresh,
-                                         max_contiguous_edge_flags=max_contiguous_edge_flags,
                                          add_to_history=' '.join(sys.argv), polarizations=ap.polarizations,
                                          verbose=ap.verbose, skip_if_flag_within_edge_distance=ap.skip_if_flag_within_edge_distance,
                                          flag_yaml=ap.flag_yaml, Nbls_per_load=ap.Nbls_per_load,
-                                         skip_contiguous_flags=skip_gaps_larger_then_filter_period,
                                          skip_flagged_edges=skip_flagged_edges,
                                          filled_outfilename=ap.filled_outfilename,
                                          CLEAN_outfilename=ap.CLEAN_outfilename,
                                          standoff=ap.standoff, horizon=ap.horizon, tol=ap.tol,
                                          skip_wgt=ap.skip_wgt, min_dly=ap.min_dly, zeropad=ap.zeropad,
-                                         flag_model_rms_outliers=flag_model_rms_outliers,
                                          clean_flags_in_resid_flags=True, **filter_kwargs)


### PR DESCRIPTION
I'm getting the following error. Hopefully this will fix it.

```delay_filter_run.py zen.grp1.of1.LST.4.62939.sum.red_avg.uvh5 --res_outfilename zen.grp1.of1.LST.4.62939.sum.red_avg.residual.uvh5 --CLEAN_outfilename zen.grp1.of1.LST.4.62939.sum.red_avg.CLEAN.u
vh5 --standoff 2000 --horizon 0 --tol 1e-06 --skip_wgt 0.1 --window tukey --maxiter 100 --alpha 0.1 --zeropad 256 --Nbls_per_load 100 --clobber
LST values stored in zen.grp1.of1.LST.4.62939.sum.red_avg.uvh5 are not self-consistent with time_array and telescope location. Consider recomputing with utils.get_lst_for_time.
Selected polarization values are not evenly spaced. This will make it impossible to write this data out to some file types
Traceback (most recent call last):
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/bin/delay_filter_run.py", line 68, in <module>
    clean_flags_in_resid_flags=True, **filter_kwargs)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/hera_cal/delay_filter.py", line 182, in load_delay_filter_and_write
    skip_flagged_edges=skip_flagged_edges, **filter_kwargs)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/hera_cal/delay_filter.py", line 87, in run_delay_filter
    skip_flagged_edges=skip_flagged_edges, **filter_kwargs)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/hera_cal/vis_clean.py", line 652, in vis_clean
    overwrite=overwrite, **filter_kwargs)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/hera_cal/vis_clean.py", line 965, in fourier_filter
    **filter_kwargs)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/uvtools/dspec.py", line 431, in fourier_filter
    _process_filter_kwargs(filter_kwargs, defaults)
  File "/lustre/aoc/projects/hera/heramgr/anaconda2/envs/h1c_idr3/lib/python3.7/site-packages/uvtools/dspec.py", line 62, in _process_filter_kwargs
    "valid arguments include %s"%(list(default_dict.keys())))
ValueError: max_contiguous_edge_flags is not a valid argument!valid arguments include ['tol', 'window', 'alpha', 'maxiter', 'gain', 'edgecut_low', 'edgecut_hi', 'add_clean_residual', 'filt2d_mode
']
Fri Apr 16 19:30:00 MDT 2021```