### PR TITLE
Allow weighting by frequency-averaged samples in timeavg_waterfall

### DIFF
--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -579,6 +579,7 @@ def time_average_argparser():
     ap.add_argument("--t_avg", type=float, help="number of seconds to average over.", default=None)
     ap.add_argument("--rephase", default=False, action="store_true", help="rephase to averaging window center.")
     ap.add_argument("--dont_wgt_by_nsample", default=False, action="store_true", help="don't weight averages by nsample. Default is to wgt by nsamples.")
+    ap.add_argument("--wgt_by_favg_nsample", default=False, action="store_true", help="weight each integration by frequency-averaged nsamples.")
     ap.add_argument("--clobber", default=False, action="store_true", help="Overwrite output files.")
     ap.add_argument("--verbose", default=False, action="store_true", help="verbose output.")
     ap.add_argument("--flag_output", default=None, type=str, help="optional filename to save a separate copy of the time-averaged flags as a uvflag object.")

--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -499,8 +499,8 @@ class FRFilter(VisClean):
 
 
 def time_avg_data_and_write(input_data_list, output_data, t_avg, baseline_list=None,
-                            wgt_by_nsample=True, rephase=False, filetype='uvh5',
-                            verbose=False, clobber=False, flag_output=None):
+                            wgt_by_nsample=True, wgt_by_favg_nsample=False, rephase=False,
+                            filetype='uvh5', verbose=False, clobber=False, flag_output=None):
     """Time-averaging with a baseline cornerturn
 
 
@@ -517,6 +517,9 @@ def time_avg_data_and_write(input_data_list, output_data, t_avg, baseline_list=N
     wgt_by_nsample: bool, optional
         weight by nsamples in time average
         default is True
+    wgt_by_favg_nsample : bool
+        If True, perform time average weighting by averaging the number of samples across
+        frequency for each integration. Mutually exclusive with wgt_by_nsample. Default False.
     rephase: bool, optional
         rephase each time bin to central lst.
     filetype : str, optional
@@ -544,7 +547,7 @@ def time_avg_data_and_write(input_data_list, output_data, t_avg, baseline_list=N
         fr.read(bls=baseline_list, axis='blt')
 
         fr.timeavg_data(fr.data, fr.times, fr.lsts, t_avg, flags=fr.flags, nsamples=fr.nsamples,
-                        wgt_by_nsample=wgt_by_nsample, rephase=rephase)
+                        wgt_by_nsample=wgt_by_nsample, wgt_by_favg_nsample=wgt_by_favg_nsample, rephase=rephase)
         fr.write_data(fr.avg_data, output_data, overwrite=clobber, flags=fr.avg_flags, filetype=filetype,
                       nsamples=fr.avg_nsamples, times=fr.avg_times, lsts=fr.avg_lsts)
         if flag_output is not None:

--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -319,8 +319,9 @@ class FRFilter(VisClean):
     """
     FRFilter object. See hera_cal.vis_clean.VisClean.__init__ for instantiation options.
     """
-    def timeavg_data(self, data, times, lsts, t_avg, flags=None, nsamples=None, wgt_by_nsample=True,
-                     rephase=False, verbose=True, output_prefix='avg', keys=None, overwrite=False):
+    def timeavg_data(self, data, times, lsts, t_avg, flags=None, nsamples=None,
+                     wgt_by_nsample=True, wgt_by_favg_nsample=False, rephase=False,
+                     verbose=True, output_prefix='avg', keys=None, overwrite=False):
         """
         Time average data attached to object given a averaging time-scale t_avg [seconds].
         The resultant averaged data, flags, time arrays, etc. are attached to self
@@ -352,6 +353,9 @@ class FRFilter(VisClean):
             wgt_by_nsample : bool
                 If True, perform time average weighted by nsample, otherwise perform
                 uniform average. Default is True.
+            wgt_by_favg_nsample : bool
+                If True, perform time average weighting by averaging the number of samples across
+                frequency for each integration. Mutually exclusive with wgt_by_nsample. Default False.
             rephase : bool
                 If True, rephase data in averaging window to the window-center.
             keys : list of len-3 antpair-pol tuples
