### PR TITLE
Set lmin / lmax from integration times rather then file ordering

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -555,9 +555,8 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
         # get times
         dlsts, dtimes, larrs, tarrs = io.get_file_times(dfs, filetype='uvh5')
 
-        filemaxtime = np.argmax([tarr.max() for tarr in tarrs]) # we want lmax to be the lst from the file with the maximum time actually
-        filemintime = np.argmin([tarr.min() for tarr in tarrs]) # we want lmin to be the lst from the file with the minimum time actually
-
+        filemaxtime = np.argmax([tarr.max() for tarr in tarrs])  # we want lmax to be the lst from the file with the maximum time actually
+        filemintime = np.argmin([tarr.min() for tarr in tarrs])  # we want lmin to be the lst from the file with the minimum time actually
 
         # get lmin: LST of first integration.
         if di == 0:

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -554,18 +554,22 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
         # get times
         dlsts, dtimes, larrs, tarrs = io.get_file_times(dfs, filetype='uvh5')
 
-        # get lmin: LST of first integration from first file
+        filemaxtime = np.argmax([tarr.max() for tarr in tarrays]) # we want lmax to be the lst from the file with the maximum time actually
+        filemintime = np.argmin([tarr.min() for tarr in tarrays]) # we want lmin to be the lst from the file with the minimum time actually
+
+
+        # get lmin: LST of first integration.
         if di == 0:
-            lmin = larrs[0][0]
+            lmin = larrs[filemintime][np.argmin(tarrs[filemintime])]
 
         # unwrap relative to lmin
         for la in larrs:
             if la[0] < lmin:
                 la += 2 * np.pi
 
-        # get lmax
+        # get lmax (lst of maximum obs time)
         if di == (len(data_files) - 1):
-            lmax = larrs[-1][-1]
+            lmax = larrs[filemaxtime][np.argmax(tarrs[filemaxtime])]
 
         # append
         lst_arrays.append(larrs)

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -554,8 +554,8 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
         # get times
         dlsts, dtimes, larrs, tarrs = io.get_file_times(dfs, filetype='uvh5')
 
-        filemaxtime = np.argmax([tarr.max() for tarr in tarrays]) # we want lmax to be the lst from the file with the maximum time actually
-        filemintime = np.argmin([tarr.min() for tarr in tarrays]) # we want lmin to be the lst from the file with the minimum time actually
+        filemaxtime = np.argmax([tarr.max() for tarr in tarrs]) # we want lmax to be the lst from the file with the maximum time actually
+        filemintime = np.argmin([tarr.min() for tarr in tarrs]) # we want lmin to be the lst from the file with the minimum time actually
 
 
         # get lmin: LST of first integration.

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -550,6 +550,7 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
     # get time arrays for each file
     lst_arrays = []
     time_arrays = []
+    lmax = None
     for di, dfs in enumerate(data_files):
         # get times
         dlsts, dtimes, larrs, tarrs = io.get_file_times(dfs, filetype='uvh5')
@@ -568,8 +569,12 @@ def config_lst_bin_files(data_files, dlst=None, atol=1e-10, lst_start=None, lst_
                 la += 2 * np.pi
 
         # get lmax (lst of maximum obs time)
-        if di == (len(data_files) - 1):
-            lmax = larrs[filemaxtime][np.argmax(tarrs[filemaxtime])]
+        lmax_t = larrs[filemaxtime][np.argmax(tarrs[filemaxtime])]
+        # don't necessarily assume that the last files in obs list have the
+        # greatest LSTs. This will also keep any LSTs in nights after first night
+        # that happened to have LSTs before the first obs on the first night.
+        if lmax is None or lmax_t > lmax:
+            lmax = lmax_t
 
         # append
         lst_arrays.append(larrs)


### PR DESCRIPTION
Variables `lmin` and `lmax` in `lstbin.config_lst_bin_files` are meant to represent the lsts of the minimum and maximum integrations on each night. They are set by the first/last integrations on the first and last files on each night to be lst binned *but* the files are ordered by their names. If the names are not ascending by observation time, which can be the case when the files are labeled by LST instead of JD, then the min lst might be a late integration. If lst_stop is not set, this can cause significant chunks of data to be dropped in some cases. For example, if we are lst-binning files that start at some large radian LST (such as 6.2 say) and end at 0.08, lstmax will erroneously be be set to 6.2 and lstmin will be 0.08. If lst_stop is not provided but we provide and lst_start of 6.19, then lst_stop will be set to lmax=6.2 (in the below line), discarding most of the files from lstbinning.

https://github.com/HERA-Team/hera_cal/blob/a863658c8212fb0c60e2624900697b3fe316b40f/hera_cal/lstbin.py#L593

and this will cutoff all the LSTs after 0.0.

To fix this, I now set lmin to be the lst of the minimum observation time (not the first file) and lmax to the lst of the maximum observation time (not the last file).

