### PR TITLE
Fix blaveraging bug

### DIFF
--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -284,7 +284,7 @@ class VisClean(object):
 
         # iterate over redundancies
         for red in reds:
-            avg_vec = np.mean([self.blvecs[r] for r in red], axis=0)
+            avg_vec = np.mean([self.blvecs[r] for r in red if r in self.blvecs], axis=0)
             for r in red:
                 self.blvecs[r] = avg_vec.copy()
                 self.bllens[r] = np.linalg.norm(avg_vec) / constants.c.value


### PR DESCRIPTION
depends on #710. Fix line in red baseline group averaging that will throw an error if the VisClean objects data set does not contain all of the baselines in the array.