### PR TITLE
Spw ranges fourier filter

### DIFF
--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -19,7 +19,7 @@ dependencies:
   - future
   - pytest-cov
   - coveralls
-  - pyvdata<2.2.0
+  - pyuvdata<2.2.0
 
   - pip:
     #- git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata

--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -19,9 +19,10 @@ dependencies:
   - future
   - pytest-cov
   - coveralls
+  - pyvdata<2.2.0
 
   - pip:
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
+    #- git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
     - git+https://github.com/HERA-Team/uvtools
     - git+https://github.com/HERA-Team/linsolve
     - git+https://github.com/HERA-Team/hera_qm

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -47,7 +47,7 @@ class Test_DelayFilter(object):
             wgts = {k: np.ones_like(dfil.flags[k], dtype=np.float)}
             wgts[k][0, :] = 0.0
             dfil.run_filter(to_filter=[k], weight_dict=wgts, standoff=0., horizon=1., tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
-            assert dfil.clean_info[k]['status']['axis_1'][0] == 'skipped'
+            assert dfil.clean_info[k][(0, dfil.Nfreqs)]['status']['axis_1'][0] == 'skipped'
             np.testing.assert_array_equal(dfil.clean_flags[k][0, :], np.ones_like(dfil.flags[k][0, :]))
             np.testing.assert_array_equal(dfil.clean_model[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))
             np.testing.assert_array_equal(dfil.clean_resid[k][0, :], np.zeros_like(dfil.clean_resid[k][0, :]))

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -230,6 +230,9 @@ def test_get_max_contiguous_flag_from_filter_periods():
     assert mcf == 3
     mcf = vis_clean.get_max_contiguous_flag_from_filter_periods((times, freqs), filter_centers, filter_half_widths)
     assert tuple(mcf) == (3, 2)
+    # test assertion errors
+    pytest.raises(ValueError, [1.], [0.], [.5])
+    pytest.raises(ValueError, [[1.], [0.]], [0.], [.5])
 
 
 def test_flag_model_rms():

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -231,8 +231,8 @@ def test_get_max_contiguous_flag_from_filter_periods():
     mcf = vis_clean.get_max_contiguous_flag_from_filter_periods((times, freqs), filter_centers, filter_half_widths)
     assert tuple(mcf) == (3, 2)
     # test assertion errors
-    pytest.raises(ValueError, [1.], [0.], [.5])
-    pytest.raises(ValueError, [[1.], [0.]], [0.], [.5])
+    pytest.raises(ValueError, vis_clean.get_max_contiguous_flag_from_filter_periods, [1.], [0.], [.5])
+    pytest.raises(ValueError, vis_clean.get_max_contiguous_flag_from_filter_periods, [[1.], [0.]], [0.], [.5])
 
 
 def test_flag_model_rms():

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -44,20 +44,46 @@ def test_truncate_flagged_edges():
     assert np.all(np.isclose(xout, freqs[:-1]))
     assert np.all(np.isclose(dout, data_in[:, :-1]))
     assert np.all(np.isclose(wout, weights_in[:, :-1]))
-    assert edges == [(0, 0), (0, 1)]
+    assert edges == [(0, 1)]
     # test time truncation
     xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, times, ax='time')
     assert np.all(np.isclose(xout, times[:-2]))
     assert np.all(np.isclose(dout, data_in[:-2, :]))
     assert np.all(np.isclose(wout, weights_in[:-2, :]))
-    assert edges == [(0, 2), (0, 0)]
+    assert edges == [(0, 2)]
     # test truncating both.
     xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, (times, freqs), ax='both')
     assert np.all(np.isclose(xout[0], times[:-2]))
     assert np.all(np.isclose(xout[1], freqs[:-1]))
     assert np.all(np.isclose(dout, data_in[:-2, :-1]))
     assert np.all(np.isclose(wout, weights_in[:-2, :-1]))
-    assert edges == [(0, 2), (0, 1)]
+    assert edges == [[(0, 2)], [(0, 1)]]
+
+
+def test_restore_flagged_edges():
+    Nfreqs = 64
+    Ntimes = 60
+    data_in = np.outer(np.arange(1, Ntimes + 1), np.arange(1, Nfreqs + 1))
+    weights_in = np.abs(data_in).astype(float)
+    data_in = data_in + .3j * data_in
+    # flag channel 30
+    weights_in[:, 30] = 0.
+    # flag last channel
+    weights_in[:, -1] = 0.
+    # flag last two integrations
+    weights_in[-2:, :] = 0.
+    times = np.arange(60) * 10.
+    freqs = np.arange(64) * 100e3
+    # test freq truncation
+    xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, freqs, ax='freq')
+    wrest = vis_clean.restore_flagged_edges(xout, wout, edges)
+    assert np.allclose(weights_in, wrest[:, :-1])
+    assert np.allclose(wrest[:, -1], 0.0)
+    xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, times, ax='time')
+    wrest = vis_clean.restore_flagged_edges(xout, wout, edges, ax='time')
+    assert np.allclose(wout, wrest[:-2, :])
+    assert np.allclose(wrest[:-2, :], 0.0)
+
 
 def find_discontinuity_edges():
     assert find_discontinuity_edges([0, 1, 4, 9]) == [(0, 2), (2, 3), (3, 4)]
@@ -72,37 +98,39 @@ def test_flag_rows_with_flags_within_edge_distance():
     weights_in[33, 12] = 0.
     weights_in[2, 30] = 0.
     weights_in[-10, 20] = 0.
+    freqs = np.arange(Nfreqs) * 100e3
     # under the above flagging pattern
     # freq flagging with min_flag_edge_distance=2 yields 32nd integration flagged only.
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance=3, ax='freq')
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=3, ax='freq')
     for i in range(wout.shape[0]):
         if i == 32:
             assert np.all(np.isclose(wout[i], 0.0))
         else:
             assert np.all(np.isclose(wout[i], weights_in[i]))
     # extending edge_distance to 12 should yield 33rd integration being flagged as well.
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance=13, ax='freq')
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=13, ax='freq')
     for i in range(wout.shape[0]):
         if i == 32 or i == 33:
             assert np.all(np.isclose(wout[i], 0.0))
         else:
             assert np.all(np.isclose(wout[i], weights_in[i]))
     # now do time axis. 30th channel should be flagged for this case.
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance=3, ax='time')
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=3, ax='time')
     for i in range(wout.shape[1]):
         if i == 30:
             assert np.all(np.isclose(wout[:, i], 0.0))
         else:
             assert np.all(np.isclose(wout[:, i], weights_in[:, i]))
     # 30th and 20th channels should end up flagged for this case.
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance=11, ax='time')
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=11, ax='time')
     for i in range(wout.shape[1]):
         if i == 30 or i == 20:
             assert np.all(np.isclose(wout[:, i], 0.0))
         else:
             assert np.all(np.isclose(wout[:, i], weights_in[:, i]))
     # now do both
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance=(3, 3), ax='both')
+    times = np.arange(Ntimes) * 10.
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance([times, freqs], weights_in, min_flag_edge_distance=(3, 3), ax='both')
     for i in range(wout.shape[1]):
         if i == 30:
             assert np.all(np.isclose(wout[:, i], 0.0))
@@ -318,12 +346,12 @@ class Test_VisClean(object):
         # this line is repeated to cover the overwrite skip
         V.fourier_filter(keys=[k], filter_centers=fc, filter_half_widths=fw, suppression_factors=ff, max_contiguous_edge_flags=20,
                          ax='freq', mode='dayenu', zeropad=10, output_prefix='clean', overwrite=False)
-        assert np.all([V.clean_info[k]['status']['axis_1'][i] == 'success' for i in V.clean_info[k]['status']['axis_1']])
+        assert np.all([V.clean_info[k][(0, V.Nfreqs)]['status']['axis_1'][i] == 'success' for i in V.clean_info[k][(0, V.Nfreqs)]['status']['axis_1']])
         # now do a time filter
         V.fourier_filter(keys=[k], filter_centers=fc, filter_half_widths=fwt, suppression_factors=ff, overwrite=True,
                          ax='time', mode='dayenu', zeropad=10, max_contiguous_edge_flags=20)
