### PR TITLE
Streamline I/O in `auto_reflection_run()`

### DIFF
--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -1446,13 +1446,13 @@ def auto_reflection_run(data, dly_ranges, output_fname, filetype='uvh5', input_c
         The CLEAN min_dly should always be less than the lower boundary of dly_range.
     """
     # dly_ranges type check
-    if isinstance(dly_ranges, (str, np.str)):
+    if isinstance(dly_ranges, str):
         dly_ranges = [ast.literal_eval(dly_ranges)]
     if isinstance(dly_ranges, tuple):
         dly_ranges = [dly_ranges]
     if isinstance(dly_ranges, list):
         for i, dlyr in enumerate(dly_ranges):
-            if isinstance(dlyr, (str, np.str)):
+            if isinstance(dlyr, str):
                 dly_ranges[i] = ast.literal_eval(dlyr)
 
     # initialize reflection fitter

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -1390,6 +1390,8 @@ def auto_reflection_argparser():
     a.add_argument("--opt_tol", default=1e-3, type=float, help="Optimization stopping tolerance.")
     a.add_argument("--opt_buffer", default=[25, 25], type=float, nargs='*', help="delay buffer [ns] +/- initial guess for setting range of objective function")
     a.add_argument("--skip_frac", default=0.9, type=float, help="Float in range [0, 1]. Fraction of (non-edge) flagged channels above which integration is skipped in optimization.")
+    a.add_argument("--only_write_final_calfits", dest='write_each_calfits', default=True, action='store_false',
+                   help="Instead of writing one calfits file for each dly_range, instead only write a single combined calfits file with all reflections multiplied.")
     return a
 
 

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -484,11 +484,6 @@ class ReflectionFitter(FRFilter):
         else:
             kwargs = {'x_orientation': self.hd.x_orientation}
 
-        # Approriately handle the case where the gains have been time-averaged
-        if np.all([gain.shape[0] == 1 for gain in rgains.values()]):
-            if len(time_array) > 1:
-                time_array = np.mean(time_array, keepdims=True)            
-        
         # write calfits
         antnums2antnames = dict(zip(self.hd.antenna_numbers, self.hd.antenna_names))
         echo("...writing {}".format(output_calfits), verbose=verbose)
@@ -1410,7 +1405,8 @@ def auto_reflection_run(data, dly_ranges, output_fname, filetype='uvh5', input_c
         output_fname : str, full path to output calfits file
         filetype : str, filetype if data is a str, options=['uvh5', 'miriad', 'uvfits']
         input_cal : str or UVCal subclass, calibration to apply to data on-the-fly
-        time_avg : bool, if True, time-average the entire input data before reflection modeling
+        time_avg : bool, if True, time-average the entire input data before reflection modeling.
+            This will produce single-integration calfits files.
         write_npz : bool, if True, write an NPZ with reflection parameters with matching path as output_fname
         antenna_numbers : int list, list of antenna number integers to run on. Default is all in data.
         polarizations : str list, list of polarization strings to run on, default is all
@@ -1493,6 +1489,7 @@ def auto_reflection_run(data, dly_ranges, output_fname, filetype='uvh5', input_c
         flags = RF.avg_flags
         nsamples = RF.avg_nsamples
         model = RF.avgm_data
+        RF.times = np.mean(RF.times, keepdims=True)
 
     # iterate over dly_ranges
     gains = []

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -409,8 +409,8 @@ class ReflectionFitter(FRFilter):
         return out_ref_amp, out_ref_dly, out_ref_phs, out_ref_info, out_ref_eps, out_ref_gains
 
     def write_auto_reflections(self, output_calfits, input_calfits=None, time_array=None,
-                               add_to_history='', verbose=True):
-                               freq_array=None, overwrite=False, write_npz=False, write_calfits=True,
+                               freq_array=None, overwrite=False, write_npz=False,
+                               write_calfits=True, add_to_history='', verbose=True):
         """
         Write reflection gain terms from self.ref_gains.
 
@@ -484,6 +484,11 @@ class ReflectionFitter(FRFilter):
         else:
             kwargs = {'x_orientation': self.hd.x_orientation}
 
+        # Approriately handle the case where the gains have been time-averaged
+        if np.all([gain.shape[0] == 1 for gain in rgains.values()]):
+            if len(time_array) > 1:
+                time_array = np.mean(time_array, keepdims=True)            
+        
         # write calfits
         antnums2antnames = dict(zip(self.hd.antenna_numbers, self.hd.antenna_names))
         echo("...writing {}".format(output_calfits), verbose=verbose)

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -409,8 +409,8 @@ class ReflectionFitter(FRFilter):
         return out_ref_amp, out_ref_dly, out_ref_phs, out_ref_info, out_ref_eps, out_ref_gains
 
     def write_auto_reflections(self, output_calfits, input_calfits=None, time_array=None,
-                               freq_array=None, overwrite=False, write_npz=False,
                                add_to_history='', verbose=True):
+                               freq_array=None, overwrite=False, write_npz=False, write_calfits=True,
         """
         Write reflection gain terms from self.ref_gains.
 
@@ -431,11 +431,12 @@ class ReflectionFitter(FRFilter):
             overwrite : bool, if True, overwrite output file
             write_npz : bool, if True, write an NPZ file holding reflection
                 params with the same pathname as output_calfits
+            write_calfits : bool, if False, skip writing 
             add_to_history: string to add to history of output calfits file
             verbose : bool, report feedback to stdout
 
         Returns:
-            uvc : UVCal object with new gains
+            uvc : UVCal object with new gains (or None if write_calfits is False)
         """
         # Create reflection gains
         rgains, rflags = self.ref_gains, self.ref_flags
@@ -459,6 +460,10 @@ class ReflectionFitter(FRFilter):
                          lsts=self.lsts, antpos=self.antpos, flags=rflags,
                          history=version.history_string(add_to_history))
 
+        # return None if we don't want to write a calfits file
+        if not write_calfits:
+            return None
+
         if input_calfits is not None:
             # Load calfits
             cal = io.HERACal(input_calfits)
@@ -479,6 +484,7 @@ class ReflectionFitter(FRFilter):
         else:
             kwargs = {'x_orientation': self.hd.x_orientation}
 
+        # write calfits
         antnums2antnames = dict(zip(self.hd.antenna_numbers, self.hd.antenna_names))
         echo("...writing {}".format(output_calfits), verbose=verbose)
         uvc = io.write_cal(output_calfits, rgains, freq_array, time_array, flags=rflags,

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -306,7 +306,8 @@ class Test_ReflectionFitter_Cables(object):
     def test_auto_reflection_run(self):
         # most of the code tests have been done above, this is just to ensure this wrapper function runs
         uvd = simulate_reflections(cdelay=[150.0, 250.0], cphase=[0.0, 0.0], camp=[1e-2, 1e-2], add_cable=True, cable_ants=[23], add_xtalk=False)
-        reflections.auto_reflection_run(uvd, [(100, 200), (200, 300)], "./ex.calfits", time_avg=True, window='blackmanharris', write_npz=True, overwrite=True, ref_sig_cut=1.0)
+        reflections.auto_reflection_run(uvd, [(100, 200), (200, 300)], "./ex.calfits", time_avg=True, compress_tavg_calfits=True, 
+                                        window='blackmanharris', write_npz=True, overwrite=True, ref_sig_cut=1.0)
         assert os.path.exists("./ex.calfits")
         assert os.path.exists("./ex.npz")
         assert os.path.exists("./ex.ref2.calfits")
@@ -334,8 +335,8 @@ class Test_ReflectionFitter_Cables(object):
         os.remove("./ex.ref2.npz")
 
         # Try with write_each_calfits = False
-        reflections.auto_reflection_run(uvd, [(100, 200), (200, 300)], "./ex.calfits", time_avg=True, window='blackmanharris', 
-                                        write_npz=False, overwrite=True, ref_sig_cut=1.0, write_each_calfits=False)
+        reflections.auto_reflection_run(uvd, [(100, 200), (200, 300)], "./ex.calfits", time_avg=True, compress_tavg_calfits=True,
+                                        window='blackmanharris', write_npz=False, overwrite=True, ref_sig_cut=1.0, write_each_calfits=False)
         assert os.path.exists("./ex.calfits")
         assert not os.path.exists("./ex.ref2.calfits")
         uvc3 = UVCal()

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -296,6 +296,12 @@ class Test_ReflectionFitter_Cables(object):
         assert a.dly_ranges[0] == '10,20'
         assert len(a.dly_ranges) == 2
         assert np.allclose(a.opt_buffer, [25, 75])
+        assert a.write_each_calfits
+
+        sys.argv = [sys.argv[0], 'a', '--only_write_final_calfits']
+        parser = reflections.auto_reflection_argparser()
+        a = parser.parse_args()
+        assert not a.write_each_calfits
 
     def test_auto_reflection_run(self):
         # most of the code tests have been done above, this is just to ensure this wrapper function runs

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -309,8 +309,10 @@ class Test_ReflectionFitter_Cables(object):
         # ensure gains have two humps at 150 and 250 ns
         uvc = UVCal()
         uvc.read_calfits('./ex.calfits')
+        assert uvc.Ntimes == 1  # because time_avg=True
         uvc2 = UVCal()
         uvc2.read_calfits('./ex.ref2.calfits')
+        assert uvc2.Ntimes == 1  # because time_avg=True
         uvc.gain_array *= uvc2.gain_array
         aind = np.argmin(np.abs(uvc.ant_array - 23))
         g = uvc.gain_array[aind, 0, :, :, 0].T
@@ -324,6 +326,16 @@ class Test_ReflectionFitter_Cables(object):
         os.remove("./ex.npz")
         os.remove("./ex.ref2.calfits")
         os.remove("./ex.ref2.npz")
+
+        # Try with write_each_calfits = False
+        reflections.auto_reflection_run(uvd, [(100, 200), (200, 300)], "./ex.calfits", time_avg=True, window='blackmanharris', 
+                                        write_npz=False, overwrite=True, ref_sig_cut=1.0, write_each_calfits=False)
+        assert os.path.exists("./ex.calfits")
+        assert not os.path.exists("./ex.ref2.calfits")
+        uvc3 = UVCal()
+        uvc3.read_calfits('./ex.calfits')
+        np.testing.assert_array_equal(uvc3.gain_array, uvc.gain_array)
+        os.remove("./ex.calfits")
 
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -340,7 +340,7 @@ class Test_ReflectionFitter_Cables(object):
         assert not os.path.exists("./ex.ref2.calfits")
         uvc3 = UVCal()
         uvc3.read_calfits('./ex.calfits')
-        np.testing.assert_array_equal(uvc3.gain_array, uvc.gain_array)
+        np.testing.assert_array_almost_equal(uvc3.gain_array, uvc.gain_array, 12)
         os.remove("./ex.calfits")
 
 


### PR DESCRIPTION
I've been experimenting with making reflection fitting part of a daily pipeline for a re-analysis of H1C IDR3 that I'm exploring. Given the paucity of evidence for substantial time variability in the reflections, I'm trying to produce a single reflection fit for the whole day. I tried implementing this with `auto_reflection_run.py` and ran into two issues, which this PR address:

1.  This function produced one calfits file per `dly_range` provided. If I'm fitting dozens of reflections, that produces a lot of files that I don't really want. If I want to go back and reconstruct all the individual reflections, that's what the npzs are good for. So this PR implements a `write_each_calfits` option, which is default True (so no change in the default behavior) but when False will only write a final combined calfits file. If one turns on `write_npz`, that's still done per delay range.

2. When using `time_avg=True` its a bit silly to produce a calfits file with the full-temporal resolution when a single-integration calfits file will do (especially considering that I'm now handling this case explicitly in `apply_cal`--see #756). In my case, since I was doing a whole day, each calfits file was 11 GB! And there were dozens of them! So now, when `time_avg` is true, RF.times is reduced to a length-1 vector so that gains are not broadcast. 
