### PR TITLE
Fix error in FRF argparser and separate out option group

### DIFF
--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -1252,32 +1252,32 @@ def tophat_frfilter_argparser(mode='clean'):
     '''
     ap = vis_clean._filter_argparser()
     filt_options = ap.add_argument_group(title='Options for the fr-filter')
-    filt_options.add_argument("--frate_width_multiplier", type=float, default=1.0, help="Fraction of maximum sky-fringe-rate to interpolate / filter."
-                                                                              "Used if select_mainlobe is False and max_frate_coeffs not specified.")
-    filt_options.add_argument("--frate_standoff", type=float, default=0.0, help="Standoff in fringe-rate to filter [mHz]."
-                                                                      "Used of select_mainlobe is False and max_frate_coeffs not specified.")
-    filt_options.add_argument("--min_frate_half_width", type=float, default=0.025, help="minimum half-width of fringe-rate filter, regardless of baseline length in mHz."
-                                                                              "Default is 0.025.")
-    filt_options.add_argument("--max_frate_half_width", type=float, default=np.inf, help="maximum half-width of fringe-rate filter, regardless of baseline length in mHz."
-                                                                               "Default is np.inf, i.e. no limit.")
-    filt_options.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2."
-                                                                                  "Providing these overrides the sky-based fringe-rate determination! Default is None.")
+    filt_options.add_argument("--frate_width_multiplier", type=float, default=1.0, help="Fraction of maximum sky-fringe-rate to interpolate / filter. "
+                                                                                        "Used if select_mainlobe is False and max_frate_coeffs not specified.")
+    filt_options.add_argument("--frate_standoff", type=float, default=0.0, help="Standoff in fringe-rate to filter [mHz]. "
+                                                                                "Used of select_mainlobe is False and max_frate_coeffs not specified.")
+    filt_options.add_argument("--min_frate_half_width", type=float, default=0.025, help="minimum half-width of fringe-rate filter, regardless of baseline length in mHz. "
+                                                                                        "Default is 0.025.")
+    filt_options.add_argument("--max_frate_half_width", type=float, default=np.inf, help="maximum half-width of fringe-rate filter, regardless of baseline length in mHz. "
+                                                                                         "Default is np.inf, i.e. no limit.")
+    filt_options.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2. "
+                                                                                            "Providing these overrides the sky-based fringe-rate determination! Default is None.")
     filt_options.add_argument("--skip_autos", default=False, action="store_true", help="Exclude autos from filtering.")
     filt_options.add_argument("--beamfitsfile", default=None, type=str, help="Path to UVBeam beamfits file to use for determining isotropic sky fringe-rates to filter.")
     filt_options.add_argument("--percentile_low", default=5.0, type=float, help="Reject fringe-rates with beam power below this percentile if beamfitsfile is provided.")
     filt_options.add_argument("--percentile_high", default=95.0, type=float, help="Reject fringe-rates with beam power above this percentile if beamfitsfile is provided.")
     filt_options.add_argument("--taper", default='none', type=str, help="Weight fringe-rates at different frequencies by the square of this taper if beamfitsfile is provided.")
-    filt_options.add_argument("--fr_freq_skip", default=1, type=int, help="fr_freq_skip: int, optional"
-                                                                "bin fringe rates from every freq_skip channels."
-                                                                "default is 1 -> takes a long time. We recommend setting this to be larger.")
-    filt_options.add_argument("--pre_filter_modes_between_lobe_minimum_and_zero", type=bool, default=False, help="Subtract emission between the main-lobe fringe-rate region and zero"
-                                                                                                       "before applying main-lobe fringe rate filter. This is to prevent"
-                                                                                                       "the main-lobe filter to responding to overwhelmingly bright emission"
-                                                                                                       "centered at zero fringe-rate, which can happen if we have lots of cross-talk.")
+    filt_options.add_argument("--fr_freq_skip", default=1, type=int, help="fr_freq_skip: int, optional "
+                                                                          "bin fringe rates from every freq_skip channels. "
+                                                                          "default is 1 -> takes a long time. We recommend setting this to be larger.")
+    filt_options.add_argument("--pre_filter_modes_between_lobe_minimum_and_zero", type=bool, default=False, help="Subtract emission between the main-lobe fringe-rate region and zero "
+                                                                                                                 "before applying main-lobe fringe rate filter. This is to prevent "
+                                                                                                                 "the main-lobe filter to responding to overwhelmingly bright emission "
+                                                                                                                 "centered at zero fringe-rate, which can happen if we have lots of cross-talk.")
     filt_options.add_argument("--wgt_by_nsample", default=False, action="store_true", help="Use weights proportional to nsamples during FRF. Default is to just use flags by nsamples.")
     from .smooth_cal import _pair
-    filt_options.add_argument("--excluded_lsts", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of LSTs in hours \
-                          bounding (inclusively) LSTs assigned zero weight during FRF, e.g. '3-4 10-12 23-.5'")
+    filt_options.add_argument("--excluded_lsts", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of LSTs in hours "
+                                                                                         "bounding (inclusively) LSTs assigned zero weight during FRF, e.g. '3-4 10-12 23-.5'")
 
     desc = ("Filtering case ['max_frate_coeffs', 'uvbeam', 'sky']",
             "If case == 'max_frate_coeffs', then determine fringe rate centers",

--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -1252,31 +1252,31 @@ def tophat_frfilter_argparser(mode='clean'):
     '''
     ap = vis_clean._filter_argparser()
     filt_options = ap.add_argument_group(title='Options for the fr-filter')
-    ap.add_argument("--frate_width_multiplier", type=float, default=1.0, help="Fraction of maximum sky-fringe-rate to interpolate / filter."
+    filt_options.add_argument("--frate_width_multiplier", type=float, default=1.0, help="Fraction of maximum sky-fringe-rate to interpolate / filter."
                                                                               "Used if select_mainlobe is False and max_frate_coeffs not specified.")
-    ap.add_argument("--frate_standoff", type=float, default=0.0, help="Standoff in fringe-rate to filter [mHz]."
+    filt_options.add_argument("--frate_standoff", type=float, default=0.0, help="Standoff in fringe-rate to filter [mHz]."
                                                                       "Used of select_mainlobe is False and max_frate_coeffs not specified.")
-    ap.add_argument("--min_frate_half_width", type=float, default=0.025, help="minimum half-width of fringe-rate filter, regardless of baseline length in mHz."
+    filt_options.add_argument("--min_frate_half_width", type=float, default=0.025, help="minimum half-width of fringe-rate filter, regardless of baseline length in mHz."
                                                                               "Default is 0.025.")
-    ap.add_argument("--max_frate_half_width", type=float, default=np.inf, help="maximum half-width of fringe-rate filter, regardless of baseline length in mHz."
+    filt_options.add_argument("--max_frate_half_width", type=float, default=np.inf, help="maximum half-width of fringe-rate filter, regardless of baseline length in mHz."
                                                                                "Default is np.inf, i.e. no limit.")
-    ap.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2."
+    filt_options.add_argument("--max_frate_coeffs", type=float, default=None, nargs=2, help="Maximum fringe-rate coefficients for the model max_frate [mHz] = x1 * EW_bl_len [ m ] + x2."
                                                                                   "Providing these overrides the sky-based fringe-rate determination! Default is None.")
-    ap.add_argument("--skip_autos", default=False, action="store_true", help="Exclude autos from filtering.")
-    ap.add_argument("--beamfitsfile", default=None, type=str, help="Path to UVBeam beamfits file to use for determining isotropic sky fringe-rates to filter.")
-    ap.add_argument("--percentile_low", default=5.0, type=float, help="Reject fringe-rates with beam power below this percentile if beamfitsfile is provided.")
-    ap.add_argument("--percentile_high", default=95.0, type=float, help="Reject fringe-rates with beam power above this percentile if beamfitsfile is provided.")
-    ap.add_argument("--taper", default='none', type=str, help="Weight fringe-rates at different frequencies by the square of this taper if beamfitsfile is provided.")
-    ap.add_argument("--fr_freq_skip", default=1, type=int, help="fr_freq_skip: int, optional"
+    filt_options.add_argument("--skip_autos", default=False, action="store_true", help="Exclude autos from filtering.")
+    filt_options.add_argument("--beamfitsfile", default=None, type=str, help="Path to UVBeam beamfits file to use for determining isotropic sky fringe-rates to filter.")
+    filt_options.add_argument("--percentile_low", default=5.0, type=float, help="Reject fringe-rates with beam power below this percentile if beamfitsfile is provided.")
+    filt_options.add_argument("--percentile_high", default=95.0, type=float, help="Reject fringe-rates with beam power above this percentile if beamfitsfile is provided.")
+    filt_options.add_argument("--taper", default='none', type=str, help="Weight fringe-rates at different frequencies by the square of this taper if beamfitsfile is provided.")
+    filt_options.add_argument("--fr_freq_skip", default=1, type=int, help="fr_freq_skip: int, optional"
                                                                 "bin fringe rates from every freq_skip channels."
                                                                 "default is 1 -> takes a long time. We recommend setting this to be larger.")
-    ap.add_argument("--pre_filter_modes_between_lobe_minimum_and_zero", type=bool, default=False, help="Subtract emission between the main-lobe fringe-rate region and zero"
+    filt_options.add_argument("--pre_filter_modes_between_lobe_minimum_and_zero", type=bool, default=False, help="Subtract emission between the main-lobe fringe-rate region and zero"
                                                                                                        "before applying main-lobe fringe rate filter. This is to prevent"
                                                                                                        "the main-lobe filter to responding to overwhelmingly bright emission"
                                                                                                        "centered at zero fringe-rate, which can happen if we have lots of cross-talk.")
-    ap.add_argument("--wgt_by_nsample", default=False, action="store_true", help="Use weights proportional to nsamples during FRF. Default is to just use flags by nsamples.")
+    filt_options.add_argument("--wgt_by_nsample", default=False, action="store_true", help="Use weights proportional to nsamples during FRF. Default is to just use flags by nsamples.")
     from .smooth_cal import _pair
-    ap.add_argument("--excluded_lsts", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of LSTs in hours \
+    filt_options.add_argument("--excluded_lsts", type=_pair, default=[], nargs='+', help="space-separated list of dash-separted pairs of LSTs in hours \
                           bounding (inclusively) LSTs assigned zero weight during FRF, e.g. '3-4 10-12 23-.5'")
 
     desc = ("Filtering case ['max_frate_coeffs', 'uvbeam', 'sky']",
@@ -1286,7 +1286,7 @@ def tophat_frfilter_argparser(mode='clean'):
             "from histogram of main-beam wrt instantaneous sky fringe rates.",
             "If case == 'sky': then use fringe-rates corresponding to range of ",
             "instantanous fringe-rates that include sky emission.")
-    ap.add_argument("--case", default="sky", help=desc, type=str)
+    filt_options.add_argument("--case", default="sky", help=' '.join(desc), type=str)
     return ap
 
 


### PR DESCRIPTION
This PR fixes two minor issues in `tophat_frfilter_argparser`. 

The first was causing an error:
```
(python3) Joshs-MacBook-Pro:hera_cal jsdillon$ tophat_frfilter_run.py -h
Traceback (most recent call last):
  File "/Users/jsdillon/anaconda3/envs/python3/bin/tophat_frfilter_run.py", line 14, in <module>
    ap = parser.parse_args()
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 1825, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 1858, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 2067, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 2007, in consume_optional
    take_action(action, args, option_string)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 1935, in take_action
    action(self, namespace, argument_values, option_string)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 1098, in __call__
    parser.print_help()
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 2555, in print_help
    self._print_message(self.format_help(), file)
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 2539, in format_help
    return formatter.format_help()
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 283, in format_help
    help = self._root_section.format_help()
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/jsdillon/anaconda3/envs/python3/lib/python3.10/argparse.py", line 532, in _format_action
    if action.help and action.help.strip():
AttributeError: 'tuple' object has no attribute 'strip'
```
This was fixed by changing `help=desc` to `help=' '.join(desc)`.

Second, while the code originally create an options group specific to the FRF with the line `filt_options = ap.add_argument_group(title='Options for the fr-filter')`, it was never used. I've now added all options here to that group, as I think was originally intended.