### PR TITLE
fix bug where chunks can be added that are completely flagged.

### DIFF
--- a/hera_cal/tests/test_vis_clean.py
+++ b/hera_cal/tests/test_vis_clean.py
@@ -584,6 +584,10 @@ class Test_VisClean(object):
                     skip_contiguous_flags=True, max_frate=0.025)
         for k in V.clean_flags:
             assert np.all(V.clean_flags[k])
+        V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='time', overwrite=True,
+                    skip_flagged_edges=True, max_frate=0.025)
+        for k in V.clean_flags:
+            assert np.all(V.clean_flags[k])
         V.vis_clean(keys=[(24, 25, 'ee'), (24, 24, 'ee')], ax='both', overwrite=True,
                     skip_contiguous_flags=True, max_frate=0.025)
         for k in V.clean_flags:

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -142,8 +142,10 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
                 # truncate data to be filtered where appropriate.
                 ind_left = np.min(unflagged_chans)
                 ind_right = np.max(unflagged_chans) + 1
-            inds_left.append(ind_left)
-            inds_right.append(ind_right)
+                # only append indices if there are some unflagged channels in the chunk.
+                # otherwise we should completely discard the chunk.
+                inds_left.append(ind_left)
+                inds_right.append(ind_right)
 
         dout = np.hstack([data_in[:, chunk[0] + ind_left: chunk[0] + ind_right] for ind_left, ind_right, chunk in zip(inds_left, inds_right, chunks)])
         wout = np.hstack([weights_in[:, chunk[0] + ind_left: chunk[0] + ind_right] for ind_left, ind_right, chunk in zip(inds_left, inds_right, chunks)])

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -62,21 +62,18 @@ def find_discontinuity_edges(x, xtol=1e-3):
             x = [0, 1, 4, 9] -> [(0, 2) (2, 3), (3, 4)]
             x = [0, 1, 2, 4, 5, 6, 7, 11, 12] -> [(0, 3), (3, 7), (7, 9)]
     """
-    if len(x) > 0:
-        xdiff = np.diff(x)
-        discontinuities = np.where(~np.isclose(xdiff, np.min(np.abs(xdiff)) * np.sign(xdiff[0]),
-                                   rtol=0.0, atol=np.abs(np.min(xdiff)) * xtol))[0]
-        if len(discontinuities) == 0:
-            edges = [(0, len(x))]
-        elif len(discontinuities) == 1:
-            edges = [(0, discontinuities[0] + 1), (discontinuities[0] + 1, len(x))]
-        else:
-            edges = [(0, discontinuities[0] + 1)]
-            for i in range(len(discontinuities) - 1):
-                edges.append((discontinuities[i] + 1, discontinuities[i + 1] + 1))
-            edges.append((discontinuities[-1] + 1, len(x)))
+    xdiff = np.diff(x)
+    discontinuities = np.where(~np.isclose(xdiff, np.min(np.abs(xdiff)) * np.sign(xdiff[0]),
+                               rtol=0.0, atol=np.abs(np.min(xdiff)) * xtol))[0]
+    if len(discontinuities) == 0:
+        edges = [(0, len(x))]
+    elif len(discontinuities) == 1:
+        edges = [(0, discontinuities[0] + 1), (discontinuities[0] + 1, len(x))]
     else:
-        edges = [(0, 0)]
+        edges = [(0, discontinuities[0] + 1)]
+        for i in range(len(discontinuities) - 1):
+            edges.append((discontinuities[i] + 1, discontinuities[i + 1] + 1))
+        edges.append((discontinuities[-1] + 1, len(x)))
     return edges
 
 

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -134,18 +134,17 @@ def truncate_flagged_edges(data_in, weights_in, x, ax='freq'):
         inds_right = []
         # Identify edge channels that are flagged.
         for chunk in chunks:
-            ind_left = 0
-            ind_right = chunk[1] - chunk[0]
+            ind_left = 0 # If there are no unflagged channels, then the chunk should have zero width.
+            ind_right = 0
             chunkslice = slice(chunk[0], chunk[1])
             unflagged_chans = np.where(~np.all(np.isclose(weights_in[:, chunkslice], 0.0), axis=0))[0]
             if np.count_nonzero(unflagged_chans) > 0:
                 # truncate data to be filtered where appropriate.
                 ind_left = np.min(unflagged_chans)
                 ind_right = np.max(unflagged_chans) + 1
-                # only append indices if there are some unflagged channels in the chunk.
-                # otherwise we should completely discard the chunk.
-                inds_left.append(ind_left)
-                inds_right.append(ind_right)
+
+            inds_left.append(ind_left)
+            inds_right.append(ind_right)
 
         dout = np.hstack([data_in[:, chunk[0] + ind_left: chunk[0] + ind_right] for ind_left, ind_right, chunk in zip(inds_left, inds_right, chunks)])
         wout = np.hstack([weights_in[:, chunk[0] + ind_left: chunk[0] + ind_right] for ind_left, ind_right, chunk in zip(inds_left, inds_right, chunks)])


### PR DESCRIPTION
Fixes an edge case in `vis_clean.truncate_flagged_edges` in which chunks can be produced that are completely flagged if there is a discontinuity in the x-axis that falls within a completely flagged region.

Also add handling of case where a data waterfall is completely flagged in `vis_clean.vis_clean`.