### PR TITLE
Change default lst-binned visibilities from 1 to 0

### DIFF
--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -410,9 +410,9 @@ def lst_bin(data_list, lst_list, flags_list=None, nsamples_list=None, dlst=None,
 
         # fill nans
         d_nan = np.isnan(d_avg)
-        d_avg[d_nan] = 1.0
+        d_avg[d_nan] = 0.0 + 0.0j
         f_min[d_nan] = True
-        d_std[d_nan] = 1.0
+        d_std[d_nan] = 0.0 + 0.0j
         d_num[d_nan] = 0.0
 
         # insert into dictionaries

--- a/hera_cal/tests/test_lstbin.py
+++ b/hera_cal/tests/test_lstbin.py
@@ -154,7 +154,7 @@ class Test_lstbin(object):
         assert (512, 512, 'ee') in output[4]
         assert np.allclose(output[4][(512, 512, 'ee')], 0.0)
         assert np.all(output[2][(512, 512, 'ee')])
-        assert np.allclose(output[1][(512, 512, 'ee')], 1.0)
+        assert np.allclose(output[1][(512, 512, 'ee')], 0.0)
         # test conjugated flags and nsamples
         flags_list_conj = copy.deepcopy(self.flgs_list)
         nsamp_list_conj = copy.deepcopy(self.nsmp_list)

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -624,7 +624,7 @@ def test_red_average():
     davg = np.sum(d * w, axis=0) / np.sum(w, axis=0).clip(1e-10, np.inf)
     # set flagged data to 1.0+0.0j
     flagged_f = np.all(w == 0, axis=0)
-    davg[flagged_f] = 1.0
+    davg[flagged_f] = 0.0
     assert np.isclose(hda.get_data(blkey), davg).all()
 
     # try where all weights are unity but user provided flags are preserved.

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1337,9 +1337,9 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
             # take the weighted average
             wsum = np.sum(w, axis=0).clip(1e-10, np.inf)  # this is the normalization
             davg = np.sum(d * w, axis=0) / wsum  # weighted average
-            # set flagged data to 1.0+0.0j
+            # set flagged data to 0.0+0.0j
             flagged_f = np.all(f == 0, axis=0)
-            davg[flagged_f] = 1.0
+            davg[flagged_f] = 0.0 + 0.0j
             fmax = np.max(f, axis=2)  # collapse along freq: marks any fully flagged integrations
             if tint.squeeze().ndim == 1:  # tint.squeeze() can be one-dimensional if we have one time sample in our data.
                 iavg = np.sum(tint.squeeze()[:, None] * fmax, axis=0) / np.sum(fmax, axis=0).clip(1e-10, np.inf)


### PR DESCRIPTION
This PR changes the default value for flagged visibilities from 1+0j to 0+0j for the LST-binner. I also updated the redundant averager because having them have different defaults broke a unit test.

This was an issue for me when looking at delay-filtered and then delay-transformed visibilities coming out of the LST-binner using `vis_clean.fft_data()`. I was expecting 0s where there were flags, but I instead had to set them to 0s manually in order to perform this FFT without artifacts. 