### PR TITLE
Run polarity flip detection algorithm one polarization at a time

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -492,19 +492,26 @@ def find_polarity_flipped_ants(dly_cal_data, reds, edge_cut=0, max_rel_angle=(np
             of this scales exponentially as 2^max_recursion_depth.
 
     Returns:
-        is_flipped: dictionary mapping antenna tuple e.g. (0, 'Jee') to Booleans.
+        polarity_flips: dictionary mapping antenna tuple e.g. (0, 'Jee') to Booleans.
             If no solution is found returns a dictionary mapping antennas to None.
     '''
-
     ants = set([ant for red in reds for bl in red for ant in utils.split_bl(bl)])
-    polarity_groups = _build_polarity_baseline_groups(dly_cal_data, reds, edge_cut=edge_cut, max_rel_angle=np.pi / 8)
+    antpols = set([ant[1] for ant in ants])
+    polarity_flips = {ant: None for ant in ants}
 
-    try:
-        is_flipped, even_vs_odd_IDs = _recursive_try_assumptions(polarity_groups, ants, {}, {}, 1, max_recursion_depth=5)
-    except AssertionError:  # No solution is found.
-        is_flipped = {ant: None for ant in ants}
+    # find polarity flips, one antpol at a time
+    for ap in antpols:
+        reds_here = filter_reds(reds, pols=[join_pol(ap, ap)])
+        ants_here = [ant for ant in ants if ant[1] == ap]
+        polarity_groups = _build_polarity_baseline_groups(dly_cal_data, reds_here, edge_cut=edge_cut, max_rel_angle=np.pi / 8)
+        try:
+            is_flipped, even_vs_odd_IDs = _recursive_try_assumptions(polarity_groups, ants_here, {}, {}, 1, max_recursion_depth=max_recursion_depth)
+            for ant in ants_here:
+                polarity_flips[ant] = is_flipped[ant]
+        except AssertionError:
+            pass  # No solution is found, so leave fips as None
 
-    return is_flipped
+    return polarity_flips
 
 
 def _check_polLists_minV(polLists):

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -249,7 +249,7 @@ class TestMethods(object):
     def test_find_polarity_flipped_ants(self):
         # test normal operation
         antpos = hex_array(3, split_core=False, outriggers=0)
-        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        reds = om.get_reds(antpos, pols=['ee', 'nn'], pol_mode='2pol')
         rc = om.RedundantCalibrator(reds)
         freqs = np.linspace(.1, .2, 100)
         ants = [(ant, 'Jee') for ant in antpos]
@@ -268,7 +268,8 @@ class TestMethods(object):
         data[(0, 1, 'ee')] *= -1
         meta, g_fc = rc.firstcal(data, freqs)
         for ant in meta['polarity_flips']:
-            assert np.all([m is None for m in meta['polarity_flips'][ant]])
+            if ant[1] == 'Jee':
+                assert np.all([m is None for m in meta['polarity_flips'][ant]])
 
         # test errors
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR fixes an issue in polarity flip detection when running firstcal with multiple polarizations simultaneously. It now runs each polarization independently and combines the results.