-        assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
-        assert V.clean_info[k]['status']['axis_0'][3] == 'success'
+        assert V.clean_info[k][(0, V.Nfreqs)]['status']['axis_0'][0] == 'skipped'
+        assert V.clean_info[k][(0, V.Nfreqs)]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -346,8 +374,8 @@ class Test_VisClean(object):
                          suppression_factors=[ff, ff],
                          mode='dayenu', overwrite=True,
                          zeropad=[20, 10], ax='both', max_contiguous_edge_flags=100)
-        assert V.clean_info[k]['status']['axis_0'][0] == 'skipped'
-        assert V.clean_info[k]['status']['axis_0'][3] == 'success'
+        assert V.clean_info[k][(0, V.Nfreqs)]['status']['axis_0'][0] == 'skipped'
+        assert V.clean_info[k][(0, V.Nfreqs)]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -376,7 +404,7 @@ class Test_VisClean(object):
         # numpy issues.
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
                                  V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-15))
-        assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert np.all([V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
 
         assert pytest.raises(AssertionError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', max_frate=None, mode='dayenu')
         assert pytest.raises(ValueError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', max_frate='arglebargle', mode='dayenu')
@@ -385,8 +413,8 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='freq', overwrite=False, mode='dayenu')
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='time', overwrite=True, max_frate=1.0, mode='dayenu')
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3] == 'success'
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][0] == 'skipped'
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -396,9 +424,9 @@ class Test_VisClean(object):
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
                                  V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-15))
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dayenu')
-        assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3] == 'success'
+        assert np.all(['success' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][0] == 'skipped'
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -434,7 +462,7 @@ class Test_VisClean(object):
         # check that filtered_data is the same in channels that were not flagged
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
                                  V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-6))
-        assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert np.all([V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
 
         assert pytest.raises(AssertionError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', mode='dpss_leastsq')
         assert pytest.raises(ValueError, V.vis_clean, keys=[(24, 25, 'ee')], ax='time', max_frate='arglebargle', mode='dpss_leastsq')
@@ -443,8 +471,8 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='freq', overwrite=False, mode='dpss_leastsq')
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='time', overwrite=True, max_frate=1.0, mode='dpss_leastsq')
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0] == 'skipped'
-        assert V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3] == 'success'
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][0] == 'skipped'
+        assert V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][3] == 'success'
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -454,7 +482,7 @@ class Test_VisClean(object):
         assert np.all(np.isclose(V.clean_data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]],
                                  V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-6))
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 25, 'ee')], ax='both', overwrite=True, max_frate=1.0, mode='dpss_leastsq')
-        assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert np.all(['success' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -644,7 +672,7 @@ class Test_VisClean(object):
 
         # basic freq clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True)
-        assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert np.all([V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] == 'success' for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -655,8 +683,8 @@ class Test_VisClean(object):
                                  V.data[(24, 25, 'ee')][~V.flags[(24, 25, 'ee')] & ~V.clean_flags[(24, 25, 'ee')]], atol=1e-16))
         # basic time clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', max_frate=10., overwrite=True)
-        assert 'skipped' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][0]
-        assert 'success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][3]
+        assert 'skipped' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][0]
+        assert 'success' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][3]
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -668,8 +696,8 @@ class Test_VisClean(object):
         # basic 2d clean
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,
                     filt2d_mode='plus')
-        assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
-        assert np.all(['success' == V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
+        assert np.all(['success' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][i] for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0']])
+        assert np.all(['success' == V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
         # check that clean resid is equal to zero in flagged channels
         assert np.all(V.clean_resid[(24, 25, 'ee')][V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')]] == 0.)
         assert np.any(V.clean_resid[(24, 25, 'ee')][~(V.clean_flags[(24, 25, 'ee')] | V.flags[(24, 25, 'ee')])] != 0.)
@@ -681,8 +709,8 @@ class Test_VisClean(object):
 
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', flags=V.flags + True, max_frate=10.,
                     overwrite=True, filt2d_mode='plus')
-        assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_1'][i] == 'skipped' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_1']])
-        assert np.all([V.clean_info[(24, 25, 'ee')]['status']['axis_0'][i] == 'skipped' for i in V.clean_info[(24, 25, 'ee')]['status']['axis_0']])
+        assert np.all([V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1'][i] == 'skipped' for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_1']])
+        assert np.all([V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0'][i] == 'skipped' for i in V.clean_info[(24, 25, 'ee')][(0, V.Nfreqs)]['status']['axis_0']])
 
         # test fft data
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', max_frate=10., overwrite=True,

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -127,14 +127,14 @@ def test_flag_rows_with_flags_within_edge_distance():
         else:
             assert np.all(np.isclose(wout[:, i], weights_in[:, i]))
     # 30th and 20th channels should end up flagged for this case.
-    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=11, ax='time')
+    times = np.arange(Ntimes) * 10.
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(times, weights_in, min_flag_edge_distance=11, ax='time')
     for i in range(wout.shape[1]):
         if i == 30 or i == 20:
             assert np.all(np.isclose(wout[:, i], 0.0))
         else:
             assert np.all(np.isclose(wout[:, i], weights_in[:, i]))
     # now do both
-    times = np.arange(Ntimes) * 10.
     wout = vis_clean.flag_rows_with_flags_within_edge_distance([times, freqs], weights_in, min_flag_edge_distance=(3, 3), ax='both')
     for i in range(wout.shape[1]):
         if i == 30:

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -40,24 +40,28 @@ def test_truncate_flagged_edges():
     times = np.arange(60) * 10.
     freqs = np.arange(64) * 100e3
     # test freq truncation
-    xout, dout, wout, edges = vis_clean.truncate_flagged_edges(data_in, weights_in, freqs, ax='freq')
+    xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, freqs, ax='freq')
     assert np.all(np.isclose(xout, freqs[:-1]))
     assert np.all(np.isclose(dout, data_in[:, :-1]))
     assert np.all(np.isclose(wout, weights_in[:, :-1]))
     assert edges == [(0, 0), (0, 1)]
     # test time truncation
-    xout, dout, wout, edges = vis_clean.truncate_flagged_edges(data_in, weights_in, times, ax='time')
+    xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, times, ax='time')
     assert np.all(np.isclose(xout, times[:-2]))
     assert np.all(np.isclose(dout, data_in[:-2, :]))
     assert np.all(np.isclose(wout, weights_in[:-2, :]))
     assert edges == [(0, 2), (0, 0)]
     # test truncating both.
-    xout, dout, wout, edges = vis_clean.truncate_flagged_edges(data_in, weights_in, (times, freqs), ax='both')
+    xout, dout, wout, edges, _ = vis_clean.truncate_flagged_edges(data_in, weights_in, (times, freqs), ax='both')
     assert np.all(np.isclose(xout[0], times[:-2]))
     assert np.all(np.isclose(xout[1], freqs[:-1]))
     assert np.all(np.isclose(dout, data_in[:-2, :-1]))
     assert np.all(np.isclose(wout, weights_in[:-2, :-1]))
     assert edges == [(0, 2), (0, 1)]
+
+def find_discontinuity_edges():
+    assert find_discontinuity_edges([0, 1, 4, 9]) == [(0, 2), (2, 3), (3, 4)]
+    assert find_discontinuity_edges([0, 1, 2, 4, 5, 6, 7, 11, 12]) == [(0, 3), (3, 7), (7, 8), (8, 9)]
 
 
 def test_flag_rows_with_flags_within_edge_distance():

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -143,6 +143,32 @@ def test_flag_rows_with_flags_within_edge_distance():
         if i == 32:
             assert np.all(np.isclose(wout[i], 0.0))
 
+ef test_flag_rows_with_flags_within_edge_distance_with_breaks():
+    Nfreqs = 64
+    Ntimes = 60
+    freqs = np.hstack([np.arange(23), 30 + np.arange(24), 58 + np.arange(17)]) * 100e3 + 150e6 #  freq axis with discontinuities at 23 and 47 integrations.
+    times = np.hstack([np.arange(20) * 11., 41 * 11. + np.arange(27) * 11., 200 * 11. + np.arange(13) * 11.]) # time axis with discontinuities at 29 abd 47 integrations
+    weights_in = np.outer(np.arange(1, Ntimes + 1), np.arange(1, Nfreqs + 1))
+    # frequency direction and time direction separately.
+    weights_in[2, 30] = 0. # time 2 should not get flagged
+    weights_in[21, 48] = 0. # time 21 should get flagged
+    weights_in[55, 46] = 0. # time 55 should get flagged
+    weights_in[25, -2] = 0. # time 25 should get flagged
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=3, ax='freq')
+    assert list(np.where(np.all(np.isclose(wout, 0.), axis=1))[0]) == [21, 25, 55]
+    weights_in[22, 30] = 0. # channel 30 should be flagged
+    # channel 48 will also be flagged.
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance(times, weights_in, min_flag_edge_distance=3, ax='time')
+    assert list(np.where(np.all(np.isclose(wout, 0.), axis=0))[0]) == [30, 48]
+    weights_in = np.outer(np.arange(1, Ntimes + 1), np.arange(1, Nfreqs + 1))
+    # both directions
+    weights_in[22, 30] = 0. # time 2 should not get flagged
+    weights_in[55, 46] = 0. # time 55 should get flagged
+    weights_in[25, -2] = 0. # time 25 should get flagged
+    weights_in[22, 30] = 0. # channel 30 should be flagged
+    wout = vis_clean.flag_rows_with_flags_within_edge_distance([times, freqs], weights_in, min_flag_edge_distance=[2, 3], ax='both')
+    assert list(np.where(np.all(np.isclose(wout, 0.), axis=0))[0]) == [30]
+    assert list(np.where(np.all(np.isclose(wout, 0.), axis=1))[0]) == [25, 55]
 
 def test_flag_rows_with_contiguous_flags():
     Nfreqs = 64

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -674,31 +674,118 @@ class Test_VisClean(object):
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True,
                     skip_flagged_edges=True, mode='dpss_leastsq')
         for k in V.clean_flags:
-            for i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
-                assert np.all(V.clean_flags[k][:, i])
-            for i in range(1, 28):
-                assert not np.any(V.clean_flags[k][:, i])
-            for i in range(34, 46):
-                assert not np.any(V.clean_flags[k][:, i])
-            for i in range(48, V.Nfreqs):
-                assert not np.any(V.clean_flags[k][:, i])
-
+            for i in range(V.Nfreqs):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
+                    assert np.all(V.clean_flags[k][:, i])
+                else:
+                    assert not np.any(V.clean_flags[k][:, i])
         # test spw_range functionality.
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='freq', overwrite=True,
                     skip_flagged_edges=True, filter_spw_ranges=[(0, 30), (30, 46), (46, V.Nfreqs)])
         for k in V.clean_flags:
-            for i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
-                assert np.all(V.clean_flags[k][:, i])
-            for i in range(1, 28):
-                assert not np.any(V.clean_flags[k][:, i])
-            for i in range(34, 46):
-                assert not np.any(V.clean_flags[k][:, i])
-            for i in range(48, V.Nfreqs):
-                assert not np.any(V.clean_flags[k][:, i])
+            for i in range(V.Nfreqs):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
+                    assert np.all(V.clean_flags[k][:, i])
+                else:
+                    assert not np.any(V.clean_flags[k][:, i])
         # test NotImplementedError
         pytest.raises(NotImplementedError, V.vis_clean, keys=[(24, 25, 'ee')], ax='freq', overwrite=True,
                       filter_spw_ranges=[(0, 30), (31, V.Nfreqs)])
-        # test time filtering and filtering both axes.
+
+    def test_vis_clean_spws_time(self, tmpdir):
+        # test spw-ranges with time filtering.
+        tmp_path = tmpdir.strpath
+        template = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
+        # first run flagging channels and frequencies
+        fname_edgeflags = os.path.join(tmp_path, "zen.2458043.40141.xx.HH.XRAA.edgeflags.uvh5")
+        fname_flagged = os.path.join(tmp_path, "zen.2458043.40141.xx.HH.XRAA.allflags.uvh5")
+        hdt = io.HERAData(template)
+        d, f, n = hdt.read(times=np.hstack([hdt.times[:30], hdt.times[32:48], hdt.times[49:]]))
+        for k in d:
+            f[k][:] = False
+            f[k][0, :] = True
+            for i in (28, 29, 30, 31, 32, 33):
+                f[k][i, :] = True  # flags around first discont
+            f[k][12, :] = True  # should be inpainted
+            f[k][46, :] = True  # flag near second break
+            f[k][47, :] = True  # flag near second break
+            f[k][49, :] = True  # should be inpainted
+            d[k] = np.random.randn(*d[k].shape) + np.random.randn(*d[k].shape) * 1j
+            n[k] = np.ones(d[k].shape)
+        hdt.update(flags=f, data=d)
+        hdt.write_uvh5(fname_edgeflags)
+        V = VisClean(fname_edgeflags, filetype='uvh5')
+        V.read()
+        V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', overwrite=True,
+                    skip_flagged_edges=True, mode='dpss_leastsq', max_frate=0.025)
+        for k in V.clean_flags:
+            for i in range(V.Ntimes):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
+                    assert np.all(V.clean_flags[k][i])
+                else:
+                    assert not np.any(V.clean_flags[k][i])
+        # test spw_range functionality in time axis clean.
+        V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', overwrite=True,
+                    skip_flagged_edges=True, filter_spw_ranges=[(0, 30), (30, 46), (46, V.Nfreqs)], max_frate=0.025, mode='dpss_leastsq')
+        for k in V.clean_flags:
+            for i in range(V.Ntimes):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46, 47):
+                    assert np.all(V.clean_flags[k][i])
+                else:
+                    assert not np.any(V.clean_flags[k][i])
+
+    def test_vis_clean_spws_both(self, tmpdir):
+        # test spw-ranges with time filtering.
+        tmp_path = tmpdir.strpath
+        template = os.path.join(DATA_PATH, "zen.2458043.40141.xx.HH.XRAA.uvh5")
+        # first run flagging channels and frequencies
+        fname_edgeflags = os.path.join(tmp_path, "zen.2458043.40141.xx.HH.XRAA.edgeflags.uvh5")
+        fname_flagged = os.path.join(tmp_path, "zen.2458043.40141.xx.HH.XRAA.allflags.uvh5")
+        hdt = io.HERAData(template)
+        d, f, n = hdt.read(times=np.hstack([hdt.times[:30], hdt.times[32:48], hdt.times[49:]]),
+                           frequencies=np.hstack([hdt.freqs[:21], hdt.freqs[23:45], hdt.freqs[52:]]))
+        for k in d:
+            f[k][:] = False
+            f[k][0, :] = True
+            for i in (12, 28, 29, 30, 31, 32, 33, 46, 49):
+                f[k][i, :] = True  # flags around first discont
+            for j in (4, 18, 21, 22, 23, 42, 43, 52):
+                f[k][:, j] = True
+
+            d[k] = np.random.randn(*d[k].shape) + np.random.randn(*d[k].shape) * 1j
+            n[k] = np.ones(d[k].shape)
+        hdt.update(flags=f, data=d)
+        hdt.write_uvh5(fname_edgeflags)
+        V = VisClean(fname_edgeflags, filetype='uvh5')
+        V.read()
+        V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', overwrite=True,
+                    skip_flagged_edges=True, mode='dpss_leastsq', max_frate=0.025)
+        for k in V.clean_flags:
+            for i in (range(V.Ntimes)):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46):
+                    assert np.all(V.clean_flags[k][i])
+                else:
+                    assert np.count_nonzero(~V.clean_flags[k][i]) == V.Nfreqs - 5
+            for j in range(V.Nfreqs):
+                if j in (21, 22, 23, 42, 43):
+                    assert np.all(V.clean_flags[k][:, j])
+                else:
+                    assert np.count_nonzero(~V.clean_flags[k][:, j]) == V.Ntimes - 8
+
+        # test spw_range functionality in time axis clean.
+        V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', overwrite=True,
+                    skip_flagged_edges=True, filter_spw_ranges=[(0, 30), (30, 46), (46, V.Nfreqs)], max_frate=0.025, mode='dpss_leastsq')
+        for k in V.clean_flags:
+            for i in (range(V.Ntimes)):
+                if i in (0, 28, 29, 30, 31, 32, 33, 46):
+                    assert np.all(V.clean_flags[k][i])
+                else:
+                    assert np.count_nonzero(~V.clean_flags[k][i]) == V.Nfreqs - 5
+            for j in range(V.Nfreqs):
+                if j in (21, 22, 23, 42, 43):
+                    assert np.all(V.clean_flags[k][:, j])
+                else:
+                    assert np.count_nonzero(~V.clean_flags[k][:, j]) == V.Ntimes - 8
 
     def test_apply_flags(self):
         # cover edge cases of apply_flags not covered in test_delay_filter and

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -611,7 +611,7 @@ class Test_VisClean(object):
         for k in [(24, 25, 'ee'), (24, 24, 'ee')]:
             for i in range(V.Ntimes):
                 if i == 12:
