### PR TITLE
Add hermitian=True to pinv to speed up calculation of chi^2 per bl prediction by a factor of 2

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1451,8 +1451,8 @@ def predict_chisq_per_bl(reds):
 
     A = solver.ls_amp.get_A()[:, :, 0]
     B = solver.ls_phs.get_A()[:, :, 0]
-    A_data_resolution = A.dot(np.linalg.pinv(A.T.dot(A)).dot(A.T))
-    B_data_resolution = B.dot(np.linalg.pinv(B.T.dot(B)).dot(B.T))
+    A_data_resolution = A.dot(np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T))
+    B_data_resolution = B.dot(np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T))
 
     predicted_chisq_per_bl = 1.0 - np.diag(A_data_resolution + B_data_resolution) / 2.0
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}


### PR DESCRIPTION
Credit to @AaronParsons for noting this speed-up.