### PR TITLE
Make default skip_flagged_edges self-consistent in smooth_cal

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -962,7 +962,7 @@ def smooth_cal_argparser():
                           discrete prolate spheroidal sequences to smooth calibration solutions.')
     flt_opts.add_argument("--eigenval_cutoff", type=str, default=1e-8, help="sinc_matrix eigenvalue cutoff to use for included dpss modes. \
                           Only used when the filtering method is 'DPSS'")
-    flt_opts.add_argument("--skip_flagged_edges", type=str, default=False, help="if True, do not filter over flagged edge times/freqs (filter over sub-region).\
+    flt_opts.add_argument("--dont_skip_flagged_edges", default=False, action="store_true", help="if True, do not skip over flagged edge times/freqs (filter over sub-region).\
                           Only used when method used is 'DPSS'")
     args = a.parse_args()
     return args

--- a/scripts/smooth_cal_run.py
+++ b/scripts/smooth_cal_run.py
@@ -26,7 +26,7 @@ if a.run_if_first is None or sorted(a.calfits_list)[0] == a.run_if_first:
                              time_threshold=a.time_threshold, ant_threshold=a.ant_threshold, verbose=a.verbose)
     cs.time_freq_2D_filter(freq_scale=a.freq_scale, time_scale=a.time_scale, tol=a.tol, filter_mode=a.filter_mode,
                            window=a.window, maxiter=a.maxiter, method=a.method, eigenval_cutoff=a.eigenval_cutoff,
-                           skip_flagged_edges=a.skip_flagged_edges, **win_kwargs)
+                           skip_flagged_edges=(not a.dont_skip_flagged_edges), **win_kwargs)
     cs.write_smoothed_cal(output_replace=(a.infile_replace, a.outfile_replace),
                           add_to_history=' '.join(sys.argv), clobber=a.clobber)
 else:


### PR DESCRIPTION
This PR makes the default skip_flagged_edges `True`, both in the argparser and script, so that the default value in `time_freq_2D_filter()` matches the default value in the script.