-                    assert np.all(V.clean_flags[k][i])
+                    assert V.clean_info[k][(0, V.Nfreqs)]['status']['axis_1'][i] == 'skipped'
                 else:
                     assert not np.any(V.clean_flags[k][i])
 
@@ -764,6 +764,8 @@ class Test_VisClean(object):
             for i in (range(V.Ntimes)):
                 if i in (0, 28, 29, 30, 31, 32, 33, 46):
                     assert np.all(V.clean_flags[k][i])
+                    for spw_range in V.clean_info[k]:
+                        assert i not in V.clean_info[k][spw_range]['status']['axis_1']
                 else:
                     assert np.count_nonzero(~V.clean_flags[k][i]) == V.Nfreqs - 5
             for j in range(V.Nfreqs):
@@ -779,13 +781,20 @@ class Test_VisClean(object):
             for i in (range(V.Ntimes)):
                 if i in (0, 28, 29, 30, 31, 32, 33, 46):
                     assert np.all(V.clean_flags[k][i])
+                    for spw_range in V.clean_info[k]:
+                        assert i not in V.clean_info[k][spw_range]['status']['axis_1']
                 else:
                     assert np.count_nonzero(~V.clean_flags[k][i]) == V.Nfreqs - 5
-            for j in range(V.Nfreqs):
-                if j in (21, 22, 23, 42, 43):
-                    assert np.all(V.clean_flags[k][:, j])
-                else:
-                    assert np.count_nonzero(~V.clean_flags[k][:, j]) == V.Ntimes - 8
+                    for spw_range in V.clean_info[k]:
+                        assert i in V.clean_info[k][spw_range]['status']['axis_1']
+            for spw_range in V.clean_info[k]:
+                for j in range(spw_range[0], spw_range[1]):
+                    if j in (21, 22, 23, 42, 43):
+                        assert np.all(V.clean_flags[k][:, j])
+                        assert j not in V.clean_info[k][spw_range]['status']['axis_0']
+                    else:
+                        assert np.count_nonzero(~V.clean_flags[k][:, j]) == V.Ntimes - 8
+                        assert j in V.clean_info[k][spw_range]['status']['axis_0']
 
     def test_apply_flags(self):
         # cover edge cases of apply_flags not covered in test_delay_filter and

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -232,7 +232,7 @@ def test_get_max_contiguous_flag_from_filter_periods():
     assert tuple(mcf) == (3, 2)
     # test assertion errors
     pytest.raises(ValueError, vis_clean.get_max_contiguous_flag_from_filter_periods, [1.], [0.], [.5])
-    pytest.raises(ValueError, vis_clean.get_max_contiguous_flag_from_filter_periods, [[1.], [0.]], [0.], [.5])
+    pytest.raises(ValueError, vis_clean.get_max_contiguous_flag_from_filter_periods, [[1.], [0.]], [[0.], [0.]], [[.5], [.5]])
 
 
 def test_flag_model_rms():

--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -143,32 +143,34 @@ def test_flag_rows_with_flags_within_edge_distance():
         if i == 32:
             assert np.all(np.isclose(wout[i], 0.0))
 
-ef test_flag_rows_with_flags_within_edge_distance_with_breaks():
+
+def test_flag_rows_with_flags_within_edge_distance_with_breaks():
     Nfreqs = 64
     Ntimes = 60
-    freqs = np.hstack([np.arange(23), 30 + np.arange(24), 58 + np.arange(17)]) * 100e3 + 150e6 #  freq axis with discontinuities at 23 and 47 integrations.
-    times = np.hstack([np.arange(20) * 11., 41 * 11. + np.arange(27) * 11., 200 * 11. + np.arange(13) * 11.]) # time axis with discontinuities at 29 abd 47 integrations
+    freqs = np.hstack([np.arange(23), 30 + np.arange(24), 58 + np.arange(17)]) * 100e3 + 150e6  # freq axis with discontinuities at 23 and 47 integrations.
+    times = np.hstack([np.arange(20) * 11., 41 * 11. + np.arange(27) * 11., 200 * 11. + np.arange(13) * 11.])  # time axis with discontinuities at 29 abd 47 integrations
     weights_in = np.outer(np.arange(1, Ntimes + 1), np.arange(1, Nfreqs + 1))
     # frequency direction and time direction separately.
-    weights_in[2, 30] = 0. # time 2 should not get flagged
-    weights_in[21, 48] = 0. # time 21 should get flagged
-    weights_in[55, 46] = 0. # time 55 should get flagged
-    weights_in[25, -2] = 0. # time 25 should get flagged
+    weights_in[2, 30] = 0.  # time 2 should not get flagged
+    weights_in[21, 48] = 0.  # time 21 should get flagged
+    weights_in[55, 46] = 0.  # time 55 should get flagged
+    weights_in[25, -2] = 0.  # time 25 should get flagged
     wout = vis_clean.flag_rows_with_flags_within_edge_distance(freqs, weights_in, min_flag_edge_distance=3, ax='freq')
     assert list(np.where(np.all(np.isclose(wout, 0.), axis=1))[0]) == [21, 25, 55]
-    weights_in[22, 30] = 0. # channel 30 should be flagged
+    weights_in[22, 30] = 0.  # channel 30 should be flagged
     # channel 48 will also be flagged.
     wout = vis_clean.flag_rows_with_flags_within_edge_distance(times, weights_in, min_flag_edge_distance=3, ax='time')
     assert list(np.where(np.all(np.isclose(wout, 0.), axis=0))[0]) == [30, 48]
     weights_in = np.outer(np.arange(1, Ntimes + 1), np.arange(1, Nfreqs + 1))
     # both directions
-    weights_in[22, 30] = 0. # time 2 should not get flagged
-    weights_in[55, 46] = 0. # time 55 should get flagged
-    weights_in[25, -2] = 0. # time 25 should get flagged
-    weights_in[22, 30] = 0. # channel 30 should be flagged
+    weights_in[22, 30] = 0.  # time 2 should not get flagged
+    weights_in[55, 46] = 0.  # time 55 should get flagged
+    weights_in[25, -2] = 0.  # time 25 should get flagged
+    weights_in[22, 30] = 0.  # channel 30 should be flagged
     wout = vis_clean.flag_rows_with_flags_within_edge_distance([times, freqs], weights_in, min_flag_edge_distance=[2, 3], ax='both')
     assert list(np.where(np.all(np.isclose(wout, 0.), axis=0))[0]) == [30]
     assert list(np.where(np.all(np.isclose(wout, 0.), axis=1))[0]) == [25, 55]
+
 
 def test_flag_rows_with_contiguous_flags():
     Nfreqs = 64

--- a/hera_cal/tests/test_xtalk_filter.py
+++ b/hera_cal/tests/test_xtalk_filter.py
@@ -47,7 +47,7 @@ class Test_XTalkFilter(object):
             wgts = {k: np.ones_like(xfil.flags[k], dtype=np.float)}
             wgts[k][:, 0] = 0.0
             xfil.run_xtalk_filter(to_filter=[k], weight_dict=wgts, tol=1e-5, window='blackman-harris', skip_wgt=0.1, maxiter=100)
