### PR TITLE
Fixing shift of lst_arrays to a list comprehension

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -579,7 +579,7 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
 
     # if lst_start is sufficiently below lmin, shift everything down an octave
     if lst_start < (lmin - np.pi):
-        lst_arrays -= 2 * np.pi
+        lst_arrays = [[la - 2 * np.pi for la in day] for day in lst_arrays]
         lmin -= 2 * np.pi
         lmax -= 2 * np.pi
 


### PR DESCRIPTION
Fixes issue when running the LST-binner with the do_LSTBIN.sh of the H1C IDR2 pipeline. Would otherwise get:

```
"/lustre/aoc/projects/hera/mmolnar/LST_bin/hera_cal/hera_cal/lstbin.py", line 582, in config_lst_bin_files
    lst_arrays -= 2 * np.pi
TypeError: unsupported operand type(s) for -=: 'list' and 'float'
```