@@ -405,7 +409,7 @@ class FRFilter(VisClean):
              ea) = timeavg_waterfall(data[k], Navg, flags=flags[k], nsamples=nsamples[k],
                                      rephase=rephase, lsts=lsts, freqs=self.freqs, bl_vec=self.blvecs[k[:2]],
                                      lat=self.lat, extra_arrays=dict(times=times), wgt_by_nsample=wgt_by_nsample,
-                                     verbose=verbose)
+                                     wgt_by_favg_nsample=wgt_by_favg_nsample, verbose=verbose)
             avg_data[k] = ad
             avg_flags[k] = af
             avg_nsamples[k] = an

--- a/hera_cal/tests/test_frf.py
+++ b/hera_cal/tests/test_frf.py
@@ -81,6 +81,19 @@ def test_timeavg_waterfall():
     with pytest.raises(ValueError):
         frf.timeavg_waterfall(d, 25, verbose=False, wgt_by_nsample=True, wgt_by_favg_nsample=True)
 
+    # test weightings
+    d = np.ones((4, 10))
+    d[0, :] *= 2
+    n = np.ones((4, 10))
+    n[0, 0:5] *= 2
+    ad, _, _, _, _ = frf.timeavg_waterfall(d, 2, rephase=False, nsamples=n, wgt_by_nsample=True)
+    np.testing.assert_array_equal(ad[1, :], 1.0) 
+    np.testing.assert_array_equal(ad[0, 0:5], 5. / 3) 
+    np.testing.assert_array_equal(ad[0, 5:10], 1.5)
+    ad, _, _, _, _ = frf.timeavg_waterfall(d, 2, rephase=False, nsamples=n, wgt_by_nsample=False, wgt_by_favg_nsample=True)
+    np.testing.assert_array_equal(ad[1, :], 1.0) 
+    np.testing.assert_array_equal(ad[0, :], 1.6)
+
 
 def test_fir_filtering():
     # convert a high-pass frprofile to an FIR filter

--- a/hera_cal/tests/test_frf.py
+++ b/hera_cal/tests/test_frf.py
@@ -77,6 +77,10 @@ def test_timeavg_waterfall():
     assert np.allclose(ad, ad2)
     assert np.allclose(al, al2 - 1.52917804)
 
+    # Test Error
+    with pytest.raises(ValueError):
+        frf.timeavg_waterfall(d, 25, verbose=False, wgt_by_nsample=True, wgt_by_favg_nsample=True)
+
 
 def test_fir_filtering():
     # convert a high-pass frprofile to an FIR filter

--- a/scripts/time_average.py
+++ b/scripts/time_average.py
@@ -26,4 +26,5 @@ frf.time_avg_data_and_write(
                             # for this reason, the argparser requests the negation.
                             filetype=args.filetype,
                             wgt_by_nsample=not(args.dont_wgt_by_nsample),
+                            wgt_by_favg_nsample=args.wgt_by_favg_nsample,
                             clobber=args.clobber, verbose=args.verbose)


### PR DESCRIPTION
Currently, timeavg_waterfall allows averaging together visibilities with either uniform weighting or nsamples weighting. The former is suboptimal (in terms of noise) while the latter risks adding spectral structure.

This PR introduces an intermediate option, `wgt_by_favg_nsample`. When averaging together integrations, this allows one to weight each integration by the average nsamples in that integration over all frequency channels. While still statistically suboptimal, this is closer to optimal while

While I don't expect this to make a big difference, I calculated the expected variance of waterfall with both uniform and `wgt_by_favg_nsample`time-averaging of a baseline in H1C IDR3.  This was done with 214 second averages. Here is the ratio:

![image](https://user-images.githubusercontent.com/5281139/119419525-4d78e780-bcaf-11eb-91c8-a3412be6b08d.png)

Much of the time, it doesn't matter. However, there are a non-trivial fraction of times where doing this decreases the variance by 50% or more.  