### PR TITLE
Fix match_times bug

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2020,9 +2020,7 @@ def match_times(datafile, modelfiles, filetype='uvh5', atol=1e-5):
 
     # shift model files relative to first file & first index if needed
     for ml in model_lsts:
-        for i in range(len(ml)):
-            if ml[i] < model_lsts[0][0]:
-                ml[i] += 2 * np.pi
+        ml[ml < model_lsts[0][0]] += 2 * np.pi
 
     # get model start and stop, buffering by dlst / 2
     model_starts = np.asarray([ml[0] - md / 2.0 for ml, md in zip(model_lsts, model_dlsts)])

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -2020,8 +2020,9 @@ def match_times(datafile, modelfiles, filetype='uvh5', atol=1e-5):
 
     # shift model files relative to first file & first index if needed
     for ml in model_lsts:
-        if ml[0] < model_lsts[0][0]:
-            ml += 2 * np.pi
+        for i in range(len(ml)):
+            if ml[i] < model_lsts[0][0]:
+                ml[i] += 2 * np.pi
 
     # get model start and stop, buffering by dlst / 2
     model_starts = np.asarray([ml[0] - md / 2.0 for ml, md in zip(model_lsts, model_dlsts)])


### PR DESCRIPTION
As written, match_times does not successfully apply phase wraps if a model file contains LST=0 cross somewhere in the middle. This PR fixes this.