-            assert xfil.clean_info[k]['status']['axis_0'][0] == 'skipped'
+            assert xfil.clean_info[k][(0, xfil.Nfreqs)]['status']['axis_0'][0] == 'skipped'
             np.testing.assert_array_equal(xfil.clean_flags[k][:, 0], np.ones_like(xfil.flags[k][:, 0]))
             np.testing.assert_array_equal(xfil.clean_model[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))
             np.testing.assert_array_equal(xfil.clean_resid[k][:, 0], np.zeros_like(xfil.clean_resid[k][:, 0]))

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -46,7 +46,7 @@ def find_discontinuity_edges(x, xtol=1e-3):
             x = [0, 1, 2, 4, 5, 6, 7, 11, 12] -> [(0, 3), (3, 7), (7, 9)]
     """
     xdiff = np.diff(x)
-    discontinuities = np.where(~np.isclose(xdiff, np.median(np.abs(xdiff)) * np.sign(xdiff[0]),
+    discontinuities = np.where(~np.isclose(xdiff, np.min(np.abs(xdiff)) * np.sign(xdiff[0]),
                                rtol=0.0, atol=np.abs(np.min(xdiff)) * xtol))[0]
     if len(discontinuities) == 0:
         edges = [(0, len(x))]

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -24,12 +24,17 @@ from .flag_utils import factorize_flags
 def find_discontinuity_edges(x, xtol=1e-3):
     """Find edges based on discontinuity in x-axis
 
+    This function helps us find discontinuities in the x-axis which exist if we have several non-contiguous subbands in our data (for example, excluding the FM band).
+
     Parameters
     ----------
     x: array-like
         1d numpy array of x-values.
     xtol: float, optional
-        fractional discontinuity in diff of xs above which an edge will be identified.
+        fractional discontinuity in diff (relative to median discontinuity)
+        to be used as a threshold for identifying discontinuities in the x-axis.
+        positions where the diff is larger then the median diff is identified as a
+        discontinuity.
 
     Returns
     -------
@@ -41,7 +46,7 @@ def find_discontinuity_edges(x, xtol=1e-3):
             x = [0, 1, 2, 4, 5, 6, 7, 11, 12] -> [(0, 3), (3, 7), (7, 9)]
     """
     xdiff = np.diff(x)
-    discontinuities = np.where(~np.isclose(xdiff, np.min(np.abs(xdiff)) * np.sign(xdiff[0]),
+    discontinuities = np.where(~np.isclose(xdiff, np.median(np.abs(xdiff)) * np.sign(xdiff[0]),
                                rtol=0.0, atol=np.abs(np.min(xdiff)) * xtol))[0]
     if len(discontinuities) == 0:
         edges = [(0, len(x))]
@@ -84,6 +89,12 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
         weights_in with completely flagged edges trimmed off.
     edges : list of 2-tuples or 2-list of lists of 2-tuples
         the width of the edges trimmed.
+        Example: Suppose we provide data 100 frequency channels and discontinuities
+        after channel 37 and after channel 59 and
+        suppose that channels [0, 12, 36, 37, 59, 60, 61] are flagged.
+        Then edges = [(1, 2), (0, 1), (2, 0)]
+        which is the number of edge channels flagged on each contiguous chunk.
+
         If ax == 'both' then a 2-list of lists of tuples
         first list is time dim, second list is freq dim.
     chunks : list of 2-tuples or 2-list of lists of 2-tuples

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -86,7 +86,6 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
         the width of the edges trimmed.
         If ax == 'both' then a 2-list of lists of tuples
         first list is time dim, second list is freq dim.
-        these lists can be greater then length 1 if treat_spectral_breaks_as_edges = True
     chunks : list of 2-tuples or 2-list of lists of 2-tuples
         List of start / end indices of each chunk that edges are applied to.
         If ax=='both' should be a 2-tuple or 2-list.
@@ -151,12 +150,10 @@ def restore_flagged_edges(x, data, edges, ax='freq'):
        dimensions (nf_trimmed, nt_trimmed)
      edges : list of 2-tuples or 2-list of lists of 2-tuples.
         the width of the edges trimmed.
-        these lists can be greater then length 1 if treat_spectral_breaks_as_edges = True
         must be 2-list of lists if ax=='both'
      chunks : list of 2-tuples or 2-list of lists of 2-tuples.
         indices indicating the chunk edges that edge widths are reference too.
         first list is time dim, second list is freq dim.
-        these lists can be greater then length 1 if treat_spectral_breaks_as_edges = True
     ax : axis to restore gaps on.
     Returns
     -------
@@ -1133,6 +1130,8 @@ class VisClean(object):
                 # also flag skipped edge channels and integrations.
                 if skip_flagged_edges:
                     if ax == 'both':
+                        print(chunks[0], edges[0])
+                        print(chunks[1], edges[1])
                         for chunk, edge in zip(chunks[1], edges[1]):
                             cslice0 = slice(chunk[0], chunk[0] + edge[0])
                             cslice1 = slice(chunk[1] - edge[1], chunk[1])

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1115,7 +1115,7 @@ class VisClean(object):
                             res, _ = zeropad_array(res, zeropad=zeropad[i], axis=i, undo=True)
                         _trim_status(info, i, zeropad[i - 1])
                 # flag integrations and channels that were skipped.
-                skipped = np.zeros_like(d, dtype=np.bool)
+                skipped = np.zeros_like(mdl, dtype=np.bool)
                 for dim in range(2):
                     if len(info['status']['axis_%d' % dim]) > 0:
                         for i in range(len(info['status']['axis_%d' % dim])):

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1789,6 +1789,12 @@ def _filter_argparser():
         Argparser with core (but not complete) functionality that is called by _linear_argparser and
         _clean_argparser.
     """
+    def list_of_int_tuples(v):
+        if '~' in v:
+            v = [tuple([int(_x) for _x in x.split('~')]) for x in v.split(",")]
+        else:
+            v = [tuple([int(_x) for _x in x.split()]) for x in v.split(",")]
+        return v
     ap = argparse.ArgumentParser(description="Perform delay filter of visibility data.")
     ap.add_argument("datafilelist", default=None, type=str, nargs="+", help="list of data files to read in and perform filtering on.")
     ap.add_argument("--mode", type=str, default="clean", help="filtering mode to use. Can be dpss_leastsq, clean, dayenu.")

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -54,6 +54,7 @@ def find_discontinuity_edges(x, xtol=1e-3):
         edges.append((discontinuities[-1] + 1, len(x)))
     return edges
 
+
 def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
     """
     cut away edge channels and integrations that are completely flagged
@@ -182,6 +183,7 @@ def restore_flagged_edges(x, data, edges, ax='freq'):
             # if axis is both, then process time-axis after freq axis.
             data_restored = restore_flagged_edges(x[0], data_restored, edges[0], ax='time')
     return data_restored
+
 
 def flag_rows_with_flags_within_edge_distance(x, weights_in, min_flag_edge_distance, ax='freq'):
     """
