### PR TITLE
propagate prefix kwarg to get_filled_data in write_filtered_data.

### DIFF
--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1399,7 +1399,7 @@ class VisClean(object):
                     elif mode == 'CLEAN':
                         data_out, flags_out = getattr(self, prefix + '_model'), getattr(self, prefix + '_flags')
                     elif mode == 'filled':
-                        data_out, flags_out = self.get_filled_data()
+                        data_out, flags_out = self.get_filled_data(prefix=prefix)
                     if partial_write:
                         # add extra_attrs to kwargs
                         for k in extra_attrs:


### PR DESCRIPTION
One line fix addresses issue where `write_filtered_data` does not propagate the prefix for the intended output data containters into `get_filled_data`. This can lead to spurious results if we are writing filtered data with the non-default prefix. 

closes #748 