### PR TITLE
Add `hera_filters` as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ installing `hera_cal`:
 Other dependencies that will be installed from PyPI on-the-fly are:
 * [linsolve](https://github.com/HERA-Team/linsolve)
 * [hera_qm](https://github.com/HERA-Team/hera_qm)
+* [hera_filters](https://github.com/HERA-Team/hera_filters)
 
-`hera_cal` also has the _optional_ dependencies of `aipy` and `hera_filters`, and some
+`hera_cal` also has the _optional_ dependency of `aipy`, and some
 functions will not work without this dependency. To install all optional dependencies, use
 `pip install .[all]` or `pip install git+git://github.com/HERA-Team/hera_cal.git[all]`.
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_args = {
         'linsolve',
         'hera_qm',
         'scikit-learn',
-        'hera_filters @ git+https://github.com/HERA-Team/hera_filters'
+        'hera_filters'
     ],
     'extras_require': {
         "all": [


### PR DESCRIPTION
Many `hera_cal` functions use `hera_filters` and now that it's on pypi we should officially add it as a dependency.