@@ -1851,8 +1853,8 @@ def _filter_argparser():
     ap.add_argument("--polarizations", default=None, type=str, nargs="+", help="list of polarizations to filter.")
     ap.add_argument("--verbose", default=False, action="store_true", help="Lots of text.")
     ap.add_argument("--filter_spw_ranges", default=None, type=list_of_int_tuples, help="List of spw channel selections to filter independently. Two acceptable formats are "
-                                                                                "Ex1: '200~300,500~650' --> [(200, 300), (500, 650), ...] and "
-                                                                                "Ex2: '200 300, 500 650' --> [(200, 300), (500, 650), ...]")
+                                                                                       "Ex1: '200~300,500~650' --> [(200, 300), (500, 650), ...] and "
+                                                                                       "Ex2: '200 300, 500 650' --> [(200, 300), (500, 650), ...]")
     # clean arguments.
     clean_options = ap.add_argument_group(title='Options for CLEAN (arguments only used if mode=="clean"!)')
     clean_options.add_argument("--window", type=str, default='blackman-harris', help='window function for frequency filtering (default "blackman-harris",\

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -985,7 +985,6 @@ class VisClean(object):
             filter2d = False
             if x is None:
                 x = (self.times - np.mean(self.times)) * 3600. * 24.
-            filter_spw_ranges = [(0, self.Nfreqs)]
             if zeropad is None:
                 zeropad = 0
         elif ax == 'freq':
@@ -995,8 +994,8 @@ class VisClean(object):
                 zeropad = 0
             if x is None:
                 x = self.freqs
-            if filter_spw_ranges is None:
-                filter_spw_ranges = [(0, self.Nfreqs)]
+        if filter_spw_ranges is None:
+            filter_spw_ranges = [(0, self.Nfreqs)]
         else:
             raise ValueError("ax must be one of ['freq', 'time', 'both']")
         if len(self.freqs) != np.sum([spw_range[1] - spw_range[0] for spw_range in filter_spw_ranges]) or not np.allclose(self.freqs, self.freqs[np.hstack([np.arange(spw_range[0], spw_range[1]).astype(int) for spw_range in filter_spw_ranges])]):

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -199,6 +199,7 @@ def flag_rows_with_flags_within_edge_distance(x, weights_in, min_flag_edge_dista
         string specifying which axis to flag edges of.
         valid options include 'freq', 'time', 'both'.
         default is 'freq'
+
     Returns
     -------
     wout, array-like 2d
@@ -207,8 +208,6 @@ def flag_rows_with_flags_within_edge_distance(x, weights_in, min_flag_edge_dista
 
     """
     if ax == 'time':
-        if isinstance(x, (tuple, list)) and len(x) == 2:
-            x = x[0]
         wout = flag_rows_with_flags_within_edge_distance(x, weights_in.T, min_flag_edge_distance).T
     else:
         if isinstance(x, (tuple, list)) and len(x) == 2:
@@ -219,12 +218,16 @@ def flag_rows_with_flags_within_edge_distance(x, weights_in, min_flag_edge_dista
         for rownum, wrow in enumerate(wout):
             flagrow = False
             for chunk in chunks:
-                cslice = slice(chunk[0], chunk[1])
                 if ax == 'both':
-                    if np.any(np.isclose(wout[rownum][cslice][:min_flag_edge_distance[1]], 0.0)) | np.any(np.isclose(wout[rownum][cslice][-min_flag_edge_distance[1] - 1:], 0.0)):
+                    cslice0 = slice(chunk[0], chunk[0] + min_flag_edge_distance[1] + 1)
+                    cslice1 = slice(chunk[1] - min_flag_edge_distance[1] - 1, chunk[1])
+                    if np.any(np.isclose(wout[rownum, cslice0], 0.0)) | np.any(np.isclose(wout[rownum, cslice1], 0.0)):
                         flagrow = True
-                elif np.any(np.isclose(wout[rownum][cslice][:min_flag_edge_distance], 0.0)) | np.any(np.isclose(wout[rownum][cslice][-min_flag_edge_distance - 1:], 0.0)):
-                    flagrow = True
+                else:
+                    cslice0 = slice(chunk[0], chunk[0] + min_flag_edge_distance + 1)
+                    cslice1 = slice(chunk[1] - min_flag_edge_distance - 1, chunk[1])
+                    if np.any(np.isclose(wout[rownum, cslice0], 0.0)) | np.any(np.isclose(wout[rownum, cslice1], 0.0)):
+                        flagrow = True
             if flagrow:
                 wout[rownum, :] = 0.
         if ax == 'both':

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -978,8 +978,6 @@ class VisClean(object):
                 x = [(self.times - np.mean(self.times)) * 3600. * 24., self.freqs]
             if skip_if_flag_within_edge_distance == 0:
                 skip_if_flag_within_edge_distance = (0, 0)
-            if filter_spw_ranges is None:
-                filter_spw_ranges = [(0, self.Nfreqs)]
         elif ax == 'time':
             filterdim = 0
             filter2d = False
@@ -994,10 +992,10 @@ class VisClean(object):
                 zeropad = 0
             if x is None:
                 x = self.freqs
-        if filter_spw_ranges is None:
-            filter_spw_ranges = [(0, self.Nfreqs)]
         else:
             raise ValueError("ax must be one of ['freq', 'time', 'both']")
+        if filter_spw_ranges is None:
+            filter_spw_ranges = [(0, self.Nfreqs)]
         if len(self.freqs) != np.sum([spw_range[1] - spw_range[0] for spw_range in filter_spw_ranges]) or not np.allclose(self.freqs, self.freqs[np.hstack([np.arange(spw_range[0], spw_range[1]).astype(int) for spw_range in filter_spw_ranges])]):
             raise NotImplementedError("No support for spw-ranges that do not disjointly cover the entire frequency band.")
         # initialize containers

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -54,7 +54,7 @@ def find_discontinuity_edges(x, xtol=1e-3):
         edges.append((discontinuities[-1] + 1, len(x)))
     return edges
 
-def truncate_flagged_edges(data_in, weights_in, x, ax='freq', treat_spectral_breaks_as_edges=True, xtol=1e-3):
+def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
     """
     cut away edge channels and integrations that are completely flagged
 
@@ -99,10 +99,7 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq', treat_spectral_bre
         edges = [edges[1], [(0, 0)]]
     else:
         # Identify all contiguous chunks.
-        if treat_spectral_breaks_as_edges:
-            chunks = find_discontinuity_edges(x)
-        else:
-            chunks = [(0, data_in.shape[1])]
+        chunks = find_discontinuity_edges(x)
         inds_left = []
         inds_right = []
         # Identify edge channels that are flagged.
@@ -182,7 +179,7 @@ def restore_flagged_edges(x, data, edges, ax='freq'):
         edges = [edges[1], edges[0]]
     return data_restored
 
-def flag_rows_with_flags_within_edge_distance(weights_in, min_flag_edge_distance, ax='freq'):
+def flag_rows_with_flags_within_edge_distance(x, weights_in, min_flag_edge_distance, ax='freq'):
     """
     flag integrations (and/or channels) with flags within min_flag_edge_distance of edge.
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -136,25 +136,29 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
 
 
 def restore_flagged_edges(x, data, edges, ax='freq'):
-    """fill in flagged regions of data array produced
-       by truncate_flagged_edges with zeros.
+    """
+    fill in flagged regions of data array produced
+    by truncate_flagged_edges with zeros.
 
-     Parameters
-     ----------
-     x: array-like or 2-list/tuple of arrays
-       1d array of x-values of data with removed edges.
-       if ax=='both', must be 2-list of arrays.
-     data: array-like
-       2d array containing data that has been trimmed with
-       trunate_flagged_edges (dout or wout)
-       dimensions (nf_trimmed, nt_trimmed)
-     edges : list of 2-tuples or 2-list of lists of 2-tuples.
+    Parameters
+    ----------
+    x: array-like or 2-list/tuple of arrays
+        1d array of x-values of data with removed edges.
+        if ax=='both', must be 2-list of arrays.
+    data: array-like
+        2d array containing data that has been trimmed with
+        trunate_flagged_edges (dout or wout)
+        dimensions (nf_trimmed, nt_trimmed)
+    edges : list of 2-tuples or 2-list of lists of 2-tuples.
         the width of the edges trimmed.
         must be 2-list of lists if ax=='both'
-     chunks : list of 2-tuples or 2-list of lists of 2-tuples.
+    chunks : list of 2-tuples or 2-list of lists of 2-tuples.
         indices indicating the chunk edges that edge widths are reference too.
         first list is time dim, second list is freq dim.
-    ax : axis to restore gaps on.
+    ax : str, optional
+        axis to restore gaps on.
+        default is 'freq'
+
     Returns
     -------
     data_restored: array-like

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -655,7 +655,7 @@ class VisClean(object):
                        x=None, keys=None, data=None, flags=None, wgts=None,
                        output_prefix='clean', zeropad=None, cache=None,
                        ax='freq', skip_wgt=0.1, verbose=False, overwrite=False,
-                       skip_flagged_edges=False,
+                       skip_flagged_edges=False, spw_ranges=None,
                        skip_contiguous_flags=False, max_contiguous_flag=None,
                        keep_flags=False, clean_flags_in_resid_flags=False,
                        skip_if_flag_within_edge_distance=0,
@@ -744,6 +744,8 @@ class VisClean(object):
             if true, do not filter over flagged edge times (if ax='time') (filter over sub-region)
             or dont filter over flagged edge freqs (if ax='freq') or dont filter over both (if ax='both')
             defualt is False
+        spw_ranges : list of 2-tuples, optional
+            list of 2-tuples specifying spw-ranges to filter simultaneously
         skip_contiguous_flags : bool, optional
             if true, skip integrations or channels with gaps that are larger then integer
             specified in max_contiguous_flag
@@ -856,11 +858,14 @@ class VisClean(object):
                 x = [(self.times - np.mean(self.times)) * 3600. * 24., self.freqs]
             if skip_if_flag_within_edge_distance == 0:
                 skip_if_flag_within_edge_distance = (0, 0)
+            if spw_ranges is None:
+                spw_ranges = [(0, self.Nfreqs)]
         elif ax == 'time':
             filterdim = 0
             filter2d = False
             if x is None:
                 x = (self.times - np.mean(self.times)) * 3600. * 24.
+            spw_ranges = [(0, self.Nfreqs)]
             if zeropad is None:
                 zeropad = 0
         elif ax == 'freq':
@@ -870,9 +875,12 @@ class VisClean(object):
                 zeropad = 0
             if x is None:
                 x = self.freqs
+            if spw_ranges is None:
+                spw_ranges = [(0, self.Nfreqs)]
         else:
             raise ValueError("ax must be one of ['freq', 'time', 'both']")
-
+        if not np.allclose(self.freqs, self.freqs[np.hstack([np.arange(spw_range[0], spw_range[1]).astype(int) for spw_range in spw_ranges])]):
+            raise NotImplementedError("No support for spw-ranges that do not disjointly cover the entire frequency band.")
         # initialize containers
         containers = ["{}_{}".format(output_prefix, dc) for dc in ['model', 'resid', 'flags', 'data', 'resid_flags']]
         for i, dc in enumerate(containers):
@@ -911,115 +919,124 @@ class VisClean(object):
                 echo("{} exists in clean_model and overwrite is False, skipping...".format(k), verbose=verbose)
                 continue
             echo("Starting fourier filter of {} at {}".format(k, str(datetime.datetime.now())), verbose=verbose)
-            d = data[k]
-            f = flags[k]
-            fw = (~f).astype(np.float)
-            w = fw * wgts[k]
-            # avoid modifying x in-place with zero-padding.
-            xp = copy.deepcopy(x)
-            if ax == 'freq':
-                # zeropad the data
-                if zeropad > 0:
-                    d, _ = zeropad_array(d, zeropad=zeropad, axis=1)
-                    w, _ = zeropad_array(w, zeropad=zeropad, axis=1)
-                    xp = np.hstack([x.min() - (1 + np.arange(zeropad)[::-1]) * np.median(np.diff(x)), x,
-                                    x.max() + (1 + np.arange(zeropad)) * np.median(np.diff(x))])
-            elif ax == 'time':
-                # zeropad the data
-                if zeropad > 0:
-                    d, _ = zeropad_array(d, zeropad=zeropad, axis=0)
-                    w, _ = zeropad_array(w, zeropad=zeropad, axis=0)
-                    xp = np.hstack([x.min() - (1 + np.arange(zeropad)[::-1]) * np.median(np.diff(x)), x,
-                                   x.max() + (1 + np.arange(zeropad)) * np.median(np.diff(x))])
-            elif ax == 'both':
-                if not isinstance(zeropad, (list, tuple)) or not len(zeropad) == 2:
-                    raise ValueError("zeropad must be a 2-tuple or 2-list of integers")
-                if not (isinstance(zeropad[0], (int, np.int)) and isinstance(zeropad[0], (int, np.int))):
-                    raise ValueError("zeropad values must all be integers. You provided %s" % (zeropad))
-                for m in range(2):
-                    if zeropad[m] > 0:
-                        d, _ = zeropad_array(d, zeropad=zeropad[m], axis=m)
-                        w, _ = zeropad_array(w, zeropad=zeropad[m], axis=m)
-                        xp[m] = np.hstack([x[m].min() - (np.arange(zeropad[m])[::-1] + 1) * np.median(np.diff(x[m])),
-                                           x[m], x[m].max() + (1 + np.arange(zeropad[m])) * np.median(np.diff(x[m]))])
-            mdl, res = np.zeros_like(d), np.zeros_like(d)
-            # if we are not including flagged edges in filtering, skip them here.
-            if skip_flagged_edges:
-                xp, din, win, edges = truncate_flagged_edges(d, w, xp, ax=ax)
-            else:
-                din = d
-                win = w
-            # skip integrations with contiguous edge flags exceeding desired limit
-            # (or precomputed limit) here.
-            if skip_contiguous_flags:
-                if max_contiguous_flag is None:
-                    max_contiguous_flag = get_max_contiguous_flag_from_filter_periods(x, filter_centers, filter_half_widths)
-                win = flag_rows_with_contiguous_flags(win, max_contiguous_flag, ax=ax)
-            # skip integrations with flags within some minimum distance of the edges here.
-            if np.any(np.asarray(skip_if_flag_within_edge_distance) > 0):
-                win = flag_rows_with_flags_within_edge_distance(win, skip_if_flag_within_edge_distance, ax=ax)
+            for spw_range in spw_ranges:
+                spw_slice = slice(spw_range[0], spw_range[1])
+                d = data[k][:, spw_slice]
+                f = flags[k][:, spw_slice]
+                fw = (~f).astype(np.float)
+                w = fw * wgts[k]
+                # avoid modifying x in-place with zero-padding.
+                xp = copy.deepcopy(x)
+                if ax == 'freq':
+                    xp = xp[spw_slice]
+                    # zeropad the data
+                    if zeropad > 0:
+                        d, _ = zeropad_array(d, zeropad=zeropad, axis=1)
+                        w, _ = zeropad_array(w, zeropad=zeropad, axis=1)
+                        xp = np.hstack([xp.min() - (1 + np.arange(zeropad)[::-1]) * np.median(np.diff(xp)), xp,
+                                        xp.max() + (1 + np.arange(zeropad)) * np.median(np.diff(xp))])
+                elif ax == 'time':
+                    # zeropad the data
+                    if zeropad > 0:
+                        d, _ = zeropad_array(d, zeropad=zeropad, axis=0)
+                        w, _ = zeropad_array(w, zeropad=zeropad, axis=0)
+                        xp = np.hstack([xp.min() - (1 + np.arange(zeropad)[::-1]) * np.median(np.diff(xp)), xp,
+                                        xp.max() + (1 + np.arange(zeropad)) * np.median(np.diff(xp))])
+                elif ax == 'both':
+                    xp[1] = xp[1][spw_slice]
+                    if not isinstance(zeropad, (list, tuple)) or not len(zeropad) == 2:
+                        raise ValueError("zeropad must be a 2-tuple or 2-list of integers")
+                    if not (isinstance(zeropad[0], (int, np.int)) and isinstance(zeropad[0], (int, np.int))):
+                        raise ValueError("zeropad values must all be integers. You provided %s" % (zeropad))
+                    for m in range(2):
+                        if zeropad[m] > 0:
+                            d, _ = zeropad_array(d, zeropad=zeropad[m], axis=m)
+                            w, _ = zeropad_array(w, zeropad=zeropad[m], axis=m)
+                            xp[m] = np.hstack([xp[m].min() - (np.arange(zeropad[m])[::-1] + 1) * np.median(np.diff(xp[m])),
+                                               xp[m], xp[m].max() + (1 + np.arange(zeropad[m])) * np.median(np.diff(xp[m]))])
+                mdl, res = np.zeros_like(d), np.zeros_like(d)
+                # if we are not including flagged edges in filtering, skip them here.
+                if skip_flagged_edges:
+                    xp, din, win, edges = truncate_flagged_edges(d, w, xp, ax=ax)
+                else:
+                    din = d
+                    win = w
+                # skip integrations with contiguous edge flags exceeding desired limit
+                # (or precomputed limit) here.
+                if skip_contiguous_flags:
+                    if max_contiguous_flag is None:
+                        max_contiguous_flag = get_max_contiguous_flag_from_filter_periods(x, filter_centers, filter_half_widths)
+                    win = flag_rows_with_contiguous_flags(win, max_contiguous_flag, ax=ax)
+                # skip integrations with flags within some minimum distance of the edges here.
+                if np.any(np.asarray(skip_if_flag_within_edge_distance) > 0):
+                    win = flag_rows_with_flags_within_edge_distance(win, skip_if_flag_within_edge_distance, ax=ax)
 
-            mdl, res, info = dspec.fourier_filter(x=xp, data=din, wgts=win, filter_centers=filter_centers,
-                                                  filter_half_widths=filter_half_widths,
-                                                  mode=mode, filter_dims=filterdim, skip_wgt=skip_wgt,
-                                                  **filter_kwargs)
-            # insert back the filtered model if we are skipping flagged edgs.
-            if skip_flagged_edges:
-                mdl = np.pad(mdl, edges)
-                res = np.pad(res, edges)
+                mdl, res, info = dspec.fourier_filter(x=xp, data=din, wgts=win, filter_centers=filter_centers,
+                                                      filter_half_widths=filter_half_widths,
+                                                      mode=mode, filter_dims=filterdim, skip_wgt=skip_wgt,
+                                                      **filter_kwargs)
+                # insert back the filtered model if we are skipping flagged edgs.
+                if skip_flagged_edges:
+                    mdl = np.pad(mdl, edges)
+                    res = np.pad(res, edges)
 
-            # unzeropad array and put in skip flags.
-            if ax == 'freq':
-                if zeropad > 0:
-                    mdl, _ = zeropad_array(mdl, zeropad=zeropad, axis=1, undo=True)
-                    res, _ = zeropad_array(res, zeropad=zeropad, axis=1, undo=True)
-            elif ax == 'time':
-                if zeropad > 0:
-                    mdl, _ = zeropad_array(mdl, zeropad=zeropad, axis=0, undo=True)
-                    res, _ = zeropad_array(res, zeropad=zeropad, axis=0, undo=True)
-            elif ax == 'both':
-                for i in range(2):
-                    if zeropad[i] > 0:
-                        mdl, _ = zeropad_array(mdl, zeropad=zeropad[i], axis=i, undo=True)
-                        res, _ = zeropad_array(res, zeropad=zeropad[i], axis=i, undo=True)
-                    _trim_status(info, i, zeropad[i - 1])
-            # flag integrations and channels that were skipped.
-            skipped = np.zeros_like(mdl, dtype=np.bool)
-            for dim in range(2):
-                if len(info['status']['axis_%d' % dim]) > 0:
-                    for i in range(len(info['status']['axis_%d' % dim])):
-                        if info['status']['axis_%d' % dim][i] == 'skipped':
-                            if dim == 0:
-                                skipped[:, i] = True
-                            elif dim == 1:
-                                skipped[i] = True
-            # just in case any artifacts make it through after our other flagging rounds
-            # flag integrations or channels where the RMS of the model exceeds the RMS of the unflagged data
-            # by some threshold.
-            if flag_model_rms_outliers:
-                skipped = flag_model_rms(skipped, d, w, mdl, model_rms_threshold=model_rms_threshold, ax=ax)
+                # unzeropad array and put in skip flags.
+                if ax == 'freq':
+                    if zeropad > 0:
+                        mdl, _ = zeropad_array(mdl, zeropad=zeropad, axis=1, undo=True)
+                        res, _ = zeropad_array(res, zeropad=zeropad, axis=1, undo=True)
+                elif ax == 'time':
+                    if zeropad > 0:
+                        mdl, _ = zeropad_array(mdl, zeropad=zeropad, axis=0, undo=True)
+                        res, _ = zeropad_array(res, zeropad=zeropad, axis=0, undo=True)
+                elif ax == 'both':
+                    for i in range(2):
+                        if zeropad[i] > 0:
+                            mdl, _ = zeropad_array(mdl, zeropad=zeropad[i], axis=i, undo=True)
+                            res, _ = zeropad_array(res, zeropad=zeropad[i], axis=i, undo=True)
+                        _trim_status(info, i, zeropad[i - 1])
+                # flag integrations and channels that were skipped.
+                skipped = np.zeros_like(mdl, dtype=np.bool)
+                for dim in range(2):
+                    if len(info['status']['axis_%d' % dim]) > 0:
+                        for i in range(len(info['status']['axis_%d' % dim])):
+                            if info['status']['axis_%d' % dim][i] == 'skipped':
+                                if dim == 0:
+                                    skipped[:, i] = True
+                                elif dim == 1:
+                                    skipped[i] = True
+                # just in case any artifacts make it through after our other flagging rounds
+                # flag integrations or channels where the RMS of the model exceeds the RMS of the unflagged data
+                # by some threshold.
+                if flag_model_rms_outliers:
+                    skipped = flag_model_rms(skipped, d, w, mdl, model_rms_threshold=model_rms_threshold, ax=ax)
 
-            # also flag skipped edge channels and integrations.
-            if skip_flagged_edges:
-                skipped[:, :edges[1][0]] = True
-                skipped[:, -edges[1][1] - 1:] = True
-                skipped[:edges[0][0], :] = True
-                skipped[-edges[0][1] - 1:, :] = True
-
-            filtered_model[k] = mdl
-            filtered_model[k][skipped] = 0.
-            filtered_resid[k] = res * fw
-            filtered_resid[k][skipped] = 0.
-            filtered_data[k] = filtered_model[k] + filtered_resid[k]
-            if not keep_flags:
-                filtered_flags[k] = skipped
-            else:
-                filtered_flags[k] = copy.deepcopy(flags[k]) | skipped
-            filtered_info[k] = info
-            if clean_flags_in_resid_flags:
-                resid_flags[k] = copy.deepcopy(flags[k]) | skipped
-            else:
-                resid_flags[k] = copy.deepcopy(flags[k])
+                # also flag skipped edge channels and integrations.
+                if skip_flagged_edges:
+                    skipped[:, :edges[1][0]] = True
+                    skipped[:, -edges[1][1] - 1:] = True
+                    skipped[:edges[0][0], :] = True
+                    skipped[-edges[0][1] - 1:, :] = True
+                if k not in filtered_model:
+                    filtered_model[k] = np.zeros_like(data[k])
+                    filtered_resid[k] = np.zeros_like(data[k])
+                    filtered_data[k] = np.zeros_like(data[k])
+                    filtered_flags[k] = np.zeros_like(flags[k])
+                    resid_flags[k] = np.zeros_like(flags[k])
+                filtered_model[k][:, spw_slice] = mdl
+                filtered_model[k][skipped, spw_slice] = 0.
+                filtered_resid[k][:, spw_slice] = res * fw
+                filtered_resid[k][skipped, spw_slice]] = 0.
+                filtered_data[k][:, spw_slice] = filtered_model[k] + filtered_resid[k]
+                if not keep_flags:
+                    filtered_flags[k][:, spw_slice] = skipped
+                else:
+                    filtered_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice]) | skipped
+                filtered_info[k] = info
+                if clean_flags_in_resid_flags:
+                    resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice]) | skipped
+                else:
+                    resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice])
 
         if hasattr(data, 'times'):
             filtered_data.times = data.times

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -60,4 +60,5 @@ delay_filter.load_delay_filter_and_write(ap.datafilelist, calfile_list=ap.calfil
                                          CLEAN_outfilename=ap.CLEAN_outfilename,
                                          standoff=ap.standoff, horizon=ap.horizon, tol=ap.tol,
                                          skip_wgt=ap.skip_wgt, min_dly=ap.min_dly, zeropad=ap.zeropad,
+                                         filter_spw_ranges=ap.filter_spw_ranges,
                                          clean_flags_in_resid_flags=True, **filter_kwargs)


### PR DESCRIPTION
PR Enables Fourier Filtering of multiple subbands simultaneously while keeping track of edge flags between subbands.

This should be merged before #700 so we can add the `filter_spw_ranges` arg to `tophat_frfilter_run.py` in #700.