### PR TITLE
Propagate vis units

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3566,7 +3566,7 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
         echo("The following model files overlap with data files in LST:\n" + "\n".join(matched_model_files), verbose=verbose)
         hd = io.HERAData(data_file)
         hdm = io.HERAData(matched_model_files)
-        hc.gain_scale = hdm.vis_units # set vis_units of hera_cal based on model files.
+        hc.gain_scale = hdm.vis_units  # set vis_units of hera_cal based on model files.
         hd_autos = io.HERAData(raw_auto_file)
         assert hdm.x_orientation == hd.x_orientation, 'Data x_orientation, {}, does not match model x_orientation, {}'.format(hd.x_orientation, hdm.x_orientation)
         assert hc.x_orientation == hd.x_orientation, 'Data x_orientation, {}, does not match redcal x_orientation, {}'.format(hd.x_orientation, hc.x_orientation)

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -3566,6 +3566,8 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
         echo("The following model files overlap with data files in LST:\n" + "\n".join(matched_model_files), verbose=verbose)
         hd = io.HERAData(data_file)
         hdm = io.HERAData(matched_model_files)
+        if hc.gain_scale is not None and hc.gain_scale.lower() != "uncalib":
+            warnings.warn(f"Warning: Overwriting redcal gain_scale of {hc.gain_scale} with model gain_scale of {hdm.vis_units}", RuntimeWarning)
         hc.gain_scale = hdm.vis_units  # set vis_units of hera_cal based on model files.
         hd_autos = io.HERAData(raw_auto_file)
         assert hdm.x_orientation == hd.x_orientation, 'Data x_orientation, {}, does not match model x_orientation, {}'.format(hd.x_orientation, hdm.x_orientation)

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -386,12 +386,14 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 # update redundant data. Don't partial write.
                 hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:
-                if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                    hd.vis_units = hc.gain_scale
-                if vis_units is not None:
-                    hd.vis_units = vis_units
-                # partial write works for no redundant averaging.
-                hd.partial_write(data_outfilename, inplace=True, clobber=clobber, add_to_history=add_to_history, **kwargs)
+                if vis_units is None:
+                    if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
+                        vis_units = hc.gain_scale
+                    else:
+                        vis_units = hd.vis_units
+                    # partial write works for no redundant averaging.
+                hd.partial_write(data_outfilename, inplace=True, clobber=clobber, add_to_history=add_to_history, vis_units=vis_units, **kwargs)
+
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
             if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -7,7 +7,7 @@
 import numpy as np
 import argparse
 import copy
-
+import warnings
 from . import io
 from . import version
 from . import utils
@@ -390,7 +390,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                         if hd.vis_units is not None and hc.gain_scale.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                             warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
-                                           " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
+                                          " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                         vis_units = hc.gain_scale
                     else:
                         vis_units = hd.vis_units
@@ -402,7 +402,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                 if hd.vis_units is not None and hc.gain_scale.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                     warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
-                                   " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
+                                  " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                 hd_red.vis_units = hc.gain_scale
             if vis_units is not None:
                 hd_red.vis_units = vis_units
@@ -439,7 +439,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                     if hd.vis_units is not None and hd.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                         warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
-                                       " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
+                                      " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                     vis_units = hc.gain_scale
             if vis_units is not None:
                 kwargs['vis_units'] = vis_units
@@ -490,7 +490,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                             if hd_red.vis_units is not None and hd_red.vis_units.lower() != "uncalib" and hd_red.vis_units.lower() != hc.gain_scale.lower():
                                 warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
-                                               " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
+                                              " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                             hd_red.vis_units = hc.gain_scale
                         if vis_units is not None:
                             hd_red.vis_units = vis_units

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -383,11 +383,15 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 # update redundant data. Don't partial write.
                 hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:
+                if hasattr(hc, 'gain_scale'):
+                    hd.vis_units = hc.gain_scale
                 # partial write works for no redundant averaging.
                 hd.partial_write(data_outfilename, inplace=True, clobber=clobber, add_to_history=add_to_history, **kwargs)
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
-            hd_red.write_uvh5(data_outfilename, clobber=clobber)
+            if hasattr(hc, 'gain_scale'):
+                hd_red.vis_units = hc.gain_scale
+            hd_red.write_uvh5(data_outfilename, clobber=clobber, **kwargs)
     # full data loading and writing
     else:
         data, data_flags, data_nsamples = hd.read(frequencies=freqs_to_load)
@@ -460,7 +464,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     else:
                         outfile = data_outfilename
                     if filetype_out == 'uvh5':
-                        hd_red.write_uvh5(outfile, clobber=clobber)
+                        if hasattr(hc, 'gain_scale'):
+                            hd_red.vis_units = hc.gain_scale
+                        hd_red.write_uvh5(outfile, clobber=clobber, **kwargs)
                     else:
                         raise NotImplementedError("redundant averaging only supported for uvh5 outputs.")
                 else:

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -430,8 +430,12 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             if vis_units is None:
                 if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                     vis_units = hc.gain_scale
-            io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
-                          data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs, vis_units=vis_units)
+            if vis_units is not None:
+                io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
+                              data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs, vis_units=vis_units)
+            else:
+                io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
+                              data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs)
         else:
             all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == hd.pols[0]]
             hd.update(data=data, flags=data_flags, nsamples=data_nsamples, **kwargs)

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -388,7 +388,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             else:
                 if vis_units is None:
                     if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                        if hd.vis_units is not None and hc.vis_units.lower() != "uncalib":
+                        if hd.vis_units is not None and hc.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                             warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
                                            " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                         vis_units = hc.gain_scale
@@ -400,7 +400,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
             if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                if hd.vis_units is not None and hc.vis_units.lower() != "uncalib":
+                if hd.vis_units is not None and hc.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                     warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
                                    " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                 hd_red.vis_units = hc.gain_scale
@@ -437,7 +437,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         if not redundant_average:
             if vis_units is None:
                 if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                    if hd.vis_units is not None and hd.vis_units.lower() != "uncalib":
+                    if hd.vis_units is not None and hd.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                         warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
                                        " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                     vis_units = hc.gain_scale
@@ -488,6 +488,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                         outfile = data_outfilename
                     if filetype_out == 'uvh5':
                         if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
+                            if hd_red.vis_units is not None and hd_red.vis_units.lower() != "uncalib" and hd_red.vis_units.lower() != hc.gain_scale.lower():
+                                warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
+                                               " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                             hd_red.vis_units = hc.gain_scale
                         if vis_units is not None:
                             hd_red.vis_units = vis_units

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -383,15 +383,17 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                 # update redundant data. Don't partial write.
                 hd_red.update(nsamples=data_nsamples, flags=data_flags, data=data)
             else:
-                if hasattr(hc, 'gain_scale'):
+                if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                     hd.vis_units = hc.gain_scale
                 # partial write works for no redundant averaging.
                 hd.partial_write(data_outfilename, inplace=True, clobber=clobber, add_to_history=add_to_history, **kwargs)
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
-            if hasattr(hc, 'gain_scale'):
+            if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                 hd_red.vis_units = hc.gain_scale
-            hd_red.write_uvh5(data_outfilename, clobber=clobber, **kwargs)
+            if 'vis_units' in kwargs and kwargs['vis_units'] is not None:
+                hd_red.vis_units = kwargs['vis_units']
+            hd_red.write_uvh5(data_outfilename, clobber=clobber)
     # full data loading and writing
     else:
         data, data_flags, data_nsamples = hd.read(frequencies=freqs_to_load)
@@ -464,9 +466,11 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
                     else:
                         outfile = data_outfilename
                     if filetype_out == 'uvh5':
-                        if hasattr(hc, 'gain_scale'):
+                        if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
                             hd_red.vis_units = hc.gain_scale
