### PR TITLE
Fixes to handling of JD to LST conversion

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1312,6 +1312,11 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     Npols = len(pols)
     polarization_array = np.array(list(map(lambda p: polstr2num(p, x_orientation=x_orientation), pols)))
 
+    # get telescope ants
+    antenna_numbers = np.unique(list(antpos.keys()))
+    Nants_telescope = len(antenna_numbers)
+    antenna_names = list(map(lambda a: "HH{}".format(a), antenna_numbers))
+
     # get antenna positions in ITRF frame
     tel_lat_lon_alt = uvutils.LatLonAlt_from_XYZ(telescope_location)
     antenna_positions = np.array(list(map(lambda k: antpos[k], antenna_numbers)))
@@ -1376,11 +1381,6 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     # get antennas in data
     data_ants = np.unique(np.concatenate([ant_1_array, ant_2_array]))
     Nants_data = len(data_ants)
-
-    # get telescope ants
-    antenna_numbers = np.unique(list(antpos.keys()))
-    Nants_telescope = len(antenna_numbers)
-    antenna_names = list(map(lambda a: "HH{}".format(a), antenna_numbers))
 
     # set uvw assuming drift phase i.e. phase center is zenith
     uvw_array = np.array([antpos[k[1]] - antpos[k[0]] for k in zip(ant_1_array, ant_2_array)])

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1321,7 +1321,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     if time_array is None:
         if start_jd is None:
             raise AttributeError("if time_array is not fed, start_jd must be fed")
-        time_array = LST2JD(lst_array, start_jd, longitude=(tel_lat_lon_alt[1] *180 / np.pi))
+        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, longitude=(tel_lat_lon_alt[1] *180 / np.pi))
     Ntimes = len(time_array)
 
     # get freqs

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1326,7 +1326,10 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     if time_array is None:
         if start_jd is None:
             raise AttributeError("if time_array is not fed, start_jd must be fed")
