### PR TITLE
Throw away baselines

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1855,7 +1855,8 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
             Default is False.
     Returns
     -------
-        N/A
+        hd: HERAData object
+            HERAData object containing data from infilename with baselines thrown out. 
 
     """
     hd = HERAData(infilename)
@@ -1888,6 +1889,7 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
     history_string += f"Also threw out {antpairs_not_to_keep} because data was fully flagged.\n"
     hd.history += version.history_string(notes=history_string)
     hd.write_uvh5(outfilename, clobber=clobber)
+    return hd
 
 
 def throw_away_flagged_ants_parser():

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -20,6 +20,7 @@ import glob
 from pyuvdata.utils import POL_STR2NUM_DICT
 from . import redcal
 import argparse
+import version
 
 try:
     import aipy
@@ -1870,13 +1871,22 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
     # Write data
     if throw_away_fully_flagged_data_baselines:
         antpairs_to_keep = []
+        antpairs_not_to_keep = []
         for antpair in hd.get_antpairs():
             fully_flagged = True
             for pol in hd.pols:
                 fully_flagged = fully_flagged & np.all(hd.get_flags(antpair + (pol, )))
             if not fully_flagged:
                 antpairs_to_keep.append(antpair)
+            else:
+                antpairs_not_to_keep.append(antpair)
         hd.select(bls=antpairs_to_keep)
+    else:
+        antpairs_not_to_keep = None
+    # wite to history.
+    history_string = f"Threw away flagged antennas from yaml_file={a_priori_flag_yaml} using throw_away_flagged_ants.\n"
+    history_string += f"Also threw out {antpairs_not_to_keep} because data was fully flagged.\n"
+    hd.history += version.history_string(notes=history_string)
     hd.write_uvh5(outfilename, clobber=clobber)
 
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1885,7 +1885,7 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
     else:
         antpairs_not_to_keep = None
     # wite to history.
-    history_string = f"Threw away flagged antennas from yaml_file={a_priori_flag_yaml} using throw_away_flagged_ants.\n"
+    history_string = f"Threw away flagged antennas from yaml_file={yaml_file} using throw_away_flagged_ants.\n"
     history_string += f"Also threw out {antpairs_not_to_keep} because data was fully flagged.\n"
     hd.history += version.history_string(notes=history_string)
     hd.write_uvh5(outfilename, clobber=clobber)

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1882,7 +1882,7 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
 
 def throw_away_flagged_ants_parser():
     # Parse arguments
-    ap = argparse.ArgumentParser(description="Throw away baselines whose antennas are flagged in a yaml file or whose.")
+    ap = argparse.ArgumentParser(description="Throw away baselines whose antennas are flagged in a yaml file or which have all integrations/chans flagged.")
     ap.add_argument("infilename", type=str, help="path to visibility data to completely flag.")
     ap.add_argument("outfilename", type=str, help="path to new visibility file to write out completely flagged data.")
     ap.add_argument("--yaml_file", default=None, type=str, help='yaml file with list of antennas to throw away.')

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1883,8 +1883,8 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
 def throw_away_flagged_ants_parser():
     # Parse arguments
     ap = argparse.ArgumentParser(description="Throw away baselines whose antennas are flagged in a yaml file or which have all integrations/chans flagged.")
-    ap.add_argument("infilename", type=str, help="path to visibility data to completely flag.")
-    ap.add_argument("outfilename", type=str, help="path to new visibility file to write out completely flagged data.")
+    ap.add_argument("infilename", type=str, help="path to visibility data throw out flagged baselines..")
+    ap.add_argument("outfilename", type=str, help="path to new visibility file to write data with thrown out baselines..")
     ap.add_argument("--yaml_file", default=None, type=str, help='yaml file with list of antennas to throw away.')
     ap.add_argument("--throw_away_fully_flagged_data_baselines", default=False, action="store_true",
                     help="Also throw away baselines that have all channels and integrations flagged.")

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -20,7 +20,7 @@ import glob
 from pyuvdata.utils import POL_STR2NUM_DICT
 from . import redcal
 import argparse
-import version
+from . import version
 
 try:
     import aipy
@@ -1856,7 +1856,7 @@ def throw_away_flagged_ants(infilename, outfilename, yaml_file=None, throw_away_
     Returns
     -------
         hd: HERAData object
-            HERAData object containing data from infilename with baselines thrown out. 
+            HERAData object containing data from infilename with baselines thrown out.
 
     """
     hd = HERAData(infilename)

