### PR TITLE
Allow argparser to set max_contiguous_edge_flags in delay_filter_run.py in DPSS mode

### DIFF
--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -32,7 +32,7 @@ elif ap.mode == 'dpss_leastsq':
     avg_red_bllens = True
     filter_kwargs['skip_contiguous_flags'] = True
     skip_flagged_edges = True
-    filter_kwargs['max_contiguous_edge_flags'] = 1
+    filter_kwargs['max_contiguous_edge_flags'] = ap.max_contiguous_edge_flags
     filter_kwargs['flag_model_rms_outliers'] = True
 else:
     raise ValueError(f"mode {mode} not supported.")


### PR DESCRIPTION
For reasons I don't understand, `delay_filter_run.py` ignored `max_contiguous_edge_flags` from the argparser and just set it to 1 in `dpss_leastsq` mode. This opens that up, but shouldn't change the default behavior, since the default value is 1.