### PR TITLE
GitHub ci update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          mkdir -p empty
-          cd empty
-          pytest --pyargs hera_cal --cov=hera_cal --cov-config=../.coveragerc --cov-report xml:../coverage.xml
-          cd ..
+          pytest --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # Adding -l {0} helps ensure conda can be found properly in windows.
+        shell: bash -l {0}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,46 +21,41 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@master
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
-    - name: Get Miniconda (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh;
-        bash $HOME/miniconda.sh -b -p $HOME/miniconda
+      - name: Setup Miniconda
+         uses: conda-incubator/setup-miniconda@v2.0.0
+         with:
+           auto-update-conda: true
+           miniconda-version: "latest"
+           python-version: ${{ matrix.python-version }}
+           environment-file: ci/${{ ENV_NAME }}.yml
+           activate-environment: ${{ ENV_NAME }}
 
-    - name: Get Miniconda (Mac OS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O $HOME/miniconda.sh;
-        bash $HOME/miniconda.sh -b -p $HOME/miniconda
+      - name: Conda Info
+        run: |
+          conda info -a
+          conda list
+          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+          if [[ $PYVER != $PYTHON ]]; then
+            exit 1;
+          fi
 
-    - name: Setup Environment
-      run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
-        ./ci/install_conda.sh
+      - name: Install
+        run: |
+          pip install .
 
-    - name: Install
-      run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
-        source activate ${ENV_NAME}
-        pip install .
+      - name: Run Tests
+        run: |
+          pytest --cov-report xml:./coverage.xml
 
-    - name: Run Tests
-      run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
-        source activate $ENV_NAME
-        pytest --cov-report xml:./coverage.xml
+      - name: Upload Coverage (Ubuntu)
+        if: matrix.os == 'ubuntu-latest' && success()
+        run: |
+          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Upload Coverage (Ubuntu)
-      if: matrix.os == 'ubuntu-latest' && success()
-      run: |
-        bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Python Style Checker
-      run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
-        source activate ${ENV_NAME}
-        pycodestyle . --ignore=E501,W291,W293,W503,W601
+      - name: Python Style Checker
+        run: |
+          pycodestyle . --ignore=E501,W291,W293,W503,W601

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           auto-update-conda: true
+          auto-activate-base: false
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           environment-file: ci/${{ env.ENV_NAME }}.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
-          environment-file: ci/${{ ENV_NAME }}.yml
-          activate-environment: ${{ ENV_NAME }}
+          environment-file: ci/${{ env.ENV_NAME }}.yml
+          activate-environment: ${{ env.ENV_NAME }}
 
       - name: Conda Info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Miniconda
-         uses: conda-incubator/setup-miniconda@v2.0.0
-         with:
-           auto-update-conda: true
-           miniconda-version: "latest"
-           python-version: ${{ matrix.python-version }}
-           environment-file: ci/${{ ENV_NAME }}.yml
-           activate-environment: ${{ ENV_NAME }}
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          python-version: ${{ matrix.python-version }}
+          environment-file: ci/${{ ENV_NAME }}.yml
+          activate-environment: ${{ ENV_NAME }}
 
       - name: Conda Info
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          mkdir -p empty  
+          mkdir -p empty
           cd empty
           pytest --pyargs hera_cal --cov=hera_cal --cov-config=../.coveragerc --cov-report xml:../coverage.xml
           cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest --cov-report xml:./coverage.xml
+          mkdir -p empty  
+          cd empty
+          pytest --pyargs hera_cal --cov=hera_cal --cov-config=../.coveragerc --cov-report xml:../coverage.xml
+          cd ..
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import sys
 import os
 import warnings
+from pathlib import Path
 import shutil
 import glob
 from collections import OrderedDict as odict
@@ -836,7 +837,8 @@ def test_select_spw_ranges_run_script_code(tmpdir):
     nf = hd.Nfreqs
     output = os.path.join(tmp_path, 'test_calibrated_output.uvh5')
     # construct bash script command
-    select_cmd = f'python ./scripts/select_spw_ranges.py {uvh5} {output} --clobber --spw_ranges 0~256,332~364,792~1000'
+    script_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+    select_cmd = f'python {script_dir}/select_spw_ranges.py {uvh5} {output} --clobber --spw_ranges 0~256,332~364,792~1000'
     # and excecute inside of python
     os.system(select_cmd)
     # test that output has correct frequencies.

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -7,7 +7,6 @@ import numpy as np
 import sys
 import os
 import warnings
-from pathlib import Path
 import shutil
 import glob
 from collections import OrderedDict as odict
@@ -837,8 +836,7 @@ def test_select_spw_ranges_run_script_code(tmpdir):
     nf = hd.Nfreqs
     output = os.path.join(tmp_path, 'test_calibrated_output.uvh5')
     # construct bash script command
-    script_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
-    select_cmd = f'python {script_dir}/select_spw_ranges.py {uvh5} {output} --clobber --spw_ranges 0~256,332~364,792~1000'
+    select_cmd = f'python ./scripts/select_spw_ranges.py {uvh5} {output} --clobber --spw_ranges 0~256,332~364,792~1000'
     # and excecute inside of python
     os.system(select_cmd)
     # test that output has correct frequencies.


### PR DESCRIPTION
some general updates to the github action ci yaml.

Uses an action to setup the conda env rather than the old clunky bash script.
~~makes an empty directory to execute the tests in, this actually tests the installed version of hera_cal and breaks a degeneracy in the namespace between installed and cloned repo.~~ this was getting too complicated because of how test_utils is set up.