--- a/scripts/throw_away_flagged_antennas.py
+++ b/scripts/throw_away_flagged_antennas.py
@@ -12,4 +12,4 @@ from hera_cal import io
 
 ap = io.throw_away_flagged_ants_parser()
 args = ap.parse_args()
-ap = io.throw_away_flagged_ants(**vars(args))
+io.throw_away_flagged_ants(**vars(args))

--- a/scripts/throw_away_flagged_antennas.py
+++ b/scripts/throw_away_flagged_antennas.py
@@ -8,26 +8,8 @@
 import sys
 import argparse
 from hera_cal import io
-from hera_qm import utils
-
-# Parse arguments
-ap = argparse.ArgumentParser(description="Completely Flag a data file.")
-ap.add_argument("infilename", type=str, help="path to visibility data to completely flag.")
-ap.add_argument("outfilename", type=str, help="path to new visibility file to write out completely flagged data")
-ap.add_argument("--yaml_file", default=False, action="store_true", help='overwrites existing file at outfile')
-ap.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
 
 
-
+ap = io.throw_away_flagged_ants_parser()
 args = ap.parse_args()
-
-# Load data
-hd = io.HERAData(args.infilename)
-hd.read()
-
-#throw away flagged antennas in yaml file.
-utils.apply_yaml_flags(uv=hd, a_priori_flag_yaml=ap.yaml_file,
-                       ant_indices_only=True, flag_ants=True, flag_freqs=False, flag_times=False, throw_away_flagged_ants=True)
-
-# Write data
-hd.write_uvh5(args.outfilename, clobber=args.clobber)
+ap = io.throw_away_flagged_ants_parser(**vars(args))

--- a/scripts/throw_away_flagged_antennas.py
+++ b/scripts/throw_away_flagged_antennas.py
@@ -12,4 +12,4 @@ from hera_cal import io
 
 ap = io.throw_away_flagged_ants_parser()
 args = ap.parse_args()
-ap = io.throw_away_flagged_ants_parser(**vars(args))
+ap = io.throw_away_flagged_ants(**vars(args))

--- a/scripts/throw_away_flagged_antennas.py
+++ b/scripts/throw_away_flagged_antennas.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2021 the HERA Project
+# Licensed under the MIT License
+
+"""Command-line script for throw away all data with apriori flags. Saves downstream I/O, memory etc..."""
+
+import sys
+import argparse
+from hera_cal import io
+from hera_qm import utils
+
+# Parse arguments
+ap = argparse.ArgumentParser(description="Completely Flag a data file.")
+ap.add_argument("infilename", type=str, help="path to visibility data to completely flag.")
+ap.add_argument("outfilename", type=str, help="path to new visibility file to write out completely flagged data")
+ap.add_argument("--yaml_file", default=False, action="store_true", help='overwrites existing file at outfile')
+ap.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
+
+
+
+args = ap.parse_args()
+
+# Load data
+hd = io.HERAData(args.infilename)
+hd.read()
+
+#throw away flagged antennas in yaml file.
+utils.apply_yaml_flags(uv=hd, a_priori_flag_yaml=ap.yaml_file,
+                       ant_indices_only=True, flag_ants=True, flag_freqs=False, flag_times=False, throw_away_flagged_ants=True)
+
+# Write data
+hd.write_uvh5(args.outfilename, clobber=args.clobber)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_args = {
                 'scripts/query_ex_ants.py', 'scripts/red_average.py',
                 'scripts/xtalk_filter_run.py', 'scripts/time_average.py',
                 'scripts/time_chunk_from_baseline_chunks_run.py', 'scripts/chunk_files.py',
-                'scripts/flag_all.py', 'scripts/throw_away_flagged_ants.py'],
+                'scripts/flag_all.py', 'scripts/throw_away_flagged_antennas.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
     'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_args = {
                 'scripts/query_ex_ants.py', 'scripts/red_average.py',
                 'scripts/xtalk_filter_run.py', 'scripts/time_average.py',
                 'scripts/time_chunk_from_baseline_chunks_run.py', 'scripts/chunk_files.py',
-                'scripts/flag_all.py'],
+                'scripts/flag_all.py', 'scripts/throw_away_flagged_ants.py'],
     'version': version.version,
     'package_data': {'hera_cal': data_files},
     'install_requires': [


### PR DESCRIPTION
A convenient script to throw away all flagged antennas. Adding this to the beginning of RTP stage 2 can save time and space. Depends on #714 