### PR TITLE
Use `self.data_ants` instead of `self.ants` in ReflectionFitter

### DIFF
--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -1355,7 +1355,7 @@ def auto_reflection_argparser():
     a.add_argument("--overwrite", default=False, action='store_true', help="Overwrite output file if it already exists")
     a.add_argument("--write_npz", default=False, action='store_true', help="Write NPZ file with reflection params with same path name as output calfits.")
     a.add_argument("--input_cal", type=str, default=None, help="Path to input .calfits to apply to data before modeling")
-    a.add_argument("--antenna_numbers", default=None, type=int, nargs='*', help="List of antenna numbers to operate on. Default is all.")
+    a.add_argument("--antenna_numbers", default=None, type=int, nargs='*', help="List of antenna numbers to operate on. Default is all in data.")
     a.add_argument("--polarizations", default=None, type=str, nargs='*', help="List of polarization strings to operate on.")
     a.add_argument("--window", default='None', type=str, help="FFT window for CLEAN")
     a.add_argument("--alpha", default=0.2, type=float, help="Alpha parameter if window is tukey")
@@ -1399,7 +1399,7 @@ def auto_reflection_run(data, dly_ranges, output_fname, filetype='uvh5', input_c
         input_cal : str or UVCal subclass, calibration to apply to data on-the-fly
         time_avg : bool, if True, time-average the entire input data before reflection modeling
         write_npz : bool, if True, write an NPZ with reflection parameters with matching path as output_fname
-        antenna_numbers : int list, list of antenna number integers to run on. Default is all.
+        antenna_numbers : int list, list of antenna number integers to run on. Default is all in data.
         polarizations : str list, list of polarization strings to run on, default is all
         edgecut_low : int, Nbins to flag but not window at low-side of the FFT axis.
         edgecut_hi : int, Nbins to flag but not window at high-side of the FFT axis.

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -274,7 +274,7 @@ class ReflectionFitter(FRFilter):
         autopols = [p for p in self.pols if p[0] == p[1]]
         if len(self.ref_gains) > 0:
             antpol = split_bl(keys[0])[0]
-            for a in self.ants:
+            for a in self.data_ants:
                 for p in autopols:
                     k = (a, split_pol(p)[0])
                     if k not in self.ref_gains:
@@ -1447,8 +1447,8 @@ def auto_reflection_run(data, dly_ranges, output_fname, filetype='uvh5', input_c
     RF = ReflectionFitter(data, filetype=filetype, input_cal=input_cal)
 
     # get antennas if possible
-    if antenna_numbers is None and hasattr(RF, 'ants'):
-        bls = [(ant, ant) for ant in RF.ants]
+    if antenna_numbers is None and hasattr(RF, 'data_ants'):
+        bls = [(ant, ant) for ant in RF.data_ants]
     elif antenna_numbers is not None:
         bls = [(ant, ant) for ant in antenna_numbers]
     else:

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -234,7 +234,6 @@ class Test_ReflectionFitter_Cables(object):
         uvc = RF.write_auto_reflections("./ex.calfits", overwrite=True, write_npz=True)
         assert uvc.Ntimes == 100
         assert len(uvc.ant_array) == 5
-        # assert np.allclose(uvc.gain_array[0], 1.0)
         assert not np.allclose(uvc.gain_array[uvc.ant_array.tolist().index(23)], 1.0)
         # assert flag propagation
         assert np.all(uvc.get_flags(a_k)[:, 0])

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -233,8 +233,8 @@ class Test_ReflectionFitter_Cables(object):
         RF.model_auto_reflections(RF.data, (200, 300), clean_flags=RF.flags, window='blackmanharris', zeropad=100, fthin=1, verbose=True)
         uvc = RF.write_auto_reflections("./ex.calfits", overwrite=True, write_npz=True)
         assert uvc.Ntimes == 100
-        assert len(uvc.ant_array) == 65
-        assert np.allclose(uvc.gain_array[0], 1.0)
+        assert len(uvc.ant_array) == 5
+        # assert np.allclose(uvc.gain_array[0], 1.0)
         assert not np.allclose(uvc.gain_array[uvc.ant_array.tolist().index(23)], 1.0)
         # assert flag propagation
         assert np.all(uvc.get_flags(a_k)[:, 0])
@@ -252,7 +252,7 @@ class Test_ReflectionFitter_Cables(object):
         RF.model_auto_reflections(RF.data, (200, 300), clean_flags=RF.flags, window='blackmanharris', zeropad=100, fthin=1, verbose=True)
         uvc = RF.write_auto_reflections("./ex.calfits", input_calfits='./ex.calfits', overwrite=True)
         assert uvc.Ntimes == 100
-        assert len(uvc.ant_array) == 65
+        assert len(uvc.ant_array) == 5
         # assert flag propagation
         assert np.all(uvc.get_flags(a_k)[:, :2])
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -489,6 +489,7 @@ class VisClean(object):
             mdict = self.hd.get_metadata_dict()
             self.antpos = mdict['antpos']
             self.ants = mdict['ants']
+            self.data_ants = mdict['data_ants']
             self.freqs = mdict['freqs']
             self.times = mdict['times']
             self.lsts = mdict['lsts']


### PR DESCRIPTION
Following from #691 and #692, this PR now updates the cable reflection fitter to loop through only antennas in the data, rather than antennas in the array. This is useful for running on down-selected data and for running and late-H4C (and onwards) data where the full array ends up in `HERAData.ants` but not in `HERAData.data_ants`.