### PR TITLE
Add fix for UVData.filename attribute

### DIFF
--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -276,6 +276,11 @@ class Test_VisClean(object):
         assert V2.hd.vis_units == 'Jy'
         assert 'Thisfilewasproducedbythefunction' in V2.hd.history.replace('\n', '').replace(' ', '')
         V.hd.history, V2.hd.history, V2.hd.vis_units = '', '', V.hd.vis_units
+        if hasattr(V.hd, "filename"):
+            # make sure filename attributes are what we're expecting
+            assert V.hd.filename == ["zen.2458098.43124.subband.uvh5"]
+            assert V2.hd.filename == ["ex.uvh5"]
+            V.hd.filename = V2.hd.filename
         assert V.hd == V2.hd
         os.remove("./ex.uvh5")
 


### PR DESCRIPTION
An upcoming PR on pyuvdata (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1015) is adding a `filename` attribute to UVData objects, similar to the `filepaths` of HERAData objects. Because this attribute will be different when two objects are read from different files, it caused one of the tests to break. This PR fixes the broken test in a backwards-compatible way such that the test should pass both before and after the relevant PR is merged on pyuvdata.