### PR TITLE
Improve the runtime and memory usage efficiency of smoothcal with DPSS modes

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -104,7 +104,7 @@ def dpss_filters(freqs, times, freq_scale=10, time_scale=1800, eigenval_cutoff=1
         if Nmax < x0.shape[0]:
             Nw = 2 * x0.shape[0] * fw * np.diff(x0)[0]
             Nterms = int(min(10 * Nw, x0.shape[0]))
-            windows, eigvals = uvtools.dspec.windows.dpss(x0.shape[0], Nw // 2, Nterms, return_ratios=True)
+            windows, eigvals = uvtools.dspec.windows.dpss(x0.shape[0], Nw / 2, Nterms, return_ratios=True)
             windows = windows[eigvals > eigenval_cutoff].T
             dpss_windows.append(windows)
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -84,10 +84,10 @@ def dpss_filters(freqs, times, freq_scale=10, time_scale=1800, eigenval_cutoff=1
         eigenval_cutoff: sinc_matrix eigenvalue cutoff to use for included dpss modes.
             Only used when the filtering method is 'DPSS'
         Nmax: Maximum number of time/frequency axis samples to attempt to compute the DPSS
-            vectors for. If the number of time/frequency values exceeds this threshold value,
+            vectors for. If the number of time/frequency samples exceeds this threshold value,
             the number of non-zero eigenvalues will be estimated to attempt to reduce the computation
             time of the DPSS vectors while still keeping all vectors whose eigenvalue is greater than
-            eigenval_cutoff. Defaults is 2000
+            eigenval_cutoff. Default is 2000 grid points.
 
     Returns:
         time_filters: DPSS filtering vectors along the time axis, ndarray of size (Ntimes, N_time_vectors)
@@ -122,13 +122,13 @@ def dpss_filters(freqs, times, freq_scale=10, time_scale=1800, eigenval_cutoff=1
 def solve_2D_DPSS(gains, weights, time_filters, freq_filters, XTXinv=None):
     """
     Filters gain solutions by solving the weighted linear least squares problem
-    for a design matrix that can be factored into two kronecker products in the following way
+    for a design matrix that can be factored by a kronecker product in the following way
 
          y = X b = (A outer B) b
 
-    where A and B are time and frequency DPSS vector matrices. More memory and computationally
-    efficient than computing the design matrix from the time and frequency filters for
-    most input matrix sizes.
+    where A and B are DPSS vector matrices for the time and frequency axes. More memory
+    and computationally efficient than computing the design matrix from the time and frequency
+    filters for most input matrix sizes.
 
     Arguments:
         gains: ndarray of shape=(Ntimes,Nfreqs) of complex calibration solutions to filter
@@ -269,7 +269,7 @@ def time_filter(gains, wgts, times, filter_scale=1800.0, nMirrors=0):
 
 def time_freq_2D_filter(gains, wgts, freqs, times, freq_scale=10.0, time_scale=1800.0,
                         tol=1e-09, filter_mode='rect', maxiter=100, window='tukey', method='CLEAN',
-                        design_matrix=None, sol_matrix=None, eigenval_cutoff=1e-8, skip_flagged_edges=True,
+                        design_matrix=None, sol_matrix=None, eigenval_cutoff=1e-9, skip_flagged_edges=True,
                         **win_kwargs):
     '''Filter calibration solutions in both time and frequency simultaneously. First rephases to remove
     a time-average delay from the gains, then performs the low-pass 2D filter in time and frequency,
@@ -840,7 +840,7 @@ class CalibrationSmoother():
         self.rephase_to_refant(warn=False)
 
     def time_freq_2D_filter(self, freq_scale=10.0, time_scale=1800.0, tol=1e-09, filter_mode='rect',
-                            window='tukey', maxiter=100, method="CLEAN", eigenval_cutoff=1e-8, skip_flagged_edges=True,
+                            window='tukey', maxiter=100, method="CLEAN", eigenval_cutoff=1e-9, skip_flagged_edges=True,
                             **win_kwargs):
         '''2D time and frequency filter stored calibration solutions on a given scale in seconds and MHz respectively.
 
@@ -995,7 +995,7 @@ def smooth_cal_argparser():
     flt_opts.add_argument("--alpha", type=float, default=.3, help='alpha parameter to use for Tukey window (ignored if window is not Tukey)')
     flt_opts.add_argument("--method", type=str, default='CLEAN', help='Algorithm used to smooth calibration solutions. Default is "CLEAN". "DPSS" uses \
                           discrete prolate spheroidal sequences to smooth calibration solutions.')
-    flt_opts.add_argument("--eigenval_cutoff", type=str, default=1e-8, help="sinc_matrix eigenvalue cutoff to use for included dpss modes. \
+    flt_opts.add_argument("--eigenval_cutoff", type=str, default=1e-9, help="sinc_matrix eigenvalue cutoff to use for included dpss modes. \
                           Only used when the filtering method is 'DPSS'")
     flt_opts.add_argument("--dont_skip_flagged_edges", default=False, action="store_true", help="if True, do not skip over flagged edge times/freqs (filter over sub-region).\
                           Only used when method used is 'DPSS'")

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -52,6 +52,10 @@ class Test_Smooth_Cal_Helper_Functions(object):
                              time_scale=0.99 / time_scale, freq_scale=1.01 / freq_scale)
         assert pytest.raises(ValueError, smooth_cal.dpss_filters, times=times, freqs=freqs,
                              time_scale=1.01 / time_scale, freq_scale=0.99 / freq_scale)
+        # test approximate estimator of the eigenvalues
+        time_filters, freq_filters = smooth_cal.dpss_filters(
+            times=times, freqs=freqs, time_scale=1.01 / time_scale, freq_scale=1.01 / freq_scale, Nmax=45
+        )
 
     def test_solve_2D_DPSS(self):
         time_filters = np.random.uniform(0, 1, size=(50, 2))

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -68,7 +68,6 @@ class Test_Smooth_Cal_Helper_Functions(object):
         XTXinv = np.random.uniform(0, 1, size=(10, 10))
         fit, info = smooth_cal.solve_2D_DPSS(gains, weights, time_filters, freq_filters, XTXinv=XTXinv)
 
-
     def test_time_filter(self):
         gains = np.ones((10, 10), dtype=complex)
         gains[3, 5] = 10.0

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -62,7 +62,6 @@ class Test_Smooth_Cal_Helper_Functions(object):
         for i in range(v.shape[1]):
             np.testing.assert_allclose(v[:, i], freq_filters[:, i])
 
-
     def test_solve_2D_DPSS(self):
         time_filters = np.random.uniform(0, 1, size=(50, 2))
         freq_filters = np.random.uniform(0, 1, size=(40, 5))

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -42,27 +42,28 @@ class Test_Smooth_Cal_Helper_Functions(object):
         freq_scale = 0.5 / (np.diff(freqs)[0] / 1e6)
         time_scale = 0.5 / (np.diff(times)[0] * 3600 * 24)
         # Show that dpss_filter generates filters for a 2D grid of times and freqs
-        design_matrix = smooth_cal.dpss_filters(
+        time_filters, freq_filters = smooth_cal.dpss_filters(
             times=times, freqs=freqs, time_scale=1.01 / time_scale, freq_scale=1.01 / freq_scale
         )
-        assert design_matrix.shape[0] == int(freqs.shape[0] * times.shape[0])
+        assert time_filters.shape[0] == times.shape[0]
+        assert freq_filters.shape[0] == freqs.shape[0]
         # test that error is thrown when filtering scale is too fine
         assert pytest.raises(ValueError, smooth_cal.dpss_filters, times=times, freqs=freqs,
                              time_scale=0.99 / time_scale, freq_scale=1.01 / freq_scale)
         assert pytest.raises(ValueError, smooth_cal.dpss_filters, times=times, freqs=freqs,
                              time_scale=1.01 / time_scale, freq_scale=0.99 / freq_scale)
 
-    def test_fit_solution_matrix(self):
-        design_matrix = np.random.uniform(0, 1, size=(100, 10))
-        weights = np.random.uniform(0, 1, size=(10, 10))
-        sol_matrix = smooth_cal.fit_solution_matrix(weights, design_matrix)
+    def test_solve_2D_DPSS(self):
+        time_filters = np.random.uniform(0, 1, size=(50, 2))
+        freq_filters = np.random.uniform(0, 1, size=(40, 5))
+        weights = np.random.uniform(0, 1, size=(50, 40))
+        gains = np.random.uniform(0, 1, size=(50, 40))
+        fit, info = smooth_cal.solve_2D_DPSS(gains, weights, time_filters, freq_filters)
 
-        # test ill-conditioned matrix block
-        design_matrix = np.zeros((100, 10))
-        design_matrix[:, 0] = np.random.uniform(1, 2, size=100)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            fit = smooth_cal.fit_solution_matrix(weights, design_matrix)
+        # Check XTXinv
+        XTXinv = np.random.uniform(0, 1, size=(10, 10))
+        fit, info = smooth_cal.solve_2D_DPSS(gains, weights, time_filters, freq_filters, XTXinv=XTXinv)
+
 
     def test_time_filter(self):
         gains = np.ones((10, 10), dtype=complex)


### PR DESCRIPTION
Smoothcal with DPSS modes seems to perform better than `CLEAN`, particularly at the band edges but takes much longer to run than `CLEAN` (8 hours vs 1 hour) and uses more memory because it performs a linear fit using a large design matrix [(Nfreqs x Ntimes) x (N_freq_dpss_vec x N_time_dpss_vec)] which is the Kronecker product of two 1D DPSS vectors. The key to speeding up smoothcal and reducing memory usage is by never building the design matrix in memory. Instead, you can use the time and frequency 1D DPSS vectors and `np.einsum` to calculate `X^T W X` without explicitly storing `X` in memory. You can also use the properties of Kronecker products to simplify `X^T W y` reducing the total number of computations.

A simple test case shows that the updated version of smoothcal with DPSS modes running on a full night's worth of data for one antenna runs faster than `CLEAN`.

<img width="1348" alt="Screen Shot 2022-04-20 at 5 04 38 AM" src="https://user-images.githubusercontent.com/17678594/164226592-17a61f7e-8241-4b3b-9792-d65f986ca772.png">

The fit seems to still be good for this updated version:

![linear_fit](https://user-images.githubusercontent.com/17678594/164307122-61b7381f-4782-463d-9e84-5a63d1509cff.png)



