### PR TITLE
Create new `RedSol` class for storing redundant solutions (gains and visibilities) with various useful methods

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -567,3 +567,7 @@ class RedDataContainer(DataContainer):
     def __setitem__(self, key, value):
         '''Sets data for to unique baseline that the key is a member of.'''
         return super().__setitem__(self._bl_to_red_key[key], value)
+
+    def __contains__(self, key):
+        '''Returns true if the baseline redundant with the key is in the data.'''
+        return key in self._bl_to_red_key

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -57,8 +57,8 @@ class DataContainer:
                 self._data = odict([(comply_bl(k), data[k]) for k in sorted(data.keys())])
             else:
                 raise KeyError('Unrecognized key type or mix of key types in data dictionary.')
-            self._antpairs = set([k[:2] for k in self._data.keys()])
-            self._pols = set([k[-1] for k in self._data.keys()])
+            self._antpairs = set([k[:2] for k in self._data])
+            self._pols = set([k[-1] for k in self._data])
 
             # placeholders for metadata (or get them from data, if possible)
             for attr in ['ants', 'data_ants', 'antpos', 'data_antpos',

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1287,7 +1287,7 @@ class RedundantCalibrator:
         return complex solutions for antennas and visibilities.
 
         Args:
-            sol: dictionary that contains both visibility and gain solutions in the
+            sol: dictionary (or RedSol) that contains both visibility and gain solutions in the
                 {(ind1,ind2,pol): np.array} and {(index,antpol): np.array} formats respectively
             degen_sol: Optional dictionary in the same format as sol. Gain amplitudes and phases
                 in degen_sol replace the values of sol in the degenerate subspace of redcal. If
@@ -1295,17 +1295,16 @@ class RedundantCalibrator:
                 Visibilties in degen_sol are ignored.  For logcal/lincal/omnical, putting firstcal
                 solutions in here can help avoid structure associated with phase-wrapping issues.
         Returns:
-            new_sol: sol with degeneracy removal/replacement performed
+            new_sol: RedSol with degeneracy removal/replacement performed
         """
 
         gains, vis = get_gains_and_vis_from_sol(sol)
         if degen_sol is None:
             degen_sol = {key: np.ones_like(val) for key, val in gains.items()}
         new_gains = self.remove_degen_gains(gains, degen_gains=degen_sol, mode='complex')
-        new_sol = deepcopy(vis)
-        calibrate_in_place(new_sol, new_gains, old_gains=gains)
-        new_sol.update(new_gains)
-        return new_sol
+        new_vis = deepcopy(vis)
+        calibrate_in_place(new_vis, new_gains, old_gains=gains)
+        return RedSol(self.reds, gains=new_gains, vis=new_vis)
 
     def count_degens(self, assume_redundant=True):
         """Count the number of degeneracies in this redundant calibrator, given the redundancies and the pol_mode.

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -401,6 +401,27 @@ class RedSol():
         '''Replaces nans and infs in this object, see redcal.make_sol_finite() for details.'''
         make_sol_finite(self)
 
+    def remove_degen(self, degen_sol=None, inplace=True):
+        """ Removes degeneracies from solutions (or replaces them with those in degen_sol).
+
+        Arguments:
+            sol: dictionary (or RedSol) that contains both visibility and gain solutions in the
+                {(ind1,ind2,pol): np.array} and {(index,antpol): np.array} formats respectively
+            degen_sol: Optional dictionary or RedSol, formatted like sol. Gain amplitudes and phases
+                in degen_sol replace the values of sol in the degenerate subspace of redcal. If
+                left as None, average gain amplitudes will be 1 and average phase terms will be 0.
+                Visibilties in degen_sol are ignored, so this can also be a dictionary of gains.
+            inplace: If True, replaces self.vis and self.gains. If False, returns a new RedSol object.
+        Returns:
+            new_sol: if not inplace, RedSol with degeneracy removal/replacement performed
+        """
+        rc = RedundantCalibrator(self.reds)
+        new_sol = rc.remove_degen(self, degen_sol=degen_sol)
+        if inplace:
+            self.__init__(self.reds, gains=new_sol.gains, vis=new_sol.vis)
+        else:
+            return new_sol
+
     def red_average(self, data, flags=None, nsamples=None, gain_flags=None, skip_calibration=False):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object.
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -422,7 +422,7 @@ class RedSol():
         else:
             return new_sol
 
-    def red_average(self, data, flags=None, nsamples=None, gain_flags=None, skip_calibration=False):
+    def red_average(self, data, flags=None, nsamples=None, gain_flags=None):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object.
 
         Arguments:
@@ -433,7 +433,6 @@ class RedSol():
                 weighting data when averaging and for figuring out the number of samples in each baseline group.
                 If not provided, it is assumed that nsamples is uniformly 1.
             gain_flags: optional dictionary used for per-antenna, per-time-and-frequency flagging when calibrating.
-            skip_calibration: Do not calibrate data with self.gains and gain_flags, go right to redundant averaging.
 
         Returns:
             red_data: RedDataContainer of redundantly averaged data.
@@ -453,7 +452,7 @@ class RedSol():
             gain_flags = {ant: np.zeros_like(self.gains[ant], bool) for ant in self.gains}
 
         # perform calibration unless otherwise specified
-        if (self.gains is not None) and not skip_calibration:
+        if self.gains is not None:
             calibrate_in_place(red_data, self.gains, data_flags=red_flags, cal_flags=gain_flags)
 
         # perform redundant averaging and downselecgiton in place and return result as RedDataContainer

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -7,11 +7,12 @@ from copy import deepcopy
 import argparse
 import os
 import linsolve
+from itertools import chain
 
 from . import utils
 from .noise import predict_noise_variance_from_autos, infer_dt
 from .datacontainer import DataContainer
-from .utils import split_pol, conj_pol, split_bl, reverse_bl, join_bl, join_pol, comply_pol, per_antenna_modified_z_scores
+from .utils import split_pol, conj_pol, split_bl, reverse_bl, join_bl, join_pol, comply_pol, per_antenna_modified_z_scores, red_average
 from .io import HERAData, HERACal, write_cal, save_redcal_meta
 from .apply_cal import calibrate_in_place
 
@@ -320,6 +321,101 @@ def make_sol_finite(sol):
             sol[k][~np.isfinite(sol[k])] = np.zeros_like(sol[k][~np.isfinite(sol[k])])
         elif len(k) == 2:  # gains
             sol[k][~np.isfinite(sol[k])] = np.ones_like(sol[k][~np.isfinite(sol[k])])
+
+
+class RedSol():
+    '''Object for containing solutions to redundant calibraton, namely gains and
+    unique-baseline visibilities, along with a variety of convenience methods.'''
+    def __init__(self, reds, gains=None, vis=None, sol_dict=None):
+        '''Initializes RedSol object.
+
+        Arguments:
+            reds: list of lists of redundant baseline tuples, e.g. (0, 1, 'ee')
+            gains: optional dictionary. Maps keys like (1, 'Jee') to complex
+                numpy arrays of gains of size (Ntimes, Nfreqs).
+            vis: optional dictionary or DataContainer. Maps keys like (0, 1, 'ee')
+                to complex numpy arrays of visibilities of size (Ntimes, Nfreqs).
+                May only contain at most one visibility per unique baseline group.
+            sol_dict: optional dictionary. Maps both gain keys and visibilitity keys
+                to numpy arrays. Cannot be provided if gains or vis is provided.
+        '''
+        if sol_dict is not None:
+            if gains is not None or vis is not None:
+                raise ValueError('If sol_dict is specified, neither gains nor vis can be.')
+            self.gains, self.vis = get_gains_and_vis_from_sol(sol_dict)
+        else:
+            self.gains = gains
+            self.vis = vis
+        self.reds = reds
+        self.vis = RedDataContainer(self.vis, reds=self.reds)
+
+    def clear(self):
+        '''Resets self.reds, self.gains, and self.vis to None.'''
+        self.reds = None
+        self.gains = None
+        self.vis = None
+
+    def __getitem__(self, key):
+        '''Get underlying gain or visibility, depending on the length of the key.'''
+        if len(key) == 3:  # visibility key
+            return self.vis[key]
+        if len(key) == 2:  # antenna-pol key
+            return self.gains[key]
+        else:
+            raise KeyError('RedSol keys should be length-2 (for gains) or length-3 (for visibilities).')
+
+    def __setitem__(self, key, value):
+        '''Set underlying gain or visibility, depending on the length of the key.'''
+        if len(key) == 3:  # visibility key
+            self.vis[key] = value
+        if len(key) == 2:  # antenna-pol key
+            self.gains[key] = value
+        else:
+            raise KeyError('RedSol keys should be length-2 (for gains) or length-3 (for visibilities).')
+
+    def __contains__(self, key):
+        '''Returns True if key is a gain key or a redundant visbility key, False otherwise.'''
+        return (key in self.gains) or (key in self.vis)
+
+    def __iter__(self):
+        '''Iterate over gain keys, then iterate over visibility keys.'''
+        return chain(self.gains, self.vis)
+
+    def make_sol_finite(self):
+        '''Replaces nans and infs in this object, see redcal.make_sol_finite() for details.'''
+        make_sol_finite(self)
+
+    def red_average(self, data, flags=None, nsamples=None, gain_flags=None, skip_calibration=False):
+        '''Performs redundant averaging of data using reds and gains stored in this RedSol object.
+
+        Arguments:
+            data: DataContainer containing visibilities to redundantly average.
+            flags: optional DataContainer marking visibilities as flagged and therefore excluded from averaging.
+            nsamples: optional DataContainer containing the number of samples in each visibility. Used for
+                weighting data when averaging and for figuring out the number of samples in each baseline group.
+            gain_flags: optional dictionary used for per-antenna, per-time-and-frequency flagging when calibrating.
+            skip_calibration: Do not calibrate data with self.gains and gain_flags, go right to redundant averaging.
+
+        Returns:
+            red_data:
+            red_flags: If flags is provided, a  final flagging pattern after redundant
+            red_nsamples:
+
+        '''
+        # make copies of data, flags, and nsamples, which are then modified and downselected in place
+        red_data = deepcopy(data)
+        red_flags = deepcopy(flags)
+        red_nsamples = deepcopy(nsamples)
+
+        # perform calibration unless otherwise specified
+        if (self.gains is not None) and not skip_calibration:
+            calibrate_in_place(red_data, self.gains, data_flags=red_flags, cal_flags=gain_flags)
+
+        # perform redundant averaging and downselecgiton in place and return result as RedDataContainer
+        red_average(red_data, self.reds, bl_tol=bl_tol, flags=red_flags, nsamples=red_nsamples, inplace=True)
+        return (RedDataContainer(red_data, reds=self.reds),
+                RedDataContainer(red_flags, reds=self.reds),
+                RedDataContainer(red_nsamples, reds=self.reds))
 
 
 def _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np.pi / 8)):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -302,6 +302,26 @@ def reds_to_antpos(reds, tol=1e-10):
     return antpos
 
 
