### PR TITLE
fix floor division.

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -61,7 +61,7 @@ class DataContainer:
             self._pols = set([k[-1] for k in self._data.keys()])
 
             # placeholders for metadata (or get them from data, if possible)
-            for attr in ['ants', 'data_ants', 'antpos', 'data_antpos', 
+            for attr in ['ants', 'data_ants', 'antpos', 'data_antpos',
                          'freqs', 'times', 'lsts', 'times_by_bl', 'lsts_by_bl']:
                 if hasattr(data, attr):
                     setattr(self, attr, getattr(data, attr))
@@ -324,14 +324,23 @@ class DataContainer:
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
-                    newD[k] = self.__getitem__(k) // D[k]
+                    if not (np.any(np.iscomplex(self.__getitem__(k))) or np.any(np.iscomplex(D[k]))):
+                        newD[k] =  self.__getitem__(k) // D[k]
+                    else:
+                        div = self.__getitem__(k) / D[k]
+                        newD[k] = np.real(div).astype(int) + 1j * np.imag(div).astype(int)
+
 
             return DataContainer(newD)
 
         else:
             newD = copy.deepcopy(self)
             for k in newD.keys():
-                newD[k] = newD[k] // D
+                if not (np.any(np.iscomplex(newD[k])) or np.any(np.iscomplex(D))):
+                    newD[k] = newD[k] // D
+                else:
+                    div = newD[k] / D
+                    newD[k] = np.real(div).astype(int) + 1j * np.imag(div).astype(int)
 
             return newD
 

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -324,7 +324,7 @@ class DataContainer:
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
-                    if not (np.any(np.iscomplex(self.__getitem__(k))) or np.any(np.iscomplex(D[k]))):
+                    if not (np.iscomplexobj(self.__getitem__(k)) or np.iscomplexobj(D[k])):
                         newD[k] = self.__getitem__(k) // D[k]
                     else:
                         div = self.__getitem__(k) / D[k]
@@ -335,7 +335,7 @@ class DataContainer:
         else:
             newD = copy.deepcopy(self)
             for k in newD.keys():
-                if not (np.any(np.iscomplex(newD[k])) or np.any(np.iscomplex(D))):
+                if not (np.iscomplexobj(newD[k]) or np.iscomplexobj(D)):
                     newD[k] = newD[k] // D
                 else:
                     div = newD[k] / D

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -325,11 +325,10 @@ class DataContainer:
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
                     if not (np.any(np.iscomplex(self.__getitem__(k))) or np.any(np.iscomplex(D[k]))):
-                        newD[k] =  self.__getitem__(k) // D[k]
+                        newD[k] = self.__getitem__(k) // D[k]
                     else:
                         div = self.__getitem__(k) / D[k]
                         newD[k] = np.real(div).astype(int) + 1j * np.imag(div).astype(int)
-
 
             return DataContainer(newD)
 

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -359,6 +359,13 @@ class TestDataContainerWithRealData(object):
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], 1.0)
         d2 = d // 2.0
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30].real // 2.0 + d[(24, 25, 'ee')][30, 30].imag // 2.0)
+        # now convert d to floats and do the same thing.
+        for k in d:
+            d[k] = d[k].real
+        d2 = d // d
+        assert np.allclose(d2[(24, 25, 'ee')][30, 30], 1.0)
+        d2 = d // 2.0
+        assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] // 2.0)
 
     def test_invert(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -358,7 +358,7 @@ class TestDataContainerWithRealData(object):
         d2 = d // d
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], 1.0)
         d2 = d // 2.0
-        assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] // 2.0)
+        assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30].real // 2.0 + d[(24, 25, 'ee')][30, 30].imag // 2.0)
 
     def test_invert(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")


### PR DESCRIPTION
numpy 1.22 and above throw value errors when you try to perform floor division with complex numbers. I've modified the implementation in `datacontainer.py` to perform floor division by taking the ratio of the complex numbers and then separately rounding down the real and imaginary components. 