-        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, longitude=(tel_lat_lon_alt[1] * 180 / np.pi))
+        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, 
+                            latitude=(tel_lat_lon_alt[0] * 180 / np.pi),
+                            longitude=(tel_lat_lon_alt[1] * 180 / np.pi),
+                            altitude=tel_lat_lon_alt[2])
     Ntimes = len(time_array)
 
     # get freqs

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1238,7 +1238,7 @@ def load_vis(input_data, return_meta=False, filetype='miriad', pop_autos=False, 
 
 def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags=None, nsamples=None,
               filetype='miriad', write_file=True, outdir="./", overwrite=False, verbose=True, history=" ",
-              return_uvd=False, start_jd=None, x_orientation="north", instrument="HERA",
+              return_uvd=False, start_jd=None, lst_branch_cut=0.0, x_orientation="north", instrument="HERA",
               telescope_name="HERA", object_name='EOR', vis_units='uncalib', dec=-30.72152,
               telescope_location=HERA_TELESCOPE_LOCATION, integration_time=None, **kwargs):
     """
@@ -1279,6 +1279,9 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     return_uvd : type=boolean, if True return UVData instance.
 
     start_jd : type=float, starting integer Julian Date of time_array if time_array is None.
+
+    lst_branch_cut : type=float, LST of data start, ensures that LSTs lower than this are wrapped around
+                     and correspond to higher JDs in time_array, but only if time_array is None [radians]
 
     x_orientation : type=str, orientation of X dipole, options=['east', 'north']
 
@@ -1326,7 +1329,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     if time_array is None:
         if start_jd is None:
             raise AttributeError("if time_array is not fed, start_jd must be fed")
-        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, 
+        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, lst_branch_cut=lst_branch_cut,
                             latitude=(tel_lat_lon_alt[0] * 180 / np.pi),
                             longitude=(tel_lat_lon_alt[1] * 180 / np.pi),
                             altitude=tel_lat_lon_alt[2])

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1326,7 +1326,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
     if time_array is None:
         if start_jd is None:
             raise AttributeError("if time_array is not fed, start_jd must be fed")
-        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, longitude=(tel_lat_lon_alt[1] *180 / np.pi))
+        time_array = LST2JD(lst_array, start_jd, allow_other_jd=True, longitude=(tel_lat_lon_alt[1] * 180 / np.pi))
     Ntimes = len(time_array)
 
     # get freqs

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -903,6 +903,10 @@ def lst_bin_files(data_files, input_cals=None, dlst=None, verbose=True, ntimes_p
         fkwargs['type'] = 'STD'
         std_file = "zen." + file_ext.format(**fkwargs)
 
+        # make sure the JD corresponding to file_lsts[0][0] is the lowest JD in the LST-binned data set
+        if lst_start is not None:
+            kwargs['lst_branch_cut'] = file_lsts[0][0]
+
         # check for overwrite
         if os.path.exists(bin_file) and overwrite is False:
             utils.echo("{} exists, not overwriting".format(bin_file), verbose=verbose)

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -314,7 +314,7 @@ def test_LST2JD():
     lsts = np.arange(-np.pi / 4, 7 * np.pi / 2, .1)
     jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=True)
     for jd in jds:
-        assert int(np.floor(jd)) in [2458041, 2458042, 2458043]
+        assert int(np.floor(jd)) in [2458041, 2458042, 2458043, 2458044]
     assert not np.all([np.floor(jd) == 2458042 for jd in jds])
     # test allow_other_jd = False
     lsts = np.arange(-np.pi / 4, 7 * np.pi / 2, .1)

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -311,13 +311,13 @@ def test_LST2JD():
     assert len(jd) == 6
     assert np.allclose(jd[3], 2458042.9660755517)
     # test allow_other_jd = True
-    lsts = np.arange(-np.pi, 5 * np.pi / 2, .1)
+    lsts = np.arange(-np.pi / 4, 7 * np.pi / 2, .1)
     jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=True)
     for jd in jds:
         assert int(np.floor(jd)) in [2458041, 2458042, 2458043]
     assert not np.all([np.floor(jd) == 2458042 for jd in jds])
     # test allow_other_jd = False
-    lsts = np.arange(-np.pi, 5 * np.pi / 2, .1)
+    lsts = np.arange(-np.pi / 4, 7 * np.pi / 2, .1)
     jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=False)
     for jd in jds:
         assert int(np.floor(jd)) == 2458042

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -321,6 +321,25 @@ def test_LST2JD():
     jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=False)
     for jd in jds:
         assert int(np.floor(jd)) == 2458042
+    # test branch cut
+    lsts = np.arange(0, 2 * np.pi, .1)
+    jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=True, lst_branch_cut=0.0)
+    assert jds[0] < jds[-1]
+    jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=True, lst_branch_cut=1)
+    assert np.min(jds[lsts < 1]) > np.max(jds[lsts > 1])
+    # test that lst 0 falls on correct day
+    for jd in range(2458042, 2458042 + 365):
+        assert np.floor(utils.LST2JD(0, start_jd=jd, allow_other_jd=True)) == jd
+    # test that lst of branch cut falls on correct day
+    for jd in range(2458042, 2458042 + 365):
+        assert np.floor(utils.LST2JD(1, start_jd=jd, allow_other_jd=True, lst_branch_cut=1)) == jd
+    # test convert back and forth for a range of days to 1e-8 radians precision
+    for start_jd in range(2458042, 2458042 + 365):
+        lsts = np.arange(0, 2*np.pi, .1)
+        lsts2 = utils.JD2LST(utils.LST2JD(lsts, start_jd=jd, allow_other_jd=True, lst_branch_cut=1))
+        is_close = (np.abs(lsts - lsts2) < 1e-8) | (np.abs(lsts - lsts2 + 2 * np.pi) < 1e-8) | (np.abs(lsts - lsts2 - 2 * np.pi) < 1e-8)
+        assert np.all(is_close)
+
 
 
 def test_JD2RA():

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -335,11 +335,10 @@ def test_LST2JD():
         assert np.floor(utils.LST2JD(1, start_jd=jd, allow_other_jd=True, lst_branch_cut=1)) == jd
     # test convert back and forth for a range of days to 1e-8 radians precision
     for start_jd in range(2458042, 2458042 + 365):
-        lsts = np.arange(0, 2*np.pi, .1)
+        lsts = np.arange(0, 2 * np.pi, .1)
         lsts2 = utils.JD2LST(utils.LST2JD(lsts, start_jd=jd, allow_other_jd=True, lst_branch_cut=1))
         is_close = (np.abs(lsts - lsts2) < 1e-8) | (np.abs(lsts - lsts2 + 2 * np.pi) < 1e-8) | (np.abs(lsts - lsts2 - 2 * np.pi) < 1e-8)
         assert np.all(is_close)
-
 
 
 def test_JD2RA():

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -310,6 +310,17 @@ def test_LST2JD():
     jd = utils.LST2JD(lst, start_jd=2458042)
     assert len(jd) == 6
     assert np.allclose(jd[3], 2458042.9660755517)
+    # test allow_other_jd = True
+    lsts = np.arange(-np.pi, 5 * np.pi / 2, .1)
+    jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=True)
+    for jd in jds:
+        assert int(np.floor(jd)) in [2458041, 2458042, 2458043]
+    assert not np.all([np.floor(jd) == 2458042 for jd in jds])
+    # test allow_other_jd = False
+    lsts = np.arange(-np.pi, 5 * np.pi / 2, .1)
+    jds = utils.LST2JD(lsts, start_jd=2458042, allow_other_jd=False)
+    for jd in jds:
+        assert int(np.floor(jd)) == 2458042
 
 
 def test_JD2RA():

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -574,13 +574,15 @@ def LST2JD(LST, start_jd, allow_other_jd=False, lst_branch_cut=0.0, latitude=-30
         while True:
             lt_indices = np.floor(jd_array) < np.floor(start_jd)
             gt_indices = np.floor(jd_array) > np.floor(start_jd)
+            # if any of the resultant days fall on a JD less than start_jd, recalculate them 2pi higher
             if np.any(lt_indices):
                 LST[lt_indices] += 2 * np.pi
                 jd_array[lt_indices] = interpolator(LST[lt_indices])
+            # if any of the resultant days fall on a JD greater than start_jd, recalculate them 2pi lower
             elif np.any(gt_indices):
                 LST[gt_indices] -= 2 * np.pi
                 jd_array[gt_indices] = interpolator(LST[gt_indices])
-            else:
+            else:  # all resultant JDs fall on start_jd
                 break
 
     if _array:

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -523,8 +523,8 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
 
     start_jd : type=int, integer julian day to use as starting point for LST2JD conversion
     
-    allow_other_jd : treat start_jd as the JD for 0 radians LST but allow
-        subsequent or following days if appropriate
+    allow_other_jd : treat the LST at the very beginning of the start_jd as the phase wrap 
+        reference and allow LSTs to map to subsequent or previous days as appropraite.
 
     longitude : type=float, degrees East of observer, default=HERA longitude
 

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -553,7 +553,7 @@ def LST2JD(LST, start_jd, allow_other_jd=False, lst_branch_cut=0.0, latitude=-30
         LST[LST < lst_branch_cut] += 2 * np.pi  
 
     # create interpolator for a given start date that puts the lst_branch_cut on start_jd
-    jd_grid = start_jd + np.linspace(-1, 2, 31) # include previous and next days
+    jd_grid = start_jd + np.linspace(-1, 2, 31)  # include previous and next days
     while True:
         lst_grid = (JD2LST(jd_grid, latitude=latitude, longitude=longitude, altitude=altitude))
         interpolator = interpolate.interp1d(np.unwrap(lst_grid - 2 * np.pi), jd_grid,

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -541,7 +541,7 @@ def LST2JD(LST, start_jd, longitude=21.42830):
 
     # iterate over LST
     jd_array = []
-    for lst in LST:
+    for lst in np.unwrap(LST):
         while True:
             # calculate fit
             jd1 = start_jd

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -543,7 +543,6 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
     base_jd = float(start_jd)
 
     # calculate fit and cache it by start_jd
-    slopes, offsets = {}, {}
     def fit_slope_offset(sjd):
         if sjd not in slopes:
             jd1 = sjd
@@ -551,11 +550,13 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
             lst1, lst2 = JD2LST(jd1, longitude=longitude), JD2LST(jd2, longitude=longitude)
             slopes[sjd] = (lst2 - lst1) / 0.01
             offsets[sjd] = lst1 - slopes[sjd] * jd1
+
+    slopes, offsets = {}, {}
     fit_slope_offset(start_jd)
 
     # iterate over LST
     jd_array = []
-    for lst in np.unwrap(LST): # TODO: this isn't going to work for lst_array if we're bouncing back and forth
+    for lst in np.unwrap(LST):
         JD = (lst - offsets[start_jd]) / slopes[start_jd]
         if not allow_other_jd:
             start_jd_here = copy.copy(start_jd)

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -519,7 +519,7 @@ def LST2JD(LST, start_jd, longitude=21.42830):
 
     Input:
     ------
-    LST : type=float, local apparent sidereal time [radians]
+    LST : type=float or array-like, local apparent sidereal time [radians]
 
     start_jd : type=int, integer julian day to use as starting point for LST2JD conversion
 
@@ -527,7 +527,7 @@ def LST2JD(LST, start_jd, longitude=21.42830):
 
     Output:
     -------
-    JD : type=float, Julian Date(s). accurate to ~1 milliseconds
+    JD : type=type(LST), Julian Date(s). accurate to ~1 milliseconds
     """
     # get LST type
     if isinstance(LST, list) or isinstance(LST, np.ndarray):

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -512,7 +512,7 @@ def JD2LST(JD, longitude=21.42830):
         return LST[0]
 
 