-                        hd_red.write_uvh5(outfile, clobber=clobber, **kwargs)
+                        if 'vis_units' in kwargs and kwargs['vis_units'] is not None:
+                            hd_red.vis_units = kwargs['vis_units']
+                        hd_red.write_uvh5(outfile, clobber=clobber)
                     else:
                         raise NotImplementedError("redundant averaging only supported for uvh5 outputs.")
                 else:

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -388,6 +388,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             else:
                 if vis_units is None:
                     if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
+                        if hd.vis_units is not None and hc.vis_units.lower() != "uncalib":
+                            warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
+                                           " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                         vis_units = hc.gain_scale
                     else:
                         vis_units = hd.vis_units
@@ -397,6 +400,9 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
             if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
+                if hd.vis_units is not None and hc.vis_units.lower() != "uncalib":
+                    warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
+                                   " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                 hd_red.vis_units = hc.gain_scale
             if vis_units is not None:
                 hd_red.vis_units = vis_units
@@ -431,13 +437,14 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         if not redundant_average:
             if vis_units is None:
                 if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
+                    if hd.vis_units is not None and hd.vis_units.lower() != "uncalib":
+                        warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
+                                       " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                     vis_units = hc.gain_scale
             if vis_units is not None:
-                io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
-                              data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs, vis_units=vis_units)
-            else:
-                io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
-                              data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs)
+                kwargs['vis_units'] = vis_units
+            io.update_vis(data_infilename, data_outfilename, filetype_in=filetype_in, filetype_out=filetype_out,
+                          data=data, flags=data_flags, add_to_history=add_to_history, clobber=clobber, **kwargs)
         else:
             all_red_antpairs = [[bl[:2] for bl in grp] for grp in all_reds if grp[-1][-1] == hd.pols[0]]
             hd.update(data=data, flags=data_flags, nsamples=data_nsamples, **kwargs)

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -388,7 +388,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
             else:
                 if vis_units is None:
                     if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                        if hd.vis_units is not None and hc.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
+                        if hd.vis_units is not None and hc.gain_scale.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                             warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
                                            " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                         vis_units = hc.gain_scale
@@ -400,7 +400,7 @@ def apply_cal(data_infilename, data_outfilename, new_calibration, old_calibratio
         if redundant_average:
             # if we did redundant averaging, just write the redundant dataset out in the end at once.
             if hasattr(hc, 'gain_scale') and hc.gain_scale is not None:
-                if hd.vis_units is not None and hc.vis_units.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
+                if hd.vis_units is not None and hc.gain_scale.lower() != "uncalib" and hd.vis_units.lower() != hc.gain_scale.lower():
                     warnings.warn(f"Replacing original data vis_units of {hd.vis_units}"
                                    " with calibration vis_units of {hc.gain_scale}", RuntimeWarning)
                 hd_red.vis_units = hc.gain_scale

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -270,7 +270,7 @@ class Test_Abscal_Solvers(object):
         ants = list(set([ant for bl in data for ant in utils.split_bl(bl)]))
         gains = abscal.abs_amp_lincal(model, data, return_gains=True, gain_ants=ants)
         for ant in ants:
-            np.testing.assert_array_equal(gains[ant], 2.0) 
+            np.testing.assert_array_equal(gains[ant], 2.0)
 
     def test_abs_amp_lincal_4pol(self):
         antpos = hex_array(2, split_core=False, outriggers=0)
@@ -542,10 +542,10 @@ class Test_Abscal_Solvers(object):
             data = copy.deepcopy(uncal_data)
             for i in range(8):
                 if i == 0:
-                    gains = abscal.global_phase_slope_logcal(model, data, antpos, solver=solver, assume_2D=True, 
+                    gains = abscal.global_phase_slope_logcal(model, data, antpos, solver=solver, assume_2D=True,
                                                              time_avg=True, return_gains=True, gain_ants=ants, verbose=False)
                 else:
-                    gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='linfit', assume_2D=False, 
+                    gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='linfit', assume_2D=False,
                                                              time_avg=True, return_gains=True, gain_ants=ants, verbose=False)
                 calibrate_in_place(data, gains)
             np.testing.assert_array_almost_equal(np.linalg.norm([data[bl] - model[bl] for bl in data]), 0)
@@ -567,10 +567,10 @@ class Test_Abscal_Solvers(object):
         ants = sorted(list(set([ant for bl in data for ant in utils.split_bl(bl)])))
         for i in range(10):
             if i == 0:
-                gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='ndim_fft', assume_2D=False, 
+                gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='ndim_fft', assume_2D=False,
                                                          time_avg=True, return_gains=True, gain_ants=ants, verbose=False)
             else:
-                gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='linfit', assume_2D=False, 
+                gains = abscal.global_phase_slope_logcal(model, data, antpos, solver='linfit', assume_2D=False,
                                                          time_avg=True, return_gains=True, gain_ants=ants, verbose=False)
             calibrate_in_place(data, gains)
         np.testing.assert_array_almost_equal(np.linalg.norm([data[bl] - model[bl] for bl in data]), 0, 5)
@@ -1068,7 +1068,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         model_antpos = {100: np.array([0, 0, 0]), 101: np.array([10, 0, 0]), 102: np.array([20, 0, 0]), 103: np.array([100, 100, 0])}
         data_bls = [(0, 2, 'ee'), (1, 2, 'ee'), (0, 3, 'ee')]
         model_bls = [(100, 101, 'ee'), (100, 102, 'ee'), (101, 103, 'ee')]
-        data_bl_to_load, model_bl_to_load, data_to_model_bl_map = abscal.match_baselines(data_bls, model_bls, antpos, model_antpos=model_antpos, 
+        data_bl_to_load, model_bl_to_load, data_to_model_bl_map = abscal.match_baselines(data_bls, model_bls, antpos, model_antpos=model_antpos,
                                                                                          data_is_redsol=True, model_is_redundant=True)
         assert len(data_bl_to_load) == 2
         assert len(model_bl_to_load) == 2
@@ -1147,7 +1147,7 @@ class Test_Post_Redcal_Abscal_Run(object):
     def test_get_idealized_antpos(self):
         # build 7 element hex with 1 outrigger. If all antennas are unflagged, the outrigger
         # is not redundant with the hex, so it introduces an extra degeneracy. That corresponds
-        # to an extra dimension in an idealized antenna position. 
+        # to an extra dimension in an idealized antenna position.
         antpos = hex_array(2, split_core=False, outriggers=0)
         antpos[7] = np.array([100, 0, 0])
         reds = redcal.get_reds(antpos, pols=['ee'])
@@ -1168,7 +1168,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         iap = abscal._get_idealized_antpos(cal_flags, antpos, ['ee'], keep_flagged_ants=True)
         # because keep_flagged_ants is True, the flagged antenna is still in the antpos dict
         assert len(iap) == 8
-        # because the only antenna necessitating a 3rd tip-tilt degeneracy is flagged, 
+        # because the only antenna necessitating a 3rd tip-tilt degeneracy is flagged,
         # get_idealized_antpos enforces that all remaining antenna positions are expressed in 2D
         assert len(iap[0]) == 2
         r2a = redcal.reds_to_antpos(redcal.filter_reds(reds, ex_ants=[7]))
@@ -1183,12 +1183,12 @@ class Test_Post_Redcal_Abscal_Run(object):
         iap = abscal._get_idealized_antpos(cal_flags, antpos, ['ee'], keep_flagged_ants=True)
         assert len(iap) == 8  # all antennas included
         # removing an on-grid antenna but keeping the outrigger doesn't change the number of degeneracies
-        assert len(iap[0]) == 3 
+        assert len(iap[0]) == 3
         # test that the flagged antenna has the position it would have had it if weren't flagged
         r2a = redcal.reds_to_antpos(reds)
         for ant in r2a:
             np.testing.assert_array_equal(iap[ant], r2a[ant])
-            
+
         # test keep_flagged_ants=False
         cal_flags = {(ant, 'Jee'): np.array([False]) for ant in antpos}
         cal_flags[(1, 'Jee')] = True
@@ -1246,7 +1246,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         data_ants = set([ant for bl in data.keys() for ant in utils.split_bl(bl)])
         rc_gains_subset = {k: rc_gains[k][tinds, :] for k in data_ants}
         rc_flags_subset = {k: rc_flags[k][tinds, :] for k in data_ants}
-        calibrate_in_place(data, rc_gains_subset, data_flags=flags, 
+        calibrate_in_place(data, rc_gains_subset, data_flags=flags,
                            cal_flags=rc_flags_subset, gain_convention=hc.gain_convention)
         wgts = DataContainer({k: (~flags[k]).astype(np.float) for k in flags.keys()})
 
@@ -1256,7 +1256,7 @@ class Test_Post_Redcal_Abscal_Run(object):
             delta_gains = abscal.post_redcal_abscal(model, copy.deepcopy(data), wgts, rc_flags_subset, verbose=False)
 
         # use returned gains to calibrate data
-        calibrate_in_place(data, delta_gains, data_flags=flags, 
+        calibrate_in_place(data, delta_gains, data_flags=flags,
                            cal_flags=rc_flags_subset, gain_convention=hc.gain_convention)
 
         # basic shape & type checks
@@ -1277,7 +1277,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         hd.write_uvh5(temp_outfile, clobber=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            hca = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, [temp_outfile], phs_conv_crit=1e-4, 
+            hca = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, [temp_outfile], phs_conv_crit=1e-4,
                                                 nInt_to_load=30, verbose=False, add_to_history='testing')
         assert os.path.exists(self.redcal_file.replace('.omni.', '.abs.'))
         np.testing.assert_array_equal(hca.total_quality_array, 0.0)
@@ -1290,14 +1290,15 @@ class Test_Post_Redcal_Abscal_Run(object):
         # test normal operation of abscal (with one missing integration, to test assinging multiple data times to one model time and then rephasing)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            hca = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, self.model_files_missing_one_int, extrap_limit=1.0, 
+            hca = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, self.model_files_missing_one_int, extrap_limit=1.0,
                                                 phs_conv_crit=1e-4, nInt_to_load=30, verbose=False, add_to_history='testing')
         pytest.raises(IOError, abscal.post_redcal_abscal_run, self.data_file, self.redcal_file, self.model_files, clobber=False)
 
         assert os.path.exists(self.redcal_file.replace('.omni.', '.abs.'))
         os.remove(self.redcal_file.replace('.omni.', '.abs.'))
         ac_gains, ac_flags, ac_quals, ac_total_qual = hca.build_calcontainers()
-
+        hdm = io.HERAData(self.model_files_missing_one_int)
+        assert hca.gain_scale == hdm.vis_units
         assert hcr.history.replace('\n', '').replace(' ', '') in hca.history.replace('\n', '').replace(' ', '')
         assert 'testing' in hca.history.replace('\n', '').replace(' ', '')
         for k in rc_gains:
@@ -1327,7 +1328,7 @@ class Test_Post_Redcal_Abscal_Run(object):
         # test redundant model and full data
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            hca_red = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, self.red_model_files, phs_conv_crit=1e-4, 
+            hca_red = abscal.post_redcal_abscal_run(self.data_file, self.redcal_file, self.red_model_files, phs_conv_crit=1e-4,
                                                     nInt_to_load=10, verbose=False, add_to_history='testing2', model_is_redundant=True)
         assert os.path.exists(self.redcal_file.replace('.omni.', '.abs.'))
         os.remove(self.redcal_file.replace('.omni.', '.abs.'))
@@ -1364,9 +1365,11 @@ class Test_Post_Redcal_Abscal_Run(object):
         # test redundant model and redundant data
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            hca_red_red = abscal.post_redcal_abscal_run(self.red_data_file, self.redcal_file, self.red_model_files, phs_conv_crit=1e-4, 
-                                                        nInt_to_load=10, verbose=False, add_to_history='testing3', model_is_redundant=True, 
+            hca_red_red = abscal.post_redcal_abscal_run(self.red_data_file, self.redcal_file, self.red_model_files, phs_conv_crit=1e-4,
+                                                        nInt_to_load=10, verbose=False, add_to_history='testing3', model_is_redundant=True,
                                                         data_is_redsol=True, raw_auto_file=self.data_file)
+        hdm = io.HERAData(self.red_model_files)
+        assert hca_red_red.gain_scale == hdm.vis_units
         assert os.path.exists(self.redcal_file.replace('.omni.', '.abs.'))
         os.remove(self.redcal_file.replace('.omni.', '.abs.'))
         ac_gains, ac_flags, ac_quals, ac_total_qual = hca_red_red.build_calcontainers()

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -1265,6 +1265,23 @@ class Test_Post_Redcal_Abscal_Run(object):
             assert delta_gains[k].shape == (3, rc_gains[k].shape[1])
             assert delta_gains[k].dtype == np.complex
 
+    def test_post_redcal_abscal_run_units_warning(self, tmpdir):
+        tmp_path = tmpdir.strpath
+        calfile_units = os.path.join(tmp_path, 'redcal_units.calfits')
+        model_units = os.path.join(tmp_path, 'model_file_units.uvh5')
+        hd = io.HERAData(self.model_files[0])
+        hd.read()
+        hd.vis_units = 'Jy'
+        hd.write_uvh5(model_units)
+        hcr = io.HERACal(self.redcal_file)
+        hcr.read()
+        hcr.gain_scale = 'k str'
+        hcr.write_calfits(calfile_units)
+        with pytest.warns(RuntimeWarning):
+            hca = abscal.post_redcal_abscal_run(self.data_file, calfile_units, [model_units], phs_conv_crit=1e-4,
+                                                nInt_to_load=30, verbose=False, add_to_history='testing')
+        assert hca.gain_scale == 'Jy'
+
     def test_post_redcal_abscal_run(self):
         # test no model overlap
         hcr = io.HERACal(self.redcal_file)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -261,6 +261,13 @@ class Test_Update_Cal(object):
         # test that units are propagated from calibration gains to calibrated data.
         new_cal = os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.uv.abs.calfits_54x_only")
         uvh5 = os.path.join(DATA_PATH, "test_input/zen.2458101.46106.xx.HH.OCR_53x_54x_only.uvh5")
+
+        uvd_with_units = UVData()
+        uvd_with_units.read_uvh5(uvh5)
+        uvd_with_units.vis_units = 'k str'
+        uvh5_units = os.path.join(tmp_path, 'test_input_kstr.uvh5')
+        uvd_with_units.write_uvh5(uvh5_units)
+
         hc = io.HERACal(new_cal)
         hc.read()
         # manually set gain-scale.
@@ -268,35 +275,41 @@ class Test_Update_Cal(object):
         calfile = os.path.join(tmp_path, 'test_cal.calfits')
         output = os.path.join(tmp_path, 'test_calibrated_output.uvh5')
         hc.write_calfits(calfile)
-        ac.apply_cal(uvh5, output, calfile)
+
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uvh5_units, output, calfile)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         ac.apply_cal(uvh5, output, calfile, vis_units='k str', clobber=True)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
         # test red_average mode.
-        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True)
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uvh5_units, output, calfile, clobber=True, redundant_average=True)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, vis_units='k str')
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
         # do this with nbl_per_load set.
-        ac.apply_cal(uvh5, output, calfile, nbl_per_load=4, clobber=True)
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uvh5_units, output, calfile, nbl_per_load=4, clobber=True)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         ac.apply_cal(uvh5, output, calfile, vis_units='k str', clobber=True, nbl_per_load=4)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
         # test red_average mode.
-        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uvh5_units, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, vis_units='k str', nbl_per_load=4)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
         # test red_average mode with partial i/o.
-        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uvh5_units, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         # test red_average mode with baseline groups.
@@ -312,10 +325,12 @@ class Test_Update_Cal(object):
                 f[bl] = f[bl_not_flagged]
                 n[bl] = n[bl_not_flagged]
         hdt.update(data=d, flags=f, nsamples=n)
+        hdt.vis_units = 'k str'
         uncalibrated_file_homogenous_nsamples_flags = os.path.join(tmp_path, 'homogenous_nsamples_flags.uvh5')
         hdt.write_uvh5(uncalibrated_file_homogenous_nsamples_flags)
-        ac.apply_cal(uncalibrated_file_homogenous_nsamples_flags,
-                     output, calfile, clobber=True, redundant_average=True, redundant_groups=3)
+        with pytest.warns(RuntimeWarning):
+            ac.apply_cal(uncalibrated_file_homogenous_nsamples_flags,
+                         output, calfile, clobber=True, redundant_average=True, redundant_groups=3)
         for grpnum in range(3):
             hdc = io.HERAData(output.replace('.uvh5', f'.{grpnum}.uvh5'))
             assert hdc.vis_units == 'Jy'

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -281,6 +281,20 @@ class Test_Update_Cal(object):
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, vis_units='k str')
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
+        # do this with nbl_per_load set.
+        ac.apply_cal(uvh5, output, calfile, nbl_per_load=4)
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'Jy'
+        ac.apply_cal(uvh5, output, calfile, vis_units='k str', clobber=True, nbl_per_load=4)
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'k str'
+        # test red_average mode.
+        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'Jy'
+        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, vis_units='k str', nbl_per_load=4)
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'k str'
         # test red_average mode with partial i/o.
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
         hdc = io.HERAData(output)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -282,7 +282,7 @@ class Test_Update_Cal(object):
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'k str'
         # do this with nbl_per_load set.
-        ac.apply_cal(uvh5, output, calfile, nbl_per_load=4)
+        ac.apply_cal(uvh5, output, calfile, nbl_per_load=4, clobber=True)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
         ac.apply_cal(uvh5, output, calfile, vis_units='k str', clobber=True, nbl_per_load=4)

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -271,10 +271,16 @@ class Test_Update_Cal(object):
         ac.apply_cal(uvh5, output, calfile)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
+        ac.apply_cal(uvh5, output, calfile, vis_units='k str', clobber=True)
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'k str'
         # test red_average mode.
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True)
         hdc = io.HERAData(output)
         assert hdc.vis_units == 'Jy'
+        ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, vis_units='k str')
+        hdc = io.HERAData(output)
+        assert hdc.vis_units == 'k str'
         # test red_average mode with partial i/o.
         ac.apply_cal(uvh5, output, calfile, clobber=True, redundant_average=True, nbl_per_load=4)
         hdc = io.HERAData(output)
@@ -299,6 +305,11 @@ class Test_Update_Cal(object):
         for grpnum in range(3):
             hdc = io.HERAData(output.replace('.uvh5', f'.{grpnum}.uvh5'))
             assert hdc.vis_units == 'Jy'
+        ac.apply_cal(uncalibrated_file_homogenous_nsamples_flags,
+                     output, calfile, clobber=True, redundant_average=True, redundant_groups=3, vis_units='k str')
+        for grpnum in range(3):
+            hdc = io.HERAData(output.replace('.uvh5', f'.{grpnum}.uvh5'))
+            assert hdc.vis_units == 'k str'
 
     def test_apply_cal_redundant_averaging(self, tmpdir):
         tmp_path = tmpdir.strpath


### PR DESCRIPTION
propagate visibility units of model to calibration file in `post_redcal_abscal_run`. Also make sure `gain_scale` is propagated to calibrated data in `apply_cal`. `vis_units` arg in `apply_cal` still overwrites `gain_scale`.