### PR TITLE
Only perform sigma clipping on real part of autocorrelations

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -349,7 +349,7 @@ def lst_bin(data_list, lst_list, flags_list=None, nsamples_list=None, dlst=None,
                 clip_flags = sigma_clip(d.real, sigma=sigma, min_N=min_N)
 
                 # clip imag and combine, skipping autocorrelations
-                if utils.split_bl(key)[0] == utils.split_bl(key)[1]:
+                if utils.split_bl(key)[0] != utils.split_bl(key)[1]:
                     imag_f = sigma_clip(d.imag, sigma=sigma, min_N=min_N)
                     clip_flags |= imag_f
 

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -351,7 +351,7 @@ def lst_bin(data_list, lst_list, flags_list=None, nsamples_list=None, dlst=None,
                 # clip imag and combine, skipping autocorrelations
                 if utils.split_bl(key)[0] == utils.split_bl(key)[1]:
                     imag_f = sigma_clip(d.imag, sigma=sigma, min_N=min_N)
-                    clip_flags = real_f + imag_f
+                    clip_flags |= imag_f
 
                 # apply min_N condition as sigma_clip only checks axis size, not number of flags
                 sc_min_N = np.logical_not(f).sum(axis=0) < min_N

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -346,13 +346,12 @@ def lst_bin(data_list, lst_list, flags_list=None, nsamples_list=None, dlst=None,
                         f[:, below_min_N_freqs] = True
 
                 # clip real
-                real_f = sigma_clip(d.real, sigma=sigma, min_N=min_N)
+                clip_flags = sigma_clip(d.real, sigma=sigma, min_N=min_N)
 
-                # clip imag
-                imag_f = sigma_clip(d.imag, sigma=sigma, min_N=min_N)
-
-                # get real + imag flags
-                clip_flags = real_f + imag_f
+                # clip imag and combine, skipping autocorrelations
+                if utils.split_bl(key)[0] == utils.split_bl(key)[1]:
+                    imag_f = sigma_clip(d.imag, sigma=sigma, min_N=min_N)
+                    clip_flags = real_f + imag_f
 
                 # apply min_N condition as sigma_clip only checks axis size, not number of flags
                 sc_min_N = np.logical_not(f).sum(axis=0) < min_N


### PR DESCRIPTION
In the process of validation, I discovered that a huge fraction of the nsamples and were getting thrown away. I'm not 100% sure, but my theory is that any autocorrelations whose imaginary component is not identically 0 were often getting tossed by the sigma clipping (also this was done with an older version of pyuvdata before real autos were more strictly enforced). 

![image](https://user-images.githubusercontent.com/5281139/162594213-72c198b5-ed50-4163-887c-01c689b8f4d7.png)

Regardless, we should not be separately sigma-clipping the imaginary parts of the autos. This PR fixes that.