### PR TITLE
Add min_dim_size feature to redcal.filter_reds

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -138,7 +138,8 @@ def get_reds(antpos, pols=['nn'], pol_mode='1pol', bl_error_tol=1.0, include_aut
 
 
 def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None, ex_ubls=None,
-                pols=None, ex_pols=None, antpos=None, min_bl_cut=None, max_bl_cut=None, max_dims=None):
+                pols=None, ex_pols=None, antpos=None, min_bl_cut=None, max_bl_cut=None,
+                max_dims=None, min_dim_size=1):
     '''
     Filter redundancies to include/exclude the specified bls, antennas, unique bl groups and polarizations.
     Also allows filtering reds by removing antennas so that the number of generalized tip/tilt degeneracies
@@ -171,6 +172,9 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
             This is equivalent to the number of generalized tip/tilt phase degeneracies of redcal that are fixed
             with remove_degen() and must be later abscaled. 2 is a classically "redundantly calibratable" planar
             array. More than 2 usually arises with subarrays of redundant baselines. None means no filtering.
+        min_dim_size: minimum number of atennnas allowed with non-zero positions in a given dimension. This
+            allows filtering out of antennas where only a few are responsible for adding a dimension. Ignored
+            if max_dims is None. Default 1 means no further filtering based on the number of anntenas in that dim.
 
     Return:
         reds: list of lists of redundant baselines in the same form as input reds.
@@ -244,8 +248,15 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
             # using the redundancies. The number of dimensions is equivalent to the number of generalized
             # tip/tilt degeneracies of redundant calibration.
             idealized_antpos = reds_to_antpos(reds, tol=IDEALIZED_BL_TOL)
-            if len(list(idealized_antpos.values())[0]) <= max_dims:
+            ia_array = np.array(list(idealized_antpos.values()))
+
+            # if we've removed all antennas, break
+            if len(ia_array) == 0:
                 break
+            # if we're down to 1 dimension, the mode finding below won't work. Just check Nants >= min_dim_size.
+            if len(ia_array[0]) <= 1:
+                if len(ia_array) >= min_dim_size:
+                    break
 
             # Find dimension with the most common mode idealized coordinate value. This is supposed to look
             # for outlier antennas off the redundant grid small sub-arrays that cannot be redundantly
@@ -262,6 +273,13 @@ def filter_reds(reds, bls=None, ex_bls=None, ants=None, ex_ants=None, ubls=None,
             # Cut all antennas not part of that mode to reduce the dimensionality of idealized_antpos
             new_ex_ants = [ant for ant in idealized_antpos if
                            np.abs(idealized_antpos[ant][mode_dim] - mode_value) > IDEALIZED_BL_TOL]
+
+            # If we're down to the reqested number of dimensions and if the next filtering would
+            # eliminate more antennas than min_dim_size, then break instead of filtering.
+            if len(ia_array[0]) <= max_dims:
+                if (len(new_ex_ants) >= min_dim_size):
+                    break
+
             reds = filter_reds(reds, ex_ants=new_ex_ants)
 
     return reds

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -173,6 +173,21 @@ class TestMethods(object):
         ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
         assert ant_inds == (set(range(0, 9)) | set(range(33, 37)))
 
+        # Remove dimenions of size less than 5, which should kill everything except 4, 5, 6, 7, 8
+        new_reds = om.filter_reds(reds, max_dims=3, min_dim_size=5)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == set(range(4, 9))
+
+        # remove dimenions of size less than 2, which should eliminate 37
+        new_reds = om.filter_reds(reds, max_dims=4, min_dim_size=2)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == (set(range(0, 9)) | set(range(33, 37)))
+
+        # remove dimensions of size less than 10, which should remove everything
+        new_reds = om.filter_reds(reds, max_dims=4, min_dim_size=10)
+        ant_inds = set([ant[0] for red in new_reds for bl in red for ant in split_bl(bl)])
+        assert ant_inds == set([])
+
     def test_add_pol_reds(self):
         reds = [[(1, 2)]]
         polReds = om.add_pol_reds(reds, pols=['xx'], pol_mode='1pol')


### PR DESCRIPTION
In working on redcal, I found a case where having just a few antennas in a new degeneracy dimension (the three in the northeast corner here) make redcal go slower and have a weird bistability in the convergence. 

![image](https://user-images.githubusercontent.com/5281139/189551221-815da590-9f30-48a6-951e-f96535554e12.png)

And here's that apparent bistability in the phase. 

![image](https://user-images.githubusercontent.com/5281139/189551493-5a2436e3-3f56-42c9-843e-0192f3ce7502.png)


Eliminating those 3 antennas (167, 189, 191) helped a lot. Here's the phase of an antenna after: 
![image](https://user-images.githubusercontent.com/5281139/189551327-bd1449c1-a9bd-4e27-944d-1a7546f84826.png)

In theory, the degeneracies are fixed by firstcal and so shouldn't be allowed to have this kind of phase structure. I'm not 100% sure what's going on. One clue is that the convergence criterion is getting stuck at much higher values than elsewhere in the band at those frequencies:
![image](https://user-images.githubusercontent.com/5281139/189551609-505ac24c-d0f6-4774-a740-1aa3f00b4b46.png)

Regardless, it seems like it's useful to enable to user to filter out dimensions that are small with `filter_reds`. This PR does that.