### PR TITLE
Allow uvfits metadata only reads

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -523,18 +523,13 @@ class HERAData(UVData):
             self.read = super().read  # re-define self.read so UVData can call self.read recursively for lists of files
             # load data
             try:
-                if self.filetype == 'uvh5':
-                    super().read(self.filepaths, file_type='uvh5', axis=axis, bls=bls, polarizations=polarizations,
+                if self.filetype in ['uvh5', 'uvfits']:
+                    super().read(self.filepaths, file_type=self.filetype, axis=axis, bls=bls, polarizations=polarizations,
                                  times=times, time_range=time_range, lsts=lsts, lst_range=lst_range, frequencies=frequencies, 
                                  freq_chans=freq_chans, read_data=read_data, run_check=run_check, check_extra=check_extra,
                                  run_check_acceptability=run_check_acceptability, **kwargs)
-                elif self.filetype == 'uvfits':
-                    super().read(
-                        self.filepaths, file_type='uvfits', axis=axis, bls=bls, polarizations=polarizations, times=times,
-                        time_range=time_range, lsts=lsts, lst_range=lst_range, frequencies=frequencies, freq_chans=freq_chans,
-                        read_data=read_data, run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability, **kwargs
-                    )
-                    self.unphase_to_drift() 
+                    if self.filetype == 'uvfits':
+                        self.unphase_to_drift() 
                 else:
                     if not read_data:
                         raise NotImplementedError('reading only metadata is not implemented for ' + self.filetype)

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -258,7 +258,7 @@ class HERAData(UVData):
     # lsts_by_bl: dictionary mapping antpairs to LSTs (radians). Also includes all reverse pairs.
 
     def __init__(self, input_data, upsample=False, downsample=False, filetype='uvh5', **read_kwargs):
-        '''Instantiate a HERAData object. If the filetype == uvh5, read in and store
+        '''Instantiate a HERAData object. If the filetype is either uvh5 or uvfits, read in and store
         useful metadata (see get_metadata_dict()), either as object attributes or,
         if input_data is a list, as dictionaries mapping string paths to metadata.
 
@@ -268,7 +268,7 @@ class HERAData(UVData):
                 Upsampling will affect the time metadata stored on this object.
             downsample: bool. If True, will downsample to match the longest integration time in the file.
                 Downsampling will affect the time metadata stored on this object.
-            filetype: supports 'uvh5' (defualt), 'miriad', 'uvfits'
+            filetype: supports 'uvh5' (default), 'miriad', 'uvfits'
             read_kwargs : kwargs to pass to UVData.read (e.g. run_check, check_extra and
                 run_check_acceptability). Only used for uvh5 filetype
         '''

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -529,9 +529,11 @@ class HERAData(UVData):
                                  freq_chans=freq_chans, read_data=read_data, run_check=run_check, check_extra=check_extra,
                                  run_check_acceptability=run_check_acceptability, **kwargs)
                 elif self.filetype == 'uvfits':
-                    super().read(self.filepaths, file_type='uvfits', axis=axis, bls=bls, polarizations=polarizations, times=times,
-                                    time_range=time_range, lsts=lsts, lst_range=lst_range, frequencies=frequencies, freq_chans=freq_chans,
-                                    read_data=read_data, run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability, **kwargs)
+                    super().read(
+                        self.filepaths, file_type='uvfits', axis=axis, bls=bls, polarizations=polarizations, times=times,
+                        time_range=time_range, lsts=lsts, lst_range=lst_range, frequencies=frequencies, freq_chans=freq_chans,
+                        read_data=read_data, run_check=run_check, check_extra=check_extra, run_check_acceptability=run_check_acceptability, **kwargs
+                    )
                     self.unphase_to_drift() 
                 else:
                     if not read_data:

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -185,7 +185,7 @@ class Test_HERAData(object):
         hd = HERAData(self.uvfits, filetype='uvfits')
         assert hd.filepaths == [self.uvfits]
         for meta in hd.HERAData_metas:
-            assert getattr(hd, meta) is None
+            assert getattr(hd, meta) is not None
 
         # bda upsample/downsample
         hd = HERAData(self.uvh5_bda, upsample=True)
@@ -441,14 +441,16 @@ class Test_HERAData(object):
 
         # uvfits
         hd = HERAData(self.uvfits, filetype='uvfits')
-        d, f, n = hd.read(bls=(0, 1, 'xx'), freq_chans=list(range(10)))
+        hd.read(read_data=False)
+        ant_pairs = hd.get_antpairs()
+        d, f, n = hd.read(bls=(ant_pairs[0][0], ant_pairs[0][1], 'xx'), freq_chans=list(range(10)))
         assert hd.last_read_kwargs['freq_chans'] == list(range(10))
         for dc in [d, f, n]:
             assert len(dc) == 1
-            assert list(dc.keys()) == [(0, 1, parse_polstr('XX', x_orientation=hd.x_orientation))]
+            assert list(dc.keys()) == [
+                (ant_pairs[0][0], ant_pairs[0][1], parse_polstr('XX', x_orientation=hd.x_orientation))
+            ]
             assert dc[0, 1, 'ee'].shape == (60, 10)
-        with pytest.raises(NotImplementedError):
-            d, f, n = hd.read(read_data=False)
 
     def test_read_bda(self):
         # no upsampling or downsampling


### PR DESCRIPTION
This was inspired by needing to fix a test to be robust against a antenna numbering fix in pyuvdata

If you don't want me do make this larger change to the package, I can just use pyuvdata functionality to find out what the antpairs are. But since metadata only reads of uvfits files are fully supported in pyuvdata, I figured I might as well make that work in this package.

see https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1148 for details