### PR TITLE
another conjugation issue.

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -39,13 +39,11 @@ def baselines_same_across_nights(data_list):
     # check whether baselines are the same across all nights
     # by checking that every baseline occurs in data_list the same number times.
     same_across_nights = False
-    baseline_counts = {}
+    baseline_counts = DataContainer({})
     for dlist in data_list:
         for k in dlist:
             if k in baseline_counts:
                 baseline_counts[k] += 1
-            elif utils.reverse_bl(k) in baseline_counts:
-                baseline_counts[utils.reverse_bl(k)] += 1
             else:
                 baseline_counts[k] = 1
     same_across_nights = np.all([baseline_counts[k] == baseline_counts[bl] for bl in baseline_counts])


### PR DESCRIPTION
Fix another line in the lst-binner that dies when a baseline appears in one file on a night but its conjugate appears in another.


The method here is checking to make sure that for each night in a set of nights to be lst-binned that all files on each night contain the same baselines sometimes, the same baselines might be present between two files though, but conjugated if this happens, the method, as currently written, will throw a key not found error since it was originally implemented with a standard python dictionary so if (117, 177) is in the dict, and it asks for (177, 117) an error will be thrown. to fix this, I changed from a dict to a DataContainer which will count a baselines conjugate key as being present in the dict


Loses two lines of coverage because of code consolidation (no new uncovered lines are introduced).