+def get_gains_and_vis_from_sol(sol):
+    """Splits a sol dictionary into len(key)==2 entries, taken to be gains,
+    and len(key)==3 entries, taken to be model visibrilities."""
+
+    g = {key: val for key, val in sol.items() if len(key) == 2}
+    v = {key: val for key, val in sol.items() if len(key) == 3}
+    return g, v
+
+
+def make_sol_finite(sol):
+    '''Replaces nans and infs in solutions, which are usually the result of visibilities that are
+    identically equal to 0. Modifies sol (which is a dictionary with gains and visibilities) in place,
+    replacing visibilities with 0.0s and gains with 1.0s'''
+    for k in sol.keys():
+        if len(k) == 3:  # visibilities
+            sol[k][~np.isfinite(sol[k])] = np.zeros_like(sol[k][~np.isfinite(sol[k])])
+        elif len(k) == 2:  # gains
+            sol[k][~np.isfinite(sol[k])] = np.ones_like(sol[k][~np.isfinite(sol[k])])
+
+
 def _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np.pi / 8)):
     '''This function looks at all redundant baselines and sees whether they mostly agree with the median
     baseline or whether they look closer to being off by pi radians. The ones close to the median are the
@@ -557,26 +577,6 @@ def parse_pol_mode(reds):
             return 'unrecognized_pol_mode'
     else:
         return 'unrecognized_pol_mode'
-
-
-def get_gains_and_vis_from_sol(sol):
-    """Splits a sol dictionary into len(key)==2 entries, taken to be gains,
-    and len(key)==3 entries, taken to be model visibrilities."""
-
-    g = {key: val for key, val in sol.items() if len(key) == 2}
-    v = {key: val for key, val in sol.items() if len(key) == 3}
-    return g, v
-
-
-def make_sol_finite(sol):
-    '''Replaces nans and infs in solutions, which are usually the result of visibilities that are
-    identically equal to 0. Modifies sol (which is a dictionary with gains and visibilities) in place,
-    replacing visibilities with 0.0s and gains with 1.0s'''
-    for k in sol.keys():
-        if len(k) == 3:  # visibilities
-            sol[k][~np.isfinite(sol[k])] = np.zeros_like(sol[k][~np.isfinite(sol[k])])
-        elif len(k) == 2:  # gains
-            sol[k][~np.isfinite(sol[k])] = np.ones_like(sol[k][~np.isfinite(sol[k])])
 
 
 class OmnicalSolver(linsolve.LinProductSolver):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -352,7 +352,7 @@ class RedSol():
         '''Get underlying gain or visibility, depending on the length of the key.'''
         if len(key) == 3:  # visibility key
             return self.vis[key]
-        if len(key) == 2:  # antenna-pol key
+        elif len(key) == 2:  # antenna-pol key
             return self.gains[key]
         else:
             raise KeyError('RedSol keys should be length-2 (for gains) or length-3 (for visibilities).')
@@ -361,7 +361,7 @@ class RedSol():
         '''Set underlying gain or visibility, depending on the length of the key.'''
         if len(key) == 3:  # visibility key
             self.vis[key] = value
-        if len(key) == 2:  # antenna-pol key
+        elif len(key) == 2:  # antenna-pol key
             self.gains[key] = value
         else:
             raise KeyError('RedSol keys should be length-2 (for gains) or length-3 (for visibilities).')

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -384,28 +384,37 @@ class RedSol():
         Arguments:
             data: DataContainer containing visibilities to redundantly average.
             flags: optional DataContainer marking visibilities as flagged and therefore excluded from averaging.
+                If not provided, it is assumed that all data are unflagged.
             nsamples: optional DataContainer containing the number of samples in each visibility. Used for
                 weighting data when averaging and for figuring out the number of samples in each baseline group.
+                If not provided, it is assumed that nsamples is uniformly 1.
             gain_flags: optional dictionary used for per-antenna, per-time-and-frequency flagging when calibrating.
             skip_calibration: Do not calibrate data with self.gains and gain_flags, go right to redundant averaging.
 
         Returns:
-            red_data:
-            red_flags: If flags is provided, a  final flagging pattern after redundant
-            red_nsamples:
-
+            red_data: RedDataContainer of redundantly averaged data.
+            red_flags: RedDataContainer of flags on redundantly averaged data.
+            red_nsamples: RedDataContainer of nsamples of that went into each redundantly averaged visibility
         '''
         # make copies of data, flags, and nsamples, which are then modified and downselected in place
+        # if flags and/or nsamples, is not provided, create zeros or ones as appropriate
         red_data = deepcopy(data)
         red_flags = deepcopy(flags)
+        if red_flags is None:
+            red_flags = DataContainer({bl: np.zeros_like(data[bl], bool) for bl in data})
         red_nsamples = deepcopy(nsamples)
+        if red_nsamples is None:
+            red_nsamples = DataContainer({bl: np.ones_like(data[bl], float) for bl in data})
+        if gain_flags is None:
+            gain_flags = {ant: np.zeros_like(self.gains[ant], bool) for ant in self.gains}
 
         # perform calibration unless otherwise specified
         if (self.gains is not None) and not skip_calibration:
             calibrate_in_place(red_data, self.gains, data_flags=red_flags, cal_flags=gain_flags)
 
         # perform redundant averaging and downselecgiton in place and return result as RedDataContainer
-        red_average(red_data, self.reds, bl_tol=bl_tol, flags=red_flags, nsamples=red_nsamples, inplace=True)
+        pos_reds = [list(red_tuple) for red_tuple in set(tuple(bl[0:2] for bl in red) for red in self.reds)]
+        red_average(red_data, pos_reds, flags=red_flags, nsamples=red_nsamples, inplace=True)
         return (RedDataContainer(red_data, reds=self.reds),
                 RedDataContainer(red_flags, reds=self.reds),
                 RedDataContainer(red_nsamples, reds=self.reds))

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -11,7 +11,7 @@ from itertools import chain
 
 from . import utils
 from .noise import predict_noise_variance_from_autos, infer_dt
-from .datacontainer import DataContainer
+from .datacontainer import DataContainer, RedDataContainer
 from .utils import split_pol, conj_pol, split_bl, reverse_bl, join_bl, join_pol, comply_pol, per_antenna_modified_z_scores, red_average
 from .io import HERAData, HERACal, write_cal, save_redcal_meta
 from .apply_cal import calibrate_in_place

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -374,6 +374,29 @@ class RedSol():
         '''Iterate over gain keys, then iterate over visibility keys.'''
         return chain(self.gains, self.vis)
 
+    def __len__(self):
+        '''Returns the total number of entries in self.gains or self.vis.'''
+        return len(self.gains) + len(self.vis)
+
+    def keys(self):
+        '''Iterate over gain keys, then iterate over visibility keys.'''
+        return self.__iter__()
+
+    def values(self):
+        '''Iterate over gain values, then iterate over visibility values.'''
+        return chain(self.gains.values(), self.vis.values())
+
+    def items(self):
+        '''Returns the keys and values of the gains, then over those of the visibilities.'''
+        return chain(self.gains.items(), self.vis.items())
+
+    def get(self, key, default=None):
+        '''Returns value associated with key, but default if key is not found.'''
+        if key in self:
+            return self[key]
+        else:
+            return default
+
     def make_sol_finite(self):
         '''Replaces nans and infs in this object, see redcal.make_sol_finite() for details.'''
         make_sol_finite(self)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -348,12 +348,6 @@ class RedSol():
         self.reds = reds
         self.vis = RedDataContainer(self.vis, reds=self.reds)
 
-    def clear(self):
-        '''Resets self.reds, self.gains, and self.vis to None.'''
-        self.reds = None
-        self.gains = None
-        self.vis = None
-
     def __getitem__(self, key):
         '''Get underlying gain or visibility, depending on the length of the key.'''
         if len(key) == 3:  # visibility key

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -462,6 +462,50 @@ class RedSol():
                 RedDataContainer(red_flags, reds=self.reds),
                 RedDataContainer(red_nsamples, reds=self.reds))
 
+    def chisq(self, data, data_wgts, gain_flags=None):
+        """Computes chi^2 defined as: chi^2 = sum_ij(|data_ij - model_ij * g_i conj(g_j)|^2 * wgts_ij)
+        and also a chisq_per_antenna which is the same sum but with fixed i.
+
+        Arguments:
+            data: DataContainer mapping baseline-pol tuples like (0,1,'nn') to complex data of shape (Nt, Nf).
+            data_wgts: multiplicative weights with which to combine chisq per visibility. Usually
+                equal to (visibility noise variance)**-1.
+            gain_flags: optional dictionary mapping ant-pol keys like (1,'Jnn') to a boolean flags waterfall
+                with the same shape as the data. Default: None, which means no per-antenna flagging.
+
+        Returns:
+            chisq: numpy array with the same shape each visibility of chi^2 calculated as above. If the
+                inferred pol_mode from reds (see redcal.parse_pol_mode) is '1pol' or '2pol', this is a
+                dictionary mapping antenna polarization (e.g. 'Jnn') to chi^2. Otherwise, there is a single
+                chisq (because polarizations mix) and this is a numpy array.
+            chisq_per_ant: dictionary mapping ant-pol keys like (1,'Jnn') to chisq per antenna, computed as
+                above but keeping i fixed and varying only j.
+        """
+        split_by_antpol = parse_pol_mode(self.reds) in ['1pol', '2pol']
+        chisq, _, chisq_per_ant, _ = utils.chisq(data, self.vis, data_wgts=data_wgts,
+                                                 gains=self.gains, gain_flags=gain_flags,
+                                                 reds=self.reds, split_by_antpol=split_by_antpol)
+        return chisq, chisq_per_ant
+
+    def normalized_chisq(self, data, data_wgts):
+        '''Computes chi^2 and chi^2 per antenna with proper normalization per DoF.
+
+        Arguments:
+            data: DataContainer mapping baseline-pol tuples like (0,1,'nn') to complex data of shape (Nt, Nf).
+            data_wgts: multiplicative weights with which to combine chisq per visibility. Usually
+                equal to (visibility noise variance)**-1.
+
+        Returns:
+            chisq: chi^2 per degree of freedom for the calibration solution. If the inferred pol_mode from
+                reds (see redcal.parse_pol_mode) is '1pol' or '2pol', this is a dictionary mapping antenna
+                polarization (e.g. 'Jnn') to chi^2. Otherwise, there is a single chisq (because polarizations
+                mix) and this is a numpy array.
+            chisq_per_ant: dictionary mapping ant-pol tuples like (1,'Jnn') to the sum of all chisqs for
+                visibilities that an antenna participates in, DoF normalized using predict_chisq_per_ant
+    '''
+        chisq, chisq_per_ant = normalized_chisq(data, data_wgts, self.reds, self.vis, self.gains)
+        return chisq, chisq_per_ant
+
 
 def _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np.pi / 8)):
     '''This function looks at all redundant baselines and sees whether they mostly agree with the median

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -306,7 +306,6 @@ def reds_to_antpos(reds, tol=1e-10):
 def get_gains_and_vis_from_sol(sol):
     """Splits a sol dictionary into len(key)==2 entries, taken to be gains,
     and len(key)==3 entries, taken to be model visibrilities."""
-
     g = {key: val for key, val in sol.items() if len(key) == 2}
     v = {key: val for key, val in sol.items() if len(key) == 3}
     return g, v
@@ -326,7 +325,7 @@ def make_sol_finite(sol):
 class RedSol():
     '''Object for containing solutions to redundant calibraton, namely gains and
     unique-baseline visibilities, along with a variety of convenience methods.'''
-    def __init__(self, reds, gains=None, vis=None, sol_dict=None):
+    def __init__(self, reds, gains={}, vis={}, sol_dict={}):
         '''Initializes RedSol object.
 
         Arguments:
@@ -337,11 +336,11 @@ class RedSol():
                 to complex numpy arrays of visibilities of size (Ntimes, Nfreqs).
                 May only contain at most one visibility per unique baseline group.
             sol_dict: optional dictionary. Maps both gain keys and visibilitity keys
-                to numpy arrays. Cannot be provided if gains or vis is provided.
+                to numpy arrays. Must be empty if gains or vis is not.
         '''
-        if sol_dict is not None:
-            if gains is not None or vis is not None:
-                raise ValueError('If sol_dict is specified, neither gains nor vis can be.')
+        if len(sol_dict) > 0:
+            if (len(gains) > 0) or (len(vis) > 0):
+                raise ValueError('If sol_dict is not empty, both gains and vis must be.')
             self.gains, self.vis = get_gains_and_vis_from_sol(sol_dict)
         else:
             self.gains = gains

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1765,12 +1765,14 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
                                            check_every=check_every, check_after=check_after, gain=gain)
 
     # update omnical flags and then remove degeneracies
-    rv['gf_omnical'] = {ant: ~np.isfinite(g) for ant, g in omni_sol.gains.items()}
-    rv['vf_omnical'] = DataContainer({bl: ~np.isfinite(v) for bl, v in omni_sol.vis.items()})
-    omni_sol.remove_degen(degen_sol=rv['g_firstcal'], inplace=True)
-    omni_sol.make_sol_finite()
-    rv['v_omnical'] = omni_sol.vis
-    rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in omni_sol.gains.items()}
+    rv['g_omnical'], rv['v_omnical'] = get_gains_and_vis_from_sol(omni_sol)
+    rv['gf_omnical'] = {ant: ~np.isfinite(g) for ant, g in rv['g_omnical'].items()}
+    rv['vf_omnical'] = DataContainer({bl: ~np.isfinite(v) for bl, v in rv['v_omnical'].items()})
+    rd_sol = rc.remove_degen(omni_sol, degen_sol=rv['g_firstcal'])
+    make_sol_finite(rd_sol)
+    rv['g_omnical'], rv['v_omnical'] = get_gains_and_vis_from_sol(rd_sol)
+    rv['v_omnical'] = DataContainer(rv['v_omnical'])
+    rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in rv['g_omnical'].items()}
 
     # compute chisqs
     rv['chisq'], rv['chisq_per_ant'] = normalized_chisq(data, data_wgts, filtered_reds, rv['v_omnical'], rv['g_omnical'])

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -315,7 +315,7 @@ def make_sol_finite(sol):
     '''Replaces nans and infs in solutions, which are usually the result of visibilities that are
     identically equal to 0. Modifies sol (which is a dictionary with gains and visibilities) in place,
     replacing visibilities with 0.0s and gains with 1.0s'''
-    for k in sol.keys():
+    for k in sol:
         if len(k) == 3:  # visibilities
             sol[k][~np.isfinite(sol[k])] = np.zeros_like(sol[k][~np.isfinite(sol[k])])
         elif len(k) == 2:  # gains

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1133,11 +1133,12 @@ class RedundantCalibrator:
         calibrate_in_place(fc_data, sol0)
         ls = self._solver(linsolve.LogProductSolver, fc_data, wgts=wgts, detrend_phs=True, sparse=sparse)
         sol = ls.solve(mode=mode)
-        sol = {self.unpack_sol_key(k): sol[k] for k in sol.keys()}
-        for ubl_key in [k for k in sol.keys() if len(k) == 3]:
-            sol[ubl_key] = sol[ubl_key] * self.phs_avg[ubl_key].conj()
-        sol_with_fc = {key: (sol[key] * sol0[key] if (key in sol0 and len(key) == 2) else sol[key]) for key in sol.keys()}
-        return {}, sol_with_fc
+        sol = RedSol(self.reds, sol_dict={self.unpack_sol_key(k): sol[k] for k in sol.keys()})
+        for ubl_key in sol.vis:
+            sol[ubl_key] *= self.phs_avg[ubl_key].conj()
+        for ant in sol.gains:
+            sol[ant] *= sol0.get(ant, 1.0)
+        return {}, sol
 
     def lincal(self, data, sol0, wgts={}, sparse=False, mode='default', conv_crit=1e-10, maxiter=50, verbose=False):
         """Taylor expands to linearize redcal equations and iteratively minimizes chi^2.
@@ -1160,11 +1161,10 @@ class RedundantCalibrator:
             sol: dictionary of gain and visibility solutions in the {(index,antpol): np.array}
                 and {(ind1,ind2,pol): np.array} formats respectively
         """
-
-        sol0 = {self.pack_sol_key(k): sol0[k] for k in sol0.keys()}
+        sol0 = {self.pack_sol_key(k): sol0[k] for k in sol0}
         ls = self._solver(linsolve.LinProductSolver, data, sol0=sol0, wgts=wgts, sparse=sparse)
         meta, sol = ls.solve_iteratively(conv_crit=conv_crit, maxiter=maxiter, verbose=verbose, mode=mode)
-        sol = {self.unpack_sol_key(k): sol[k] for k in sol.keys()}
+        sol = RedSol(self.reds, sol_dict={self.unpack_sol_key(k): sol[k] for k in sol.keys()})
         return meta, sol
 
     def omnical(self, data, sol0, wgts={}, gain=.3, conv_crit=1e-10, maxiter=50, check_every=4, check_after=1, wgt_func=lambda x: 1.):
@@ -1193,10 +1193,10 @@ class RedundantCalibrator:
                 and {(ind1,ind2,pol): np.array} formats respectively
         """
 
-        sol0 = {self.pack_sol_key(k): sol0[k] for k in sol0.keys()}
+        sol0 = {self.pack_sol_key(k): sol0[k] for k in sol0}
         ls = self._solver(OmnicalSolver, data, sol0=sol0, wgts=wgts, gain=gain)
         meta, sol = ls.solve_iteratively(conv_crit=conv_crit, maxiter=maxiter, check_every=check_every, check_after=check_after, wgt_func=wgt_func)
-        sol = {self.unpack_sol_key(k): sol[k] for k in sol.keys()}
+        sol = RedSol(self.reds, sol_dict={self.unpack_sol_key(k): sol[k] for k in sol.keys()})
         return meta, sol
 
     def remove_degen_gains(self, gains, degen_gains=None, mode='phase'):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1756,7 +1756,7 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
     # perform logcal
     if prior_sol is None:
         _, prior_sol = rc.logcal(data, sol0=rv['g_firstcal'])
-        make_sol_finite(prior_sol)
+        prior_sol.make_sol_finite()
 
     # perform omnical
     dts_by_bl = DataContainer({bl: infer_dt(times_by_bl, bl, default_dt=SEC_PER_DAY**-1) * SEC_PER_DAY for bl in red_bls})
@@ -1765,14 +1765,12 @@ def redundantly_calibrate(data, reds, freqs=None, times_by_bl=None, fc_conv_crit
                                            check_every=check_every, check_after=check_after, gain=gain)
 
     # update omnical flags and then remove degeneracies
-    rv['g_omnical'], rv['v_omnical'] = get_gains_and_vis_from_sol(omni_sol)
-    rv['gf_omnical'] = {ant: ~np.isfinite(g) for ant, g in rv['g_omnical'].items()}
-    rv['vf_omnical'] = DataContainer({bl: ~np.isfinite(v) for bl, v in rv['v_omnical'].items()})
-    rd_sol = rc.remove_degen(omni_sol, degen_sol=rv['g_firstcal'])
-    make_sol_finite(rd_sol)
-    rv['g_omnical'], rv['v_omnical'] = get_gains_and_vis_from_sol(rd_sol)
-    rv['v_omnical'] = DataContainer(rv['v_omnical'])
-    rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in rv['g_omnical'].items()}
+    rv['gf_omnical'] = {ant: ~np.isfinite(g) for ant, g in omni_sol.gains.items()}
+    rv['vf_omnical'] = DataContainer({bl: ~np.isfinite(v) for bl, v in omni_sol.vis.items()})
+    omni_sol.remove_degen(degen_sol=rv['g_firstcal'], inplace=True)
+    omni_sol.make_sol_finite()
+    rv['v_omnical'] = omni_sol.vis
+    rv['g_omnical'] = {ant: g * ~rv['gf_omnical'][ant] + rv['gf_omnical'][ant] for ant, g in omni_sol.gains.items()}
 
     # compute chisqs
     rv['chisq'], rv['chisq_per_ant'] = normalized_chisq(data, data_wgts, filtered_reds, rv['v_omnical'], rv['g_omnical'])

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -460,6 +460,7 @@ def test_RedDataContainer():
                 assert(rdata.get_ubl_key(bl) in red)
                 assert(rdata.has_key(rdata.get_ubl_key(bl)))
                 assert set(rdata.get_red(bl)) == set(red)
+                assert bl in rdata
             val_here = deepcopy(rdata[red[0]])
             rdata[red[0]] *= 2
             for bl in red:

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -333,6 +333,17 @@ class TestRedSol(object):
         with pytest.raises(ValueError):
             om.RedSol(reds, gains=g, vis=v, sol_dict=sol)
 
+    def test_setitem(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): np.ones((1, 1))}, vis={(0, 1, 'ee'): np.ones((1, 1))})
+        rs[2, 'Jee'] = 2 * np.ones((1, 1))
+        rs[1, 2, 'ee'] = 2 * np.ones((1, 1))
+        assert rs[2, 'Jee'][0, 0] == 2
+        assert rs.gains[2, 'Jee'][0, 0] == 2
+        assert rs[1, 2, 'ee'][0, 0] == 2
+        assert rs.vis[1, 2, 'ee'][0, 0] == 2
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -332,6 +332,10 @@ class TestRedSol(object):
         # test errors
         with pytest.raises(ValueError):
             om.RedSol(reds, gains=g, vis=v, sol_dict=sol)
+        with pytest.raises(KeyError):
+            rs1['stuff']
+        with pytest.raises(KeyError):
+            rs1[1, 2, 'ee', 'Jee']
 
     def test_setitem(self):
         antpos = linear_array(3)
@@ -343,6 +347,10 @@ class TestRedSol(object):
         assert rs.gains[2, 'Jee'][0, 0] == 2
         assert rs[1, 2, 'ee'][0, 0] == 2
         assert rs.vis[1, 2, 'ee'][0, 0] == 2
+        with pytest.raises(KeyError):
+            rs['stuff'] = 2
+        with pytest.raises(KeyError):
+            rs[1, 2, 'ee', 'Jee'] = 2
 
     def test_make_sol_finite(self):
         antpos = linear_array(3)

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -303,17 +303,24 @@ class TestRedSol(object):
                 assert ant in rs.gains
                 np.testing.assert_array_equal(rs[ant], rs.gains[ant])
                 np.testing.assert_array_equal(rs[ant], sol[ant])
+                np.testing.assert_array_equal(rs[ant], rs.get(ant))
             for bl in true_vis:
                 assert bl in rs
                 assert bl in rs.vis
                 np.testing.assert_array_equal(rs[bl], rs.vis[bl])
                 np.testing.assert_array_equal(rs[bl], sol[bl])
+                np.testing.assert_array_equal(rs[bl], rs.get(bl))
             for red in rs.reds:
                 for bl in red:
                     assert bl in rs
                     assert bl in rs.vis
                     np.testing.assert_array_equal(rs[bl], rs.vis[bl])
                     np.testing.assert_array_equal(rs[bl], sol[red[0]])
+                    np.testing.assert_array_equal(rs[bl], rs.get(bl))
+
+            # test default get
+            assert rs.get('fake_key') is None
+            assert rs.get('fake_key', 0) == 0
 
             # test iterator
             done_with_gains = False

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -356,6 +356,23 @@ class TestRedSol(object):
         assert rs[1, 'Jee'][0, 0] == 1
         assert rs[0, 1, 'ee'][0, 0] == 0
 
+    def test_red_average(self):
+        NANTS = 18
+        antpos = linear_array(NANTS)
+        reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
+        info = om.RedundantCalibrator(reds)
+        gains, true_vis, d = sim_red_data(reds, gain_scatter=.05)
+        w = dict([(k, 1.) for k in d.keys()])
+        meta, sol = info.logcal(d)
+        sol = info.remove_degen(sol, degen_sol=dict(list(gains.items()) + list(true_vis.items())))
+        rs = om.RedSol(reds, sol_dict=sol)
+        red_d, red_f, red_ns = rs.red_average(DataContainer(d))
+        for red in reds:
+            for bl in red:
+                np.testing.assert_array_almost_equal(true_vis[red[0]], red_d[bl])
+                np.testing.assert_array_equal(False, red_f[bl])
+                np.testing.assert_array_equal(len(red), red_ns[bl])
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -380,13 +380,27 @@ class TestRedSol(object):
         w = dict([(k, 1.) for k in d.keys()])
         meta, sol = info.logcal(d)
         sol = info.remove_degen(sol, degen_sol=dict(list(gains.items()) + list(true_vis.items())))
-        rs = om.RedSol(reds, sol_dict=sol)
-        red_d, red_f, red_ns = rs.red_average(DataContainer(d))
+        red_d, red_f, red_ns = sol.red_average(DataContainer(d))
         for red in reds:
             for bl in red:
                 np.testing.assert_array_almost_equal(true_vis[red[0]], red_d[bl])
                 np.testing.assert_array_equal(False, red_f[bl])
                 np.testing.assert_array_equal(len(red), red_ns[bl])
+
+    def test_remove_degen(self):
+        NANTS = 18
+        antpos = linear_array(NANTS)
+        reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
+        info = om.RedundantCalibrator(reds)
+        gains, true_vis, d = sim_red_data(reds, gain_scatter=.05)
+        w = dict([(k, 1.) for k in d.keys()])
+        meta, sol = info.logcal(d)
+        sol.remove_degen(degen_sol=dict(list(gains.items()) + list(true_vis.items())), inplace=True)
+        sol2 = sol.remove_degen(degen_sol=dict(list(gains.items()) + list(true_vis.items())), inplace=False)
+        for red in reds:
+            for bl in red:
+                np.testing.assert_array_almost_equal(true_vis[red[0]], sol[bl])
+                np.testing.assert_array_almost_equal(true_vis[red[0]], sol2[bl])
 
     def test_len(self):
         antpos = linear_array(3)

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -388,6 +388,40 @@ class TestRedSol(object):
                 np.testing.assert_array_equal(False, red_f[bl])
                 np.testing.assert_array_equal(len(red), red_ns[bl])
 
+    def test_len(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): np.ones((1, 1))}, vis={(0, 1, 'ee'): np.ones((1, 1))})
+        assert len(rs) == 3
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): np.ones((1, 1))})
+        assert len(rs) == 2
+        rs = om.RedSol(reds, vis={(0, 1, 'ee'): np.ones((1, 1))})
+        assert len(rs) == 1
+
+    def test_keys(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): np.ones((1, 1))}, vis={(0, 1, 'ee'): np.ones((1, 1))})
+        assert list(rs.keys()) == [(0, 'Jee'), (1, 'Jee'), (0, 1, 'ee')]
+
+    def test_values(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): 2 * np.ones((1, 1))}, vis={(0, 1, 'ee'): 3 * np.ones((1, 1))})
+        np.testing.assert_array_equal(list(rs.values())[0], np.ones((1, 1)))
+        np.testing.assert_array_equal(list(rs.values())[1], 2 * np.ones((1, 1)))
+        np.testing.assert_array_equal(list(rs.values())[2], 3 * np.ones((1, 1)))
+
+    def test_items(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): 2 * np.ones((1, 1))}, vis={(0, 1, 'ee'): 3 * np.ones((1, 1))})
+        items = list(rs.items())
+        assert items[0][0] == (0, 'Jee')
+        np.testing.assert_array_equal(items[0][1], np.ones((1, 1)))
+        assert items[2][0] == (0, 1, 'ee')
+        np.testing.assert_array_equal(items[2][1], 3 * np.ones((1, 1)))
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -436,6 +436,27 @@ class TestRedSol(object):
         assert items[2][0] == (0, 1, 'ee')
         np.testing.assert_array_equal(items[2][1], 3 * np.ones((1, 1)))
 
+    def test_chisq(self):
+        NANTS = 18
+        antpos = linear_array(NANTS)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        info = om.RedundantCalibrator(reds)
+        gains, true_vis, d = sim_red_data(reds, gain_scatter=.05)
+        w = dict([(k, 1.) for k in d.keys()])
+        meta, sol = info.logcal(d)
+        data_wgts = {bl: np.ones_like(d[bl], dtype=np.float64) for bl in d}
+
+        ucs, ucspa = sol.chisq(d, data_wgts)
+        ncs, ncspa = sol.normalized_chisq(d, data_wgts)
+        for cs, cspa in zip([ucs, ncs], [ucspa, ncspa]):
+            assert 'Jee' in cs
+            assert d[list(d.keys())[0]].shape == cs['Jee'].shape
+            assert cs['Jee'].dtype == np.float64
+            for ant in gains.keys():
+                assert ant in cspa
+                assert cspa[ant].shape == cs['Jee'].shape
+                assert cspa[ant].dtype == np.float64
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -315,6 +315,24 @@ class TestRedSol(object):
                     np.testing.assert_array_equal(rs[bl], rs.vis[bl])
                     np.testing.assert_array_equal(rs[bl], sol[red[0]])
 
+            # test iterator
+            done_with_gains = False
+            for key in rs:
+                if not done_with_gains:
+                    if len(key) == 3:
+                        done_with_gains = True
+                        assert key in rs.vis
+                    else:
+                        assert len(key) == 2
+                        assert key in rs.gains
+                else:
+                    assert len(key) == 3
+                    assert key in rs.vis
+
+        # test errors
+        with pytest.raises(ValueError):
+            om.RedSol(reds, gains=g, vis=v, sol_dict=sol)
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -344,6 +344,18 @@ class TestRedSol(object):
         assert rs[1, 2, 'ee'][0, 0] == 2
         assert rs.vis[1, 2, 'ee'][0, 0] == 2
 
+    def test_make_sol_finite(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): np.ones((1, 1))}, vis={(0, 1, 'ee'): np.ones((1, 1))})
+        rs[0, 'Jee'] *= np.inf
+        rs[1, 'Jee'] *= np.nan
+        rs[0, 1, 'ee'] *= np.nan
+        rs.make_sol_finite()
+        assert rs[0, 'Jee'][0, 0] == 1
+        assert rs[1, 'Jee'][0, 0] == 1
+        assert rs[0, 1, 'ee'][0, 0] == 0
+
 
 class TestRedundantCalibrator(object):
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -277,6 +277,45 @@ class TestMethods(object):
             om._build_polarity_baseline_groups(data, reds, max_rel_angle=np.pi)
 
 
+class TestRedSol(object):
+
+    def test_init(self):
+        NANTS = 18
+        antpos = linear_array(NANTS)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        info = om.RedundantCalibrator(reds)
+        gains, true_vis, d = sim_red_data(reds, gain_scatter=.05)
+        w = dict([(k, 1.) for k in d.keys()])
+        meta, sol = info.logcal(d)
+
+        # construct from sol_dict
+        rs1 = om.RedSol(reds, sol_dict=sol)
+
+        # construct from gains and vis
+        g, v = om.get_gains_and_vis_from_sol(sol)
+        rs2 = om.RedSol(reds, gains=g, vis=v)
+
+        # test that gains and vis are properly separated, also tests getitem and contains
+        for rs in [rs1, rs2]:
+            assert rs.reds == reds
+            for ant in gains:
+                assert ant in rs
+                assert ant in rs.gains
+                np.testing.assert_array_equal(rs[ant], rs.gains[ant])
+                np.testing.assert_array_equal(rs[ant], sol[ant])
+            for bl in true_vis:
+                assert bl in rs
+                assert bl in rs.vis
+                np.testing.assert_array_equal(rs[bl], rs.vis[bl])
+                np.testing.assert_array_equal(rs[bl], sol[bl])
+            for red in rs.reds:
+                for bl in red:
+                    assert bl in rs
+                    assert bl in rs.vis
+                    np.testing.assert_array_equal(rs[bl], rs.vis[bl])
+                    np.testing.assert_array_equal(rs[bl], sol[red[0]])
+
+
 class TestRedundantCalibrator(object):
 
     def test_init(self):


### PR DESCRIPTION
This PR introduces a new class `hera_cal.redcal.RedSol()` which stores gains and redundant visibility solutions, the latter using the new `RedDataContainer`. This is meant to work as a drop-in replacement for the combined dictionary of gains and visibilities that could later be separated out using the length of keys.

This PR also changes some of the methods on RedundantCalibrator (omnical, lincal, logcal) to return RedSol objects.

This PR will enable future simplifications to `redundantly_calibrate()` and `expand_omni_sol()`, but I'm leaving that for later.