### PR TITLE
Add RedDataContainer

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -525,12 +525,14 @@ class RedDataContainer(DataContainer):
         # Figure out reds
         if reds is not None:
             self.reds = reds
-        elif antpos is not None:
-            self.reds = get_reds(antpos, pols=self.pols(), bl_error_tol=bl_error_tol)
-        elif hasattr(self, 'antpos') and self.antpos is not None:
-            self.reds = get_reds(self.antpos, pols=self.pols(), bl_error_tol=bl_error_tol)
         else:
-            raise ValueError('Must provide reds, antpos, or have antpos available at data.antpos')
+            from .redcal import get_reds
+            if antpos is not None:
+                self.reds = get_reds(antpos, pols=self.pols(), bl_error_tol=bl_error_tol)
+            elif hasattr(self, 'antpos') and self.antpos is not None:
+                self.reds = get_reds(self.antpos, pols=self.pols(), bl_error_tol=bl_error_tol)
+            else:
+                raise ValueError('Must provide reds, antpos, or have antpos available at data.antpos')
 
         # Map all redundant keys to the same underlying data
         for red in self.reds:

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -428,3 +428,43 @@ class TestDataContainerWithRealData(object):
                 assert np.all(dc.times_by_bl[0, 1] == new_times)
                 assert np.all(dc.lsts == (np.arange(10) * 2 * np.pi / 10)[new_times])
                 assert np.all(dc.lsts_by_bl[0, 1] == (np.arange(10) * 2 * np.pi / 10)[new_times])
+
+
+def test_RedDataContainer():
+    # build hexagonal array and data which tells us which baseline it comes from
+    antpos = hex_array(4, split_core=False, outriggers=0)
+    reds = get_reds(antpos, pols=['nn', 'ee', 'ne', 'en'])
+    data = DataContainer({red[0]: np.ones((10, 10)) * (red[0][0] + 1.0j * red[0][1]) for red in reds})
+
+    # try the several ways of constructing RedDataContainer
+    rdata1 = RedDataContainer(deepcopy(data), reds)
+    rdata2 = RedDataContainer(deepcopy(data), antpos=antpos)
+    data.antpos = antpos
+    rdata3 = RedDataContainer(deepcopy(data))
+    reverse_reds = [[reverse_bl(bl) for bl in red] for red in reds]
+    reverse_data = DataContainer({red[0]: np.ones((10, 10)) * (red[0][0] + 1.0j * red[0][1]) for red in reverse_reds})
+    rdata4 = RedDataContainer(deepcopy(reverse_data), reds)
+    rdata5 = RedDataContainer(deepcopy(reverse_data), reverse_reds)
+
+    # make sure that the data for a redundant group are being accessed from the same place in memory
+    for rdata in [rdata1, rdata2, rdata3, rdata4, rdata5]:
+        assert len(rdata.keys()) == len([bl for red in rdata.reds for bl in red])
+        for red in rdata.reds:
+            for bl in red:
+                assert id(rdata[bl]) == id(rdata[red[0]])
+                assert id(rdata[reverse_bl(bl)]) == id(rdata[reverse_bl(red[0])])
+
+    # test no redundancy information error
+    with pytest.raises(ValueError):
+        data = DataContainer({red[0]: np.ones((10, 10)) * (red[0][0] + 1.0j * red[0][1]) for red in reds})
+        rdata = RedDataContainer(data)
+
+    # test too much redundancy information error
+    with pytest.raises(ValueError):
+        data = DataContainer({red[0]: np.ones((10, 10)) * (red[0][0] + 1.0j * red[0][1]) for red in reds})
+        rdata = RedDataContainer(data, reds=reds, antpos=antpos)
+
+    # test error where the the data has multiple redundant baselines per group
+    with pytest.raises(ValueError):
+        data = DataContainer({bl: np.ones((10, 10)) * (bl[0] + 1.0j * bl[1]) for red in reds for bl in red})
+        rdata = RedDataContainer(data, reds)

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -451,13 +451,19 @@ def test_RedDataContainer():
 
     # make sure that the data for a redundant group are being accessed from the same place in memory
     for i, rdata in enumerate([rdata1, rdata2, rdata3, rdata4, rdata5]):
-        assert len(rdata.keys()) == len([bl for red in rdata.reds for bl in red])
         for red in rdata.reds:
             for bl in red:
                 if i < 4:
                     assert id(rdata[bl]) == id(rdata[red[0]])
                 else:
                     assert id(rdata[reverse_bl(bl)]) == id(rdata[reverse_bl(red[0])])
+                assert(rdata.get_ubl_key(bl) in red)
+                assert(rdata.has_key(rdata.get_ubl_key(bl)))
+                assert set(rdata.get_red(bl)) == set(red)
+            val_here = deepcopy(rdata[red[0]])
+            rdata[red[0]] *= 2
+            for bl in red:
+                np.testing.assert_array_equal(val_here * 2, rdata[bl])
 
     # test no redundancy information error
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds a subclass of `DataContainer` called `RedDataContainer` designed to store redundant data, like the visibility solutions that come out of `redcal`. It can be constructed from a `DataConatiner` or a dictionary, and needs to know about the redundancies, either from `reds` or `antpos`. Will make all entries in the underlying dictionary for a given unique baseline group point to the same place in memory.