### PR TITLE
Fix uvfits test to be robust against antenna numbering fix in pyuvdata

### DIFF
--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -450,7 +450,7 @@ class Test_HERAData(object):
             assert list(dc.keys()) == [
                 (ant_pairs[0][0], ant_pairs[0][1], parse_polstr('XX', x_orientation=hd.x_orientation))
             ]
-            assert dc[0, 1, 'ee'].shape == (60, 10)
+            assert dc[ant_pairs[0][0], ant_pairs[0][1], 'ee'].shape == (60, 10)
 
     def test_read_bda(self):
         # no upsampling or downsampling


### PR DESCRIPTION
This fixes a line I missed in #783.