-def LST2JD(LST, start_jd, longitude=21.42830):
+def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
     """
     Convert Local Apparent Sidereal Time -> Julian Date via a linear fit
     at the 'start_JD' anchor point.
@@ -522,6 +522,9 @@ def LST2JD(LST, start_jd, longitude=21.42830):
     LST : type=float or array-like, local apparent sidereal time [radians]
 
     start_jd : type=int, integer julian day to use as starting point for LST2JD conversion
+    
+    allow_other_jd : treat start_jd as the JD for 0 radians LST but allow
+        subsequent or following days if appropriate
 
     longitude : type=float, degrees East of observer, default=HERA longitude
 
@@ -554,6 +557,8 @@ def LST2JD(LST, start_jd, longitude=21.42830):
             JD = (lst - offset) / slope
 
             # redo if JD isn't on starting JD
+            if allow_other_jd: 
+                break
             if JD - base_jd < 0:
                 start_jd += 1
             elif JD - base_jd > 1:

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -559,10 +559,10 @@ def LST2JD(LST, start_jd, allow_other_jd=False, lst_branch_cut=0.0, latitude=-30
         interpolator = interpolate.interp1d(np.unwrap(lst_grid - 2 * np.pi), jd_grid,
                                             kind='linear', fill_value='extrapolate')
         if np.floor(interpolator(lst_branch_cut)) > np.floor(start_jd):
-            jd_grid -= 1.0
+            jd_grid -= unt.sday.to(unt.day)
 
         elif np.floor(interpolator(lst_branch_cut)) < np.floor(start_jd):
-            jd_grid += 1.0     
+            jd_grid += unt.sday.to(unt.day)
         else:
             break
         

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -493,6 +493,7 @@ def JD2LST(JD, latitude=-30.721526120689507, longitude=21.428303826863015, altit
     Notes:
     ------
     The Local Apparent Sidereal Time is *defined* as the right ascension in the current epoch.
+    Wrapper around pyuvdata's get_lst_for_time().
     """
     # get JD type
     if isinstance(JD, list) or isinstance(JD, np.ndarray):
@@ -501,14 +502,8 @@ def JD2LST(JD, latitude=-30.721526120689507, longitude=21.428303826863015, altit
         _array = False
         JD = [JD]
 
-    # iterate over JD
-    LST = []
-    for jd in JD:
-        # construct astropy Time object
-        t = Time(jd, format='jd', scale='utc')
-        # get LST in radians at epoch of jd
-        LST.append(t.sidereal_time('apparent', longitude=longitude * unt.deg).radian)
-    LST = np.array(LST)
+    # use pyuvdata
+    LST = uvutils.get_lst_for_time(np.array(JD), latitude, longitude, altitude)
 
     if _array:
         return LST

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -474,13 +474,17 @@ def get_aa_from_uv(uvd, freqs=[0.15]):
     return aa
 
 
-def JD2LST(JD, longitude=21.42830):
+def JD2LST(JD, latitude=-30.721526120689507, longitude=21.428303826863015, altitude=1051.690000018105):
     """
     Input:
     ------
     JD : type=float or list of floats containing Julian Date(s) of an observation
 
-    longitude : type=float, longitude of observer in degrees East, default=HERA longitude
+    latitude : type=float, degrees North of observer, default=HERA latitude
+
+    longitude : type=float, degrees East of observer, default=HERA longitude
+
+    altitude : type=float, altitude in meters, default=HERA altitude
 
     Output:
     -------
@@ -512,7 +516,8 @@ def JD2LST(JD, longitude=21.42830):
         return LST[0]
 
 
-def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
+def LST2JD(LST, start_jd, allow_other_jd=False, latitude=-30.721526120689507,
+           longitude=21.428303826863015, altitude=1051.690000018105):
     """
     Convert Local Apparent Sidereal Time -> Julian Date via a linear fit
     at the 'start_JD' anchor point.
@@ -526,7 +531,11 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
     allow_other_jd : treat the LST at the very beginning of the start_jd as the phase wrap 
         reference and allow LSTs to map to subsequent or previous days as appropraite.
 
+    latitude : type=float, degrees North of observer, default=HERA latitude
+
     longitude : type=float, degrees East of observer, default=HERA longitude
+
+    altitude : type=float, altitude in meters, default=HERA altitude
 
     Output:
     -------
@@ -547,7 +556,8 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
         if sjd not in slopes:
             jd1 = sjd
             jd2 = sjd + 0.01
-            lst1, lst2 = JD2LST(jd1, longitude=longitude), JD2LST(jd2, longitude=longitude)
+            lst1 = JD2LST(jd1, latitude=latitude, longitude=longitude, altitude=altitude)
+            lst2 = JD2LST(jd2, latitude=latitude, longitude=longitude, altitude=altitude)
             slopes[sjd] = (lst2 - lst1) / 0.01
             offsets[sjd] = lst1 - slopes[sjd] * jd1
 
@@ -579,7 +589,7 @@ def LST2JD(LST, start_jd, allow_other_jd=False, longitude=21.42830):
         return jd_array[0]
 
 
-def JD2RA(JD, longitude=21.42830, latitude=-30.72152, epoch='current'):
+def JD2RA(JD, latitude=-30.721526120689507, longitude=21.428303826863015, epoch='current'):
     """
     Convert from Julian date to Equatorial Right Ascension at zenith
     during a specified epoch.
@@ -639,7 +649,7 @@ def JD2RA(JD, longitude=21.42830, latitude=-30.72152, epoch='current'):
         return RA[0]
 
 
-def get_sun_alt(jds, longitude=21.42830, latitude=-30.72152):
+def get_sun_alt(jds, latitude=-30.721526120689507, longitude=21.428303826863015):
     """
     Given longitude and latitude, get the Solar alittude at a given time.
 
@@ -737,7 +747,7 @@ def combine_calfits(files, fname, outdir=None, overwrite=False, broadcast_flags=
     uvc.write_calfits(output_fname, clobber=True)
 
 
-def lst_rephase(data, bls, freqs, dlst, lat=-30.72152, inplace=True, array=False):
+def lst_rephase(data, bls, freqs, dlst, lat=-30.721526120689507, inplace=True, array=False):
     """
     Shift phase center of each integration in data by amount dlst [radians] along right ascension axis.
     If inplace == True, this function directly edits the arrays in 'data' in memory, so as not to


### PR DESCRIPTION
This PR does a few things:

- Removes longitude independent of telescope_location in`write_vis`
- Replaces to the guts of JD2LST to wrap around pyuvdata's equivalent function
- Updates the algorithm for computing JDs from LSTs to increase accuracy by roughly 1 OOM with out an appreciable impact on speed. (This will hopefully fix some pyuvdata warnings about JDs and LSTs not matching.)
- Enables LST2JD to come up with LSTs that span multiple days to avoid discontinuities in LST-binned data
- Enables the user to specify the lst_branch_cut, which is essentially the starting LST of the data set. Values below the branch cut to map to later LSTs than values above the branch cut.
- Uses more precise locations for HERA as defaults
- Adds new tests for LST2JD

This PR resolves #720.