### PR TITLE
Add utility functions for `nucal`

### DIFF
--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -131,7 +131,7 @@ def get_u_bounds(radial_reds, antpos, freqs):
             
 
 def get_unique_orientations(
-    antpos, reds=None, pols=["nn"], min_ubl_per_orient=1, blvec_error_tol=1e-3, bl_error_tol=1.0,
+    antpos, reds, min_ubl_per_orient=1, blvec_error_tol=1e-3, bl_error_tol=1.0,
 ):
     """
     Sort baselines into groups with the same radial heading. These groups of baselines are potentially
@@ -143,8 +143,6 @@ def get_unique_orientations(
         Antenna positions in the form {ant_index: np.array([x,y,z])}.
     reds : list of lists
         List of lists of spatially redundant baselines in the array. Can be found using redcal.get_reds
-    pols : list, default=['nn']
-        A list of polarizations e.g. ['nn', 'ne', 'en', 'ee']
     min_ubl_per_orient : int, default=1
         Minimum number of baselines per unique orientation
     blvec_error_tol : float, default=1e-3
@@ -159,8 +157,8 @@ def get_unique_orientations(
     uors : list of lists of tuples
         List of list of tuples that are considered to be radially redundant
     """
-    if reds is None:
-        reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
+    # Get polarizations from reds
+    pols = list(set([rdgrp[0][-1] for rdgrp in reds]))
 
     _uors = {}
     for pol in pols:

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -434,8 +434,6 @@ class FrequencyRedundancy:
     def filter_radial_groups(
         self,
         min_nbls=1,
-        pols=None,
-        ex_pols=None,
         min_bl_cut=None,
         max_bl_cut=None,
     ):

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -467,4 +467,4 @@ class FrequencyRedundancy:
 
     def sort(self, key=None, reverse=True):
         """Sorts list by length of the radial groups"""
-        self._radial_groups.sort(key=len, reverse=reverse)
+        self._radial_groups.sort(key=(len if key is None else key), reverse=reverse)

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -4,7 +4,6 @@ from . import redcal
 import numpy as np
 from copy import deepcopy
 import astropy.constants as const
-from collections import defaultdict
 from scipy.cluster.hierarchy import fclusterdata
 
 SPEED_OF_LIGHT = const.c.si.value
@@ -359,7 +358,7 @@ class FrequencyRedundancy:
         for group in self._radial_groups:
             filtered_group = []
             for bl in group:
-                if (max_bl_cut is None or self.baseline_lengths[bl] < max_bl_cut) and (min_bl_cut is None or self._baseline_lengths[bl] > min_bl_cut):
+                if (max_bl_cut is None or self.baseline_lengths[bl] < max_bl_cut) and (min_bl_cut is None or self.baseline_lengths[bl] > min_bl_cut):
                     filtered_group.append(bl)
                 
             # Identify groups with fewer than min_nbls baselines

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -43,10 +43,7 @@ def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
     norm_vec1 = blvec1 / np.linalg.norm(blvec1)
     norm_vec2 = blvec2 / np.linalg.norm(blvec2)
 
-    if np.isclose(np.linalg.norm(norm_vec1 - norm_vec2), 0, rtol=blvec_error_tol):
-        return True
-    else:
-        return False
+    return np.isclose(np.linalg.norm(norm_vec1 - norm_vec2), 0, rtol=blvec_error_tol)
 
 def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-3):
     """

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -330,7 +330,7 @@ class FrequencyRedundancy:
         """Get all radially redundant groups with a given polarization"""
         return [group for group in self if group[0][-1] == pol]
 
-    def filter_radial_groups(self, min_nbls=1, min_bl_cut=None, max_bl_cut=None, min_u_cut=None, max_u_cut=None):
+    def filter_radial_groups(self, min_nbls=1, min_bl_cut=None, max_bl_cut=None):
         """
         Filter each radially redundant group to include/exclude the baselines based on baseline length.
         Radially redundant groups can also be completely filtered based on the number of baselines in 

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -32,8 +32,8 @@ def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
         redundant
     """
     # Split baselines in component antennas
-    ant1, ant2, pol1 = bl1
-    ant3, ant4, pol2 = bl2
+    ant1, ant2, _ = bl1
+    ant3, ant4, _ = bl2
 
     # Get baseline vectors
     blvec1 = antpos[ant1] - antpos[ant2]
@@ -43,7 +43,7 @@ def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
     norm_vec1 = blvec1 / np.linalg.norm(blvec1)
     norm_vec2 = blvec2 / np.linalg.norm(blvec2)
 
-    if np.isclose(np.linalg.norm(norm_vec1 - norm_vec2), blvec_error_tol):
+    if np.isclose(np.linalg.norm(norm_vec1 - norm_vec2), 0, rtol=blvec_error_tol):
         return True
     else:
         return False
@@ -98,6 +98,7 @@ def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-3):
     if not (cond1 or cond2):
         return False
 
+    # Last step - return whether or not baselines are in the same orientation
     return is_same_orientation(bl1, bl2, antpos, blvec_error_tol=blvec_error_tol)
 
 def get_u_bounds(radial_reds, antpos, freqs):

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -348,23 +348,13 @@ class FrequencyRedundancy:
             Cut baselines in the radially redundant group with lengths less than min_bl_cut
         max_bl_cut:
             Cut baselines in the radially redundant group with lengths less than min_bl_cut
-        min_u_cut:
-            Cut baselines in the radially redundant group with all u-modes less than min_u_cut.
-            Note baselines with some modes less than min_u_cut will not be cut
-        max_u_cut:
-            Cut baselines in the radially redundant group with all u-modes greater than max_u_cut
-            Note baselines with some modes greater than min_u_cut will not be cut
         """
         # Filter radially redundant group
         radial_reds = []
         for group in self._radial_groups:
             filtered_group = []
             for bl in group:
-                cond1 = (max_bl_cut is None or self.baseline_lengths[bl] < max_bl_cut)
-                cond2 = (min_bl_cut is None or self.baseline_lengths[bl] > min_bl_cut)
-                cond3 = (max_u_cut is None or self.baseline_lengths[bl] / SPEED_OF_LIGHT * self.freqs.min() < max_u_cut)
-                cond4 = (min_bl_cut is None or self.baseline_lengths[bl] / SPEED_OF_LIGHT * self.freqs.max() > min_u_cut)
-                if np.all([cond1, cond2, cond3, cond4]):
+                if (max_bl_cut is None or self.baseline_lengths[bl] < max_bl_cut) and (min_bl_cut is None or self.baseline_lengths[bl] > min_bl_cut):
                     filtered_group.append(bl)
                 
             # Identify groups with fewer than min_nbls baselines

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -9,121 +9,6 @@ from scipy.cluster.hierarchy import fclusterdata
 
 SPEED_OF_LIGHT = const.c.si.value
 
-class RadialRedundantGroup:
-    """
-    """
-    def __init__(self, baselines, antpos, blvec=None, pol=None):
-        """
-        """
-        _baselines = deepcopy(baselines)
-
-        # Attach polarization and normalized vector to radial redundant group
-        if pol is None:
-            pols = list(set([bl[2] for bl in baselines]))
-            if len(pols) > 1:
-                raise ValueError(
-                    f"Multiple polarizations are in your radially redundant group: {pols}"
-                )
-            else:
-                self.pol = pols[0]
-        else:
-            self.pol = pol
-            
-        if blvec is None:
-            ant1, ant2, pol = baselines[0]
-            self.blvec = (antpos[ant2] - antpos[ant1]) / np.linalg.norm(antpos[ant2] - antpos[ant1])
-        else:
-            self.blvec = blvec
-        
-        # Store baseline lengths
-        baseline_lengths = []
-        for baseline in baselines:
-            ant1, ant2, pol = baseline
-            baseline_lengths.append(np.linalg.norm(antpos[ant2] - antpos[ant1]))
-
-        # Sort baselines list by baseline length
-        self._baselines = [_baselines[idx] for idx in np.argsort(baseline_lengths)]
-        self.baseline_lengths = [
-            baseline_lengths[idx] for idx in np.argsort(baseline_lengths)
-        ]
-
-    def get_u_bounds(self, freqs):
-        """
-        Calculates the magnitude of the minimum and maximum u-modes values of the radial redundant group 
-        given an array of frequency values
-
-        Parameters:
-        ----------
-            freqs: np.ndarray
-                Array of frequencies found in the data in units of Hz
-
-        Returns:
-            ubounds: tuple
-                Tuple of the magnitude minimum and maximum u-modes sampled by this baseline group
-        """
-        umin = freqs.min() / 2.998e8 * np.min(self.baseline_lengths)
-        umax = freqs.max() / 2.998e8 * np.max(self.baseline_lengths)
-        return (umin, umax)
-
-    def filter_group(
-        self,
-        bls=None,
-        ex_bls=None,
-        ants=None,
-        ex_ants=None,
-        ubls=None,
-        ex_ubls=None,
-        pols=None,
-        ex_pols=None,
-        antpos=None,
-        min_bl_cut=None,
-        max_bl_cut=None,
-    ):
-        """
-        """
-        _baselines = redcal.filter_reds(
-            [self._baselines],
-            bls=bls,
-            ex_bls=ex_bls,
-            ants=ants,
-            ex_ants=ex_ants,
-            ubls=ubls,
-            ex_ubls=ex_ubls,
-            pols=pols,
-            ex_pols=ex_pols,
-        )
-        if len(_baselines) == 0:
-            self._baselines = []
-            self.baseline_lengths = []
-        else:
-            new_bls = []
-            new_bls_lengths = []
-            for bls in _baselines[0]:
-                index = self._baselines.index(bls)
-                if min_bl_cut is not None and self.baseline_lengths[index] < min_bl_cut:
-                    continue
-                if max_bl_cut is not None and self.baseline_lengths[index] > max_bl_cut:
-                    continue
-                new_bls.append(bls)
-                new_bls_lengths.append(self.baseline_lengths[index])
-
-            self._baselines = new_bls
-            self.baseline_lengths = new_bls_lengths
-
-    def __iter__(self):
-        """Iterate through baselines in the radially redundant group
-        """
-        return iter(self._baselines)
-
-    def __len__(self):
-        """Return the length of the baselines list
-        """
-        return len(self._baselines)
-
-    def __getitem__(self, index):
-        """Get the baseline at the chosen index
-        """
-        return self._baselines[index]
 
 def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-9):
     """
@@ -133,15 +18,16 @@ def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-9):
     Parameters:
     ----------
     bl1 : tuple
-        pass
+        Tuple of antenna indices and polarizations of the first baseline
     bl2 : tuple
-        pass
+        Tuple of antenna indices and polarizations of the second baseline
     freqs : np.ndarray
-        pass
+        Array of frequencies found in the data in units of Hz
     antpos : dict
-        pass
+        Antenna positions in the form {ant_index: np.array([x,y,z])}.
     blvec_error_tol : float, default=1e-9
-        pass
+        Largest allowable euclidean distance a unit baseline vector can be away from an existing
+        cluster to be considered a unique orientation. See "fclusterdata" for more details.
 
     Returns:
         Boolean value determining whether or not the baselines are frequency
@@ -180,3 +66,329 @@ def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-9):
     cond4 = clusters[0] == clusters[1]
 
     return (cond1 or cond2) and cond3 and cond4
+
+
+def get_unique_orientations(
+    antpos,
+    reds=None,
+    pols=["nn"],
+    min_ubl_per_orient=1,
+    blvec_error_tol=1e-9,
+    bl_error_tol=1.0,
+):
+    """
+    Sort baselines into groups with the same radial heading. These groups of baselines are potentially
+    frequency redundant in a similar way to redcal.get_reds does. Returns a list of RadialRedundantGroup objects
+
+    Parameters:
+    ----------
+    antpos : dict
+        Antenna positions in the form {ant_index: np.array([x,y,z])}.
+    reds : list of lists
+        List of lists of spatially redundant baselines in the array. Can be found using redcal.get_reds
+    pols : list, default=['nn']
+        A list of polarizations e.g. ['nn', 'ne', 'en', 'ee']
+    min_ubl_per_orient : int, default=1
+        Minimum number of baselines per unique orientation
+    blvec_error_tol : float, default=1e-9
+        Largest allowable euclidean distance a unit baseline vector can be away from an existing
+        cluster to be considered a unique orientation. See "fclusterdata" for more details.
+    bl_error_tol: float, default=1.0
+        The largest allowable difference between baselines in a redundant group
+        (in the same units as antpos). Normally, this is up to 4x the largest antenna position error.
+
+    """
+    if reds is None:
+        reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
+    else:
+        reds = deepcopy(reds)
+
+    _uors = {}
+    for pol in pols:
+        ubl_pairs = [red[0] for red in reds if red[0][-1] == pol]
+
+        # Compute normalized baseline vectors
+        normalized_vecs = []
+        for bls in ubl_pairs:
+            ant1, ant2, pol = bls
+            normalized_vecs.append(
+                (antpos[ant2] - antpos[ant1])
+                / np.linalg.norm(antpos[ant2] - antpos[ant1])
+            )
+
+        # Cluster orientations
+        clusters = fclusterdata(normalized_vecs, blvec_error_tol, criterion="distance")
+        uors = [[] for i in range(np.max(clusters))]
+
+        for cluster, bl in zip(clusters, ubl_pairs):
+            uors[cluster - 1].append(bl)
+
+        uors = sorted(uors, key=len, reverse=True)
+
+        # Find clusters with headings anti-parallel to others
+        for group in uors:
+            ant1, ant2, pol = group[0]
+            vec = (antpos[ant2] - antpos[ant1]) / np.linalg.norm(
+                antpos[ant2] - antpos[ant1]
+            )
+            vec = np.array(vec / blvec_error_tol, dtype=int)
+            if tuple(-vec) + (pol,) in _uors:
+                _uors[tuple(-vec) + (pol,)] += [utils.reverse_bl(bls) for bls in group]
+            else:
+                _uors[tuple(vec) + (pol,)] = group
+
+    # Convert lists to RadialRedundantGroup objects
+    uors = [
+        RadialRedundantGroup(_uors[key], antpos)
+        for key in _uors
+        if len(_uors[key]) >= min_ubl_per_orient
+    ]
+    uors = sorted(uors, key=len, reverse=True)
+    return uors
+
+
+class RadialRedundantGroup:
+    """ """
+
+    def __init__(self, baselines, antpos, blvec=None, pol=None):
+        """ """
+        _baselines = deepcopy(baselines)
+
+        # Attach polarization and normalized vector to radial redundant group
+        if pol is None:
+            pols = list(set([bl[2] for bl in baselines]))
+            if len(pols) > 1:
+                raise ValueError(
+                    f"Multiple polarizations are in your radially redundant group: {pols}"
+                )
+            else:
+                self.pol = pols[0]
+        else:
+            self.pol = pol
+
+        if blvec is None:
+            ant1, ant2, pol = baselines[0]
+            self.blvec = (antpos[ant2] - antpos[ant1]) / np.linalg.norm(
+                antpos[ant2] - antpos[ant1]
+            )
+        else:
+            self.blvec = blvec
+
+        # Store baseline lengths
+        baseline_lengths = []
+        for baseline in baselines:
+            ant1, ant2, pol = baseline
+            baseline_lengths.append(np.linalg.norm(antpos[ant2] - antpos[ant1]))
+
+        # Sort baselines list by baseline length
+        self._baselines = [_baselines[idx] for idx in np.argsort(baseline_lengths)]
+        self.baseline_lengths = [
+            baseline_lengths[idx] for idx in np.argsort(baseline_lengths)
+        ]
+
+    def get_u_bounds(self, freqs):
+        """
+        Calculates the magnitude of the minimum and maximum u-modes values of the radial redundant group
+        given an array of frequency values
+
+        Parameters:
+        ----------
+            freqs: np.ndarray
+                Array of frequencies found in the data in units of Hz
+
+        Returns:
+            ubounds: tuple
+                Tuple of the magnitude minimum and maximum u-modes sampled by this baseline group
+        """
+        umin = freqs.min() / 2.998e8 * np.min(self.baseline_lengths)
+        umax = freqs.max() / 2.998e8 * np.max(self.baseline_lengths)
+        return (umin, umax)
+
+    def filter_group(
+        self,
+        bls=None,
+        ex_bls=None,
+        ants=None,
+        ex_ants=None,
+        ubls=None,
+        ex_ubls=None,
+        pols=None,
+        ex_pols=None,
+        antpos=None,
+        min_bl_cut=None,
+        max_bl_cut=None,
+    ):
+        """ """
+        _baselines = redcal.filter_reds(
+            [self._baselines],
+            bls=bls,
+            ex_bls=ex_bls,
+            ants=ants,
+            ex_ants=ex_ants,
+            ubls=ubls,
+            ex_ubls=ex_ubls,
+            pols=pols,
+            ex_pols=ex_pols,
+        )
+        if len(_baselines) == 0:
+            self._baselines = []
+            self.baseline_lengths = []
+        else:
+            new_bls = []
+            new_bls_lengths = []
+            for bls in _baselines[0]:
+                index = self._baselines.index(bls)
+                if min_bl_cut is not None and self.baseline_lengths[index] < min_bl_cut:
+                    continue
+                if max_bl_cut is not None and self.baseline_lengths[index] > max_bl_cut:
+                    continue
+                new_bls.append(bls)
+                new_bls_lengths.append(self.baseline_lengths[index])
+
+            self._baselines = new_bls
+            self.baseline_lengths = new_bls_lengths
+
+    def __iter__(self):
+        """Iterate through baselines in the radially redundant group"""
+        return iter(self._baselines)
+
+    def __len__(self):
+        """Return the length of the baselines list"""
+        return len(self._baselines)
+
+    def __getitem__(self, index):
+        """Get the baseline at the chosen index"""
+        return self._baselines[index]
+
+
+class FrequencyRedundancy:
+    """ """
+
+    def __init__(
+        self, antpos, reds=None, blvec_error_tol=1e-9, pols=["nn"], bl_error_tol=1.0
+    ):
+        """
+        Parameters:
+        ----------
+        antpos : dict
+            Antenna positions in the form {ant_index: np.array([x,y,z])}.
+        reds : list of list
+            List of lists of baseline keys. Can be determined using redcal.get_reds
+        pols : list of strs
+            List of polarization strings to be used in the frequency redundant group
+        """
+        self.antpos = antpos
+
+        if reds is None:
+            reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
+
+        self._mapped_reds = {red[0]: red for red in reds}
+
+        self._radial_groups = get_unique_orientations(
+            antpos, reds=reds, pols=pols, blvec_error_tol=blvec_error_tol
+        )
+
+    def get_radial_group(self, key):
+        """
+        Get baselines with the same heading as a given baseline
+
+        Parameters:
+            key: tuple
+                Basleine key of type (ant1, ant2, pol)
+        """
+        # Identify headings
+        for group_key in self._mapped_reds:
+            if key == group_key or key in self._mapped_reds[group_key]:
+                key = group_key
+                break
+
+        for group in self._radial_groups:
+            if key in group:
+                return group
+
+    def get_redundant_group(self, key):
+        """
+        Get a list of baseline that are spatially redundant with the input baseline
+
+        Parameters:
+            key: tuple
+                Baseline key with of type (ant1, ant2, pol)
+        """
+        for group_key in self._mapped_reds:
+            if key == group_key or key in self._mapped_reds[group_key]:
+                key = group_key
+                break
+
+        if utils.reverse_bl(key) in self._mapped_reds:
+            return [
+                utils.reverse_bl(bls)
+                for bls in self._mapped_reds.get(utils.reverse_bl(key))
+            ]
+        elif key in self._mapped_reds:
+            return self._mapped_reds.get(key)
+        else:
+            raise KeyError(
+                f"Baseline {key} is not in the group of spatial redundancies"
+            )
+
+    def get_pol(self, pol):
+        """Get all radially redundant groups with a given polarization"""
+        for group in self:
+            if group.pol == pol:
+                yield group
+
+    def filter_radial_groups(
+        self,
+        min_nbls=4,
+        bls=None,
+        ex_bls=None,
+        ants=None,
+        ex_ants=None,
+        ubls=None,
+        ex_ubls=None,
+        pols=None,
+        ex_pols=None,
+        antpos=None,
+        min_bl_cut=None,
+        max_bl_cut=None,
+    ):
+        """
+        Find all radial groups with
+
+        Parameters:
+        ----------
+            min_nbls: pass
+                pass
+            ex_bls: pass
+                pass
+            ex_ants: pass
+                pass
+        """
+        _bad_groups = []
+        for gi, group in enumerate(self._radial_groups):
+            # Filter radially redundant group
+            group.filter_group(
+                bls=bls,
+                ex_bls=ex_bls,
+                ants=ants,
+                ex_ants=ex_ants,
+                ubls=ubls,
+                ex_ubls=ex_ubls,
+                pols=pols,
+                ex_pols=ex_pols,
+                min_bl_cut=min_bl_cut,
+                max_bl_cut=max_bl_cut,
+            )
+            # Identify groups with fewer than min_nbls baselines
+            if len(group) < min_nbls:
+                _bad_groups.append(gi)
+            else:
+                pass
+
+        # Remove antennas with fewer than min_nbls
+        for _bad_group in sorted(_bad_groups, reverse=True):
+            self._radial_groups.pop(_bad_group)
+
+    def __iter__(self):
+        """Iterates through the list of redundant groups"""
+        return iter(self._radial_groups)

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -131,12 +131,7 @@ def get_u_bounds(radial_reds, antpos, freqs):
             
 
 def get_unique_orientations(
-    antpos,
-    reds=None,
-    pols=["nn"],
-    min_ubl_per_orient=1,
-    blvec_error_tol=1e-3,
-    bl_error_tol=1.0,
+    antpos, reds=None, pols=["nn"], min_ubl_per_orient=1, blvec_error_tol=1e-3, bl_error_tol=1.0,
 ):
     """
     Sort baselines into groups with the same radial heading. These groups of baselines are potentially
@@ -166,8 +161,6 @@ def get_unique_orientations(
     """
     if reds is None:
         reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
-    else:
-        reds = deepcopy(reds)
 
     _uors = {}
     for pol in pols:

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -371,6 +371,7 @@ class FrequencyRedundancy:
         ----------
         key: tuple
             Baseline key with of type (ant1, ant2, pol)
+
         Returns:
         -------
         group: list of tuples

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -8,7 +8,7 @@ from scipy.cluster.hierarchy import fclusterdata
 
 SPEED_OF_LIGHT = const.c.si.value
 
-def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
+def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-4):
     """
     Determine whether or not two baselines have the same orientation
 
@@ -22,7 +22,7 @@ def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
         Array of frequencies found in the data in units of Hz
     antpos : dict
         Antenna positions in the form {ant_index: np.array([x,y,z])}.
-    blvec_error_tol : float, default=1e-3
+    blvec_error_tol : float, default=1e-4
         Largest allowable euclidean distance the first unit baseline vector can be away from
         the second
 
@@ -44,7 +44,7 @@ def is_same_orientation(bl1, bl2, antpos, blvec_error_tol=1e-3):
 
     return np.isclose(np.linalg.norm(norm_vec1 - norm_vec2), 0, rtol=blvec_error_tol)
 
-def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-3):
+def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-4):
     """
     Determine whether or not two baselines are frequency redundant. Checks that
     both baselines have the same heading, polarization, and have overlapping uv-modes
@@ -59,7 +59,7 @@ def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-3):
         Array of frequencies found in the data in units of Hz
     antpos : dict
         Antenna positions in the form {ant_index: np.array([x,y,z])}.
-    blvec_error_tol : float, default=1e-3
+    blvec_error_tol : float, default=1e-4
         Largest allowable euclidean distance the first unit baseline vector can be away from
         the second
 
@@ -126,7 +126,7 @@ def get_u_bounds(radial_reds, antpos, freqs):
     return ubounds
             
 
-def get_unique_orientations(antpos, reds, min_ubl_per_orient=1, blvec_error_tol=1e-3):
+def get_unique_orientations(antpos, reds, min_ubl_per_orient=1, blvec_error_tol=1e-4):
     """
     Sort baselines into groups with the same radial heading. These groups of baselines are potentially
     frequency redundant in a similar way to redcal.get_reds does. Returns a list of RadialRedundantGroup objects
@@ -139,7 +139,7 @@ def get_unique_orientations(antpos, reds, min_ubl_per_orient=1, blvec_error_tol=
         List of lists of spatially redundant baselines in the array. Can be found using redcal.get_reds
     min_ubl_per_orient : int, default=1
         Minimum number of baselines per unique orientation
-    blvec_error_tol : float, default=1e-3
+    blvec_error_tol : float, default=1e-4
         Largest allowable euclidean distance a unit baseline vector can be away from an existing
         cluster to be considered a unique orientation. See "fclusterdata" for more details.
     bl_error_tol: float, default=1.0
@@ -201,7 +201,7 @@ class FrequencyRedundancy:
     group radially redundant and spatially redundant groups by baseline key.
     """
     def __init__(
-        self, antpos, reds=None, blvec_error_tol=1e-3, pols=["nn"], bl_error_tol=1.0
+        self, antpos, reds=None, blvec_error_tol=1e-4, pols=["nn"], bl_error_tol=1.0
     ):
         """
         Parameters:
@@ -210,7 +210,7 @@ class FrequencyRedundancy:
             Antenna positions in the form {ant_index: np.array([x,y,z])}.
         reds : list of list
             List of lists of baseline keys. Can be determined using redcal.get_reds
-        blvec_error_tol : float, default=1e-3
+        blvec_error_tol : float, default=1e-4
             Largest allowable euclidean distance a unit baseline vector can be away from an existing
             cluster to be considered a unique orientation. See "fclusterdata" for more details.
         pols : list, default=['nn']

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -439,8 +439,10 @@ class FrequencyRedundancy:
             blmag = np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
             self.baseline_lengths[bl] = blmag
 
-        # Reset baseline mapping to spectrally redundant groups
-        self._reset_mapping_dictionaries()
+        # Add baseline group to mapped spectrally redundant groups
+        self._mapped_spectral_reds[value[0]] = value
+        for bl in value:
+            self._bl_to_spec_red_key[bl] = value[0]
 
     def append(self, value):
         """
@@ -464,8 +466,10 @@ class FrequencyRedundancy:
             blmag = np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
             self.baseline_lengths[bl] = blmag
 
-        # Reset baseline mapping to spectrally redundant groups
-        self._reset_mapping_dictionaries()
+        # Add baseline group to mapped spectrally redundant groups
+        self._mapped_spectral_reds[value[0]] = value
+        for bl in value:
+            self._bl_to_spec_red_key[bl] = value[0]
     
     def __iter__(self):
         """Iterates through the list of redundant groups"""

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -1,0 +1,182 @@
+from . import utils
+from . import redcal
+
+import numpy as np
+from copy import deepcopy
+import astropy.constants as const
+from collections import defaultdict
+from scipy.cluster.hierarchy import fclusterdata
+
+SPEED_OF_LIGHT = const.c.si.value
+
+class RadialRedundantGroup:
+    """
+    """
+    def __init__(self, baselines, antpos, blvec=None, pol=None):
+        """
+        """
+        _baselines = deepcopy(baselines)
+
+        # Attach polarization and normalized vector to radial redundant group
+        if pol is None:
+            pols = list(set([bl[2] for bl in baselines]))
+            if len(pols) > 1:
+                raise ValueError(
+                    f"Multiple polarizations are in your radially redundant group: {pols}"
+                )
+            else:
+                self.pol = pols[0]
+        else:
+            self.pol = pol
+            
+        if blvec is None:
+            ant1, ant2, pol = baselines[0]
+            self.blvec = (antpos[ant2] - antpos[ant1]) / np.linalg.norm(antpos[ant2] - antpos[ant1])
+        else:
+            self.blvec = blvec
+        
+        # Store baseline lengths
+        baseline_lengths = []
+        for baseline in baselines:
+            ant1, ant2, pol = baseline
+            baseline_lengths.append(np.linalg.norm(antpos[ant2] - antpos[ant1]))
+
+        # Sort baselines list by baseline length
+        self._baselines = [_baselines[idx] for idx in np.argsort(baseline_lengths)]
+        self.baseline_lengths = [
+            baseline_lengths[idx] for idx in np.argsort(baseline_lengths)
+        ]
+
+    def get_u_bounds(self, freqs):
+        """
+        Calculates the magnitude of the minimum and maximum u-modes values of the radial redundant group 
+        given an array of frequency values
+
+        Parameters:
+        ----------
+            freqs: np.ndarray
+                Array of frequencies found in the data in units of Hz
+
+        Returns:
+            ubounds: tuple
+                Tuple of the magnitude minimum and maximum u-modes sampled by this baseline group
+        """
+        umin = freqs.min() / 2.998e8 * np.min(self.baseline_lengths)
+        umax = freqs.max() / 2.998e8 * np.max(self.baseline_lengths)
+        return (umin, umax)
+
+    def filter_group(
+        self,
+        bls=None,
+        ex_bls=None,
+        ants=None,
+        ex_ants=None,
+        ubls=None,
+        ex_ubls=None,
+        pols=None,
+        ex_pols=None,
+        antpos=None,
+        min_bl_cut=None,
+        max_bl_cut=None,
+    ):
+        """
+        """
+        _baselines = redcal.filter_reds(
+            [self._baselines],
+            bls=bls,
+            ex_bls=ex_bls,
+            ants=ants,
+            ex_ants=ex_ants,
+            ubls=ubls,
+            ex_ubls=ex_ubls,
+            pols=pols,
+            ex_pols=ex_pols,
+        )
+        if len(_baselines) == 0:
+            self._baselines = []
+            self.baseline_lengths = []
+        else:
+            new_bls = []
+            new_bls_lengths = []
+            for bls in _baselines[0]:
+                index = self._baselines.index(bls)
+                if min_bl_cut is not None and self.baseline_lengths[index] < min_bl_cut:
+                    continue
+                if max_bl_cut is not None and self.baseline_lengths[index] > max_bl_cut:
+                    continue
+                new_bls.append(bls)
+                new_bls_lengths.append(self.baseline_lengths[index])
+
+            self._baselines = new_bls
+            self.baseline_lengths = new_bls_lengths
+
+    def __iter__(self):
+        """Iterate through baselines in the radially redundant group
+        """
+        return iter(self._baselines)
+
+    def __len__(self):
+        """Return the length of the baselines list
+        """
+        return len(self._baselines)
+
+    def __getitem__(self, index):
+        """Get the baseline at the chosen index
+        """
+        return self._baselines[index]
+
+def is_frequency_redundant(bl1, bl2, freqs, antpos, blvec_error_tol=1e-9):
+    """
+    Determine whether or not two baselines are frequency redundant. Checks that
+    both baselines have the same heading, polarization, and have overlapping uv-modes
+
+    Parameters:
+    ----------
+    bl1 : tuple
+        pass
+    bl2 : tuple
+        pass
+    freqs : np.ndarray
+        pass
+    antpos : dict
+        pass
+    blvec_error_tol : float, default=1e-9
+        pass
+
+    Returns:
+        Boolean value determining whether or not the baselines are frequency
+        redundant
+
+    """
+    # Split baselines in component antennas
+    _ant1, _ant2, _pol = bl1
+    ant1, ant2, pol = bl2
+
+    # Get baseline vectors
+    blvec1 = antpos[_ant2] - antpos[_ant1]
+    blvec2 = antpos[ant2] - antpos[ant1]
+
+    # Check umode overlap
+    blmag1 = np.linalg.norm(blvec1)
+    blmag2 = np.linalg.norm(blvec2)
+    cond1 = (
+        blmag1 * freqs.min() <= blmag2 * freqs.max()
+        and blmag1 * freqs.max() >= blmag2 * freqs.max()
+    )
+    cond2 = (
+        blmag1 * freqs.min() <= blmag2 * freqs.min()
+        and blmag1 * freqs.max() >= blmag2 * freqs.min()
+    )
+
+    # Check polarization match
+    cond3 = _pol == pol
+
+    # Check headings
+    norm_vec1 = blvec1 / np.linalg.norm(blvec1)
+    norm_vec2 = blvec2 / np.linalg.norm(blvec2)
+    clusters = fclusterdata(
+        np.array([norm_vec1, norm_vec2]), blvec_error_tol, criterion="distance"
+    )
+    cond4 = clusters[0] == clusters[1]
+
+    return (cond1 or cond2) and cond3 and cond4

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -459,6 +459,14 @@ class FrequencyRedundancy:
         for _bad_group in sorted(_bad_groups, reverse=True):
             self._radial_groups.pop(_bad_group)
 
+    def __len__(self):
+        """Get number of frequency redundant groups"""
+        return len(self._radial_groups)
+
+    def __getitem__(self, index):
+        """Get RadialRedundantGroup object from list of unique orientations"""
+        return self._radial_groups[index]
+
     def __iter__(self):
         """Iterates through the list of redundant groups"""
         return iter(self._radial_groups)

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -340,10 +340,6 @@ class FrequencyRedundancy:
         ----------
         min_nbls : int, default=1
             Minimum number of baselines allowed in a radially redundant group
-        pols : list of strings
-            polarizations to include in reds. e.g. ['nn','ee','ne','en']
-        ex_pols : list of strings
-            same as pols, but excludes polarizations.
         min_bl_cut:
             Cut baselines in the radially redundant group with lengths less than min_bl_cut
         max_bl_cut:

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -223,11 +223,8 @@ class FrequencyRedundancy:
         self.antpos = antpos
         self.blvec_error_tol = blvec_error_tol
 
-        # 
-        full_reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
-
         if reds is None:
-            reds = full_reds
+            reds = redcal.get_reds(antpos, pols=pols, bl_error_tol=bl_error_tol)
 
         # Get unique orientations
         self._radial_groups = get_unique_orientations(antpos, reds=reds, blvec_error_tol=blvec_error_tol)
@@ -398,6 +395,12 @@ class FrequencyRedundancy:
         else:
             self._radial_groups.append(group)
 
+        # Add baseline lengths to length dictionary
+        for bl in group:
+            ant1, ant2, _ = bl
+            blmag = np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            self.baseline_lengths[bl] = blmag
+
         # Reset the group now that radially redundant groups have changed
         self._reset_mapping_dictionaries()
 
@@ -424,6 +427,12 @@ class FrequencyRedundancy:
         # Add group at index
         self._radial_groups[index] = value
 
+        # Add baseline lengths to length dictionary
+        for bl in value:
+            ant1, ant2, _ = bl
+            blmag = np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            self.baseline_lengths[bl] = blmag
+
         # Reset baseline mapping to spectrally redundant groups
         self._reset_mapping_dictionaries()
 
@@ -441,6 +450,12 @@ class FrequencyRedundancy:
 
         # Append new group
         self._radial_groups.append(value)
+
+        # Add baseline lengths to length dictionary
+        for bl in value:
+            ant1, ant2, _ = bl
+            blmag = np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            self.baseline_lengths[bl] = blmag
 
         # Reset baseline mapping to spectrally redundant groups
         self._reset_mapping_dictionaries()

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -454,22 +454,20 @@ class FrequencyRedundancy:
         """
         # Filter radially redundant group
         radial_reds = []
+        for group in self._radial_groups:
+            filtered_group = []
+            for bl in group:
+                if (max_bl_cut is None or self.baseline_lengths[bl] < max_bl_cut) and (min_bl_cut is None or self._baseline_lengths[bl] > min_bl_cut):
+                    filtered_group.append(bl)
+                else:
+                    self.baseline_lengths.pop(bl)
 
-        for gi, group in enumerate(radial_reds):
-            
-            
-            group.filter_group(
-                pols=pols,
-                ex_pols=ex_pols,
-                min_bl_cut=min_bl_cut,
-                max_bl_cut=max_bl_cut,
-            )
             # Identify groups with fewer than min_nbls baselines
-            if len(group) < min_nbls:
-                pass
-        # Remove antennas with fewer than min_nbls
-        for _bad_group in sorted(_bad_groups, reverse=True):
-            self._radial_groups.pop(_bad_group)
+            if len(filtered_group) > min_nbls:
+                radial_reds.append(filtered_group)
+
+        # Remove filtered groups from baseline lengths and reds dictionaries
+        self._radial_groups = radial_reds
 
     def __len__(self):
         """Get number of frequency redundant groups"""
@@ -479,6 +477,12 @@ class FrequencyRedundancy:
         """Get RadialRedundantGroup object from list of unique orientations"""
         return self._radial_groups[index]
 
+    def __setitem__(self, index, value):
+        """Set value of index in _radial_groups"""
+        self._radial_groups[index] = value
+    
     def __iter__(self):
         """Iterates through the list of redundant groups"""
         return iter(self._radial_groups)
+
+    

--- a/hera_cal/nucal.py
+++ b/hera_cal/nucal.py
@@ -191,11 +191,7 @@ def get_unique_orientations(
                 _uors[tuple(vec) + (pol,)] = group
 
     # Convert lists to RadialRedundantGroup objects
-    uors = [
-        RadialRedundantGroup(_uors[key], antpos)
-        for key in _uors
-        if len(_uors[key]) >= min_ubl_per_orient
-    ]
+    uors = [_uors[key] for key in _uors if len(_uors[key]) >= min_ubl_per_orient]
     uors = sorted(uors, key=len, reverse=True)
     return uors
 

--- a/hera_cal/tests/test_nucal.py
+++ b/hera_cal/tests/test_nucal.py
@@ -1,89 +1,154 @@
-import pytest 
+import pytest
 import numpy as np
 from copy import deepcopy
-from hera_sim.antpos import linear_array
+from hera_sim.antpos import linear_array, hex_array
 
 from .. import redcal
 from .. import nucal
+from .. import utils
+
+
+def test_is_frequency_redundant():
+    antpos = {i: np.array([i, 0, 0]) for i in range(3)}
+    freqs = np.linspace(1, 2, 10)
+
+    # Two baselines in a linear array should be redundant
+    bl1 = (0, 1, "nn")
+    bl2 = (0, 2, "nn")
+    assert nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+
+    # One baseline should technically be frequency redundant with itself
+    assert nucal.is_frequency_redundant(bl1, bl1, freqs, antpos)
+
+    # Narrowing the bandwidth should make the baselines not frequency redundant
+    freqs = np.linspace(0.5, 0.6, 10)
+    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+
+    # Orthogonal baselines should not be frequency redundant
+    bl1 = (0, 1, "nn")
+    bl2 = (0, 2, "nn")
+    antpos = {0: np.array([0, 0, 0]), 1: np.array([1, 0, 0]), 2: np.array([0, 1, 0])}
+    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+
+
+def test_get_unique_orientations():
+    antpos = linear_array(7)
+    radial_groups = nucal.get_unique_orientations(antpos)
+
+    # Linear arrays should only have one unique orientation
+    assert len(radial_groups) == 1
+
+    # Give spatial redundancies to function and confirm result is the same
+    reds = redcal.get_reds(antpos)
+    _radial_groups = nucal.get_unique_orientations(antpos, reds)
+    assert len(radial_groups) == len(_radial_groups)
+    assert len(radial_groups[0]) == len(_radial_groups[0])
+
+    # Check to see if function identifies flipped orientations
+    reds[1] = [utils.reverse_bl(bls) for bls in reds[1]]
+    print(reds)
+    radial_groups = nucal.get_unique_orientations(antpos, reds, pols=["nn", "ee"])
+    assert len(radial_groups) == 1
+
+    # If multiple polarizations are requested, list should be size 2
+    radial_groups = nucal.get_unique_orientations(antpos, pols=["nn", "ee"])
+    assert len(radial_groups) == 2
+
+    # Filter by minimum number of baselines in unique orientation
+    antpos = hex_array(4, outriggers=0, split_core=False)
+    radial_groups = nucal.get_unique_orientations(
+        antpos, pols=["nn"], min_ubl_per_orient=5
+    )
+    for group in radial_groups:
+        assert len(group) >= 5
+
 
 class TestRadialRedundantGroup:
     def setup(self):
         self.antpos = linear_array(6)
-        self.pols = ['nn']
+        self.pols = ["nn"]
         self.reds = redcal.get_reds(self.antpos, pols=self.pols)
-        
+
     def test_init(self):
         # Select group from reds
         radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
         assert radial_group.pol == self.pols[0]
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, pol='nn')
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, pol="nn")
         assert radial_group.pol == self.pols[0]
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, blvec=np.array([1, 0, 0]))
+        radial_group = nucal.RadialRedundantGroup(
+            self.reds[0], self.antpos, blvec=np.array([1, 0, 0])
+        )
         assert np.allclose(radial_group.blvec, np.array([1, 0, 0]))
-        
+
         for bls in radial_group:
             ant1, ant2, pol = bls
-            blvec = (self.antpos[ant2] - self.antpos[ant1]) / np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            blvec = (self.antpos[ant2] - self.antpos[ant1]) / np.linalg.norm(
+                self.antpos[ant2] - self.antpos[ant1]
+            )
             assert np.allclose(radial_group.blvec, blvec)
-            
+
         assert len(radial_group) == len(self.reds[0])
-        
+
         baseline_lengths = []
         for bls in self.reds[0]:
             ant1, ant2, pol = bls
-            baseline_lengths.append(np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]))
-            
+            baseline_lengths.append(
+                np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            )
+
         assert np.allclose(radial_group.baseline_lengths, np.sort(baseline_lengths))
-        
+
         antpos = linear_array(4)
-        pols = ['nn', 'ee']
+        pols = ["nn", "ee"]
         reds = redcal.get_reds(antpos, pols=pols)
         baselines = sum(reds, [])
         pytest.raises(ValueError, nucal.RadialRedundantGroup, baselines, antpos)
-        
+
     def test_get_u_bounds(self):
         freqs = np.linspace(50e6, 250e6, 10)
         umodes = []
         for bls in self.reds[0]:
             ant1, ant2, pol = bls
-            umodes.append(freqs * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]) / 2.998e8)
-            
+            umodes.append(
+                freqs * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]) / 2.998e8
+            )
+
         umin, umax = np.min(umodes), np.max(umodes)
         radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
         _umin, _umax = radial_group.get_u_bounds(freqs)
         assert np.isclose(umin, _umin)
         assert np.isclose(umax, _umax)
-        
+
     def test_filter_groups(self):
         radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
-        
+
         # Minimum baseline length cut
         rg = deepcopy(radial_group)
         rg.filter_group(min_bl_cut=20)
         for blmag in rg.baseline_lengths:
             assert blmag > 20
-        
+
         # Max baseline length cut
         rg = deepcopy(radial_group)
         rg.filter_group(max_bl_cut=50)
         for blmag in rg.baseline_lengths:
             assert blmag < 50
-            
+
         # Filter by antenna number
         rg = deepcopy(radial_group)
-        rg.filter_group(ex_ants=(0, 'Jnn'))
+        rg.filter_group(ex_ants=(0, "Jnn"))
         for bls in rg:
             assert 0 not in bls
-            
+
         # Filter all baselines by min_bl_cut
         rg = deepcopy(radial_group)
         rg.filter_group(min_bl_cut=1000)
         assert len(rg) == 0
         assert len(rg.baseline_lengths) == 0
-        
+
         # Filter all baselines by ex_ants
         rg = deepcopy(radial_group)
-        rg.filter_group(ex_ants=[(i, 'Jnn') for i in range(6)])
+        rg.filter_group(ex_ants=[(i, "Jnn") for i in range(6)])
         assert len(rg) == 0
         assert len(rg.baseline_lengths) == 0
 
@@ -94,25 +159,47 @@ class TestRadialRedundantGroup:
             assert len(radial_group[i]) == 3
 
 
+class TestFrequencyRedundancy:
+    def setup(self):
+        self.antpos = hex_array(4, outriggers=0, split_core=False)
+        self.freq_reds = nucal.FrequencyRedundancy(self.antpos)
 
-def test_is_frequency_redundant():
-    antpos = {i: np.array([i, 0, 0]) for i in range(3)}
-    freqs = np.linspace(1, 2, 10)
-    
-    # Two baselines in a linear array should be redundant
-    bl1 = (0, 1, 'nn')
-    bl2 = (0, 2, 'nn')
-    assert nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
-    
-    # One baseline should technically be frequency redundant with itself
-    assert nucal.is_frequency_redundant(bl1, bl1, freqs, antpos)
-    
-    # Narrowing the bandwidth should make the baselines not frequency redundant
-    freqs = np.linspace(0.5, 0.6, 10)
-    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
-    
-    # Orthogonal baselines should not be frequency redundant
-    bl1 = (0, 1, 'nn')
-    bl2 = (0, 2, 'nn')
-    antpos = {0: np.array([0, 0, 0]), 1: np.array([1, 0, 0]), 2: np.array([0, 1, 0])}
-    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+    def test_init(self):
+        pass
+
+    def test_filter_groups(self):
+        freq_reds = deepcopy(self.freq_reds)
+
+        # Make sure all groups have at least 4 baselines
+        freq_reds.filter_radial_groups(min_nbls=2)
+        for group in freq_reds:
+            assert len(group) >= 2
+
+        # Filter out antenna (0, "Jnn")
+        freq_reds = deepcopy(self.freq_reds)
+        freq_reds.filter_radial_groups(ex_ants=[(0, "Jnn")])
+        for group in freq_reds:
+            for bls in group:
+                assert 0 not in bls
+
+    def test_get_pol(self):
+        freq_reds = nucal.FrequencyRedundancy(self.antpos, pols=["nn", "ee"])
+        for group in self.freq_reds.get_pol("nn"):
+            assert group.pol == "nn"
+
+    def test_get_radial_group(self):
+        reds = redcal.get_reds(self.antpos)
+        for red in reds:
+            group = self.freq_reds.get_radial_group(red[0])
+            assert red[0] in group
+
+    def test_get_redundant_group(self):
+        # Loop through the redundancies and confirm that we can grab spatially redundant groups
+        reds = redcal.get_reds(self.antpos)
+        for red in reds:
+            for bls in red:
+                group = self.freq_reds.get_redundant_group(bls)
+                assert bls in group
+
+        # Make sure KeyError is raised if incorrect key not given
+        pytest.raises(KeyError, self.freq_reds.get_redundant_group, (-1, -1, "nn"))

--- a/hera_cal/tests/test_nucal.py
+++ b/hera_cal/tests/test_nucal.py
@@ -7,6 +7,35 @@ from .. import redcal
 from .. import nucal
 from .. import utils
 
+def test_get_u_bounds():
+    antpos = {i: np.array([i, 0, 0]) for i in range(7)}
+    freqs = np.linspace(50e6, 250e6, 10)
+    radial_reds = nucal.FrequencyRedundancy(antpos)
+    u_bounds = nucal.get_u_bounds(radial_reds, antpos, freqs)
+    
+    # List of u-bounds should be the same length as radial reds
+    assert len(u_bounds) == len(radial_reds)
+
+    baseline_lengths = [radial_reds.baseline_lengths[bl] for bl in radial_reds[0]]
+
+    # Check the minimum and maximum u-bounds are what we would expect
+    assert np.isclose(u_bounds[0][0], np.min(baseline_lengths) * freqs[0] / nucal.SPEED_OF_LIGHT)
+    assert np.isclose(u_bounds[0][1], np.max(baseline_lengths) * freqs[-1] / nucal.SPEED_OF_LIGHT)
+
+def test_is_same_orientation():
+    antpos = {i: np.array([i, 0, 0]) for i in range(3)}
+    
+    # Add extra orthogonal baseline
+    antpos[3] = np.array([0, 1, 0])
+    bl1 = (0, 1, 'nn')
+    bl2 = (0, 2, 'nn')
+    bl3 = (0, 3, 'nn')
+
+    # These baselines should have the same orientation
+    assert nucal.is_same_orientation(bl1, bl2, antpos)
+
+    # These baselines should not
+    assert not nucal.is_same_orientation(bl1, bl3, antpos)
 
 def test_is_frequency_redundant():
     antpos = {i: np.array([i, 0, 0]) for i in range(3)}
@@ -30,191 +59,200 @@ def test_is_frequency_redundant():
     antpos = {0: np.array([0, 0, 0]), 1: np.array([1, 0, 0]), 2: np.array([0, 1, 0])}
     assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
 
+    # Try baselines with different polarizations
+    antpos = {i: np.array([i, 0, 0]) for i in range(3)}
+    bl1 = (0, 1, "en")
+    bl2 = (0, 2, "nn")
+    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
 
 def test_get_unique_orientations():
     antpos = linear_array(7)
-    radial_groups = nucal.get_unique_orientations(antpos)
-
-    # Linear arrays should only have one unique orientation
-    assert len(radial_groups) == 1
 
     # Give spatial redundancies to function and confirm result is the same
     reds = redcal.get_reds(antpos)
-    _radial_groups = nucal.get_unique_orientations(antpos, reds)
-    assert len(radial_groups) == len(_radial_groups)
-    assert len(radial_groups[0]) == len(_radial_groups[0])
+    radial_groups = nucal.get_unique_orientations(antpos, reds)
+    assert len(radial_groups) == 1
 
     # Check to see if function identifies flipped orientations
     reds[1] = [utils.reverse_bl(bls) for bls in reds[1]]
     radial_groups = nucal.get_unique_orientations(antpos, reds)
     assert len(radial_groups) == 1
 
-    # If multiple polarizations are requested, list should be size 2
-    radial_groups = nucal.get_unique_orientations(antpos, pols=["nn", "ee"])
-    assert len(radial_groups) == 2
-
     # Filter by minimum number of baselines in unique orientation
     antpos = hex_array(4, outriggers=0, split_core=False)
-    radial_groups = nucal.get_unique_orientations(
-        antpos, pols=["nn"], min_ubl_per_orient=5
-    )
+    reds = redcal.get_reds(antpos)
+    radial_groups = nucal.get_unique_orientations(antpos, reds, min_ubl_per_orient=5)
     for group in radial_groups:
         assert len(group) >= 5
-
-
-class TestRadialRedundantGroup:
-    def setup(self):
-        self.antpos = linear_array(6)
-        self.pols = ["nn"]
-        self.reds = redcal.get_reds(self.antpos, pols=self.pols)
-
-    def test_init(self):
-        # Select group from reds
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
-        assert radial_group.pol == self.pols[0]
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, pol="nn")
-        assert radial_group.pol == self.pols[0]
-        radial_group = nucal.RadialRedundantGroup(
-            self.reds[0], self.antpos, blvec=np.array([1, 0, 0])
-        )
-        assert np.allclose(radial_group.blvec, np.array([1, 0, 0]))
-
-        for bls in radial_group:
-            ant1, ant2, pol = bls
-            blvec = (self.antpos[ant2] - self.antpos[ant1]) / np.linalg.norm(
-                self.antpos[ant2] - self.antpos[ant1]
-            )
-            assert np.allclose(radial_group.blvec, blvec)
-
-        assert len(radial_group) == len(self.reds[0])
-
-        baseline_lengths = []
-        for bls in self.reds[0]:
-            ant1, ant2, pol = bls
-            baseline_lengths.append(
-                np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
-            )
-
-        assert np.allclose(radial_group.baseline_lengths, np.sort(baseline_lengths))
-
-        antpos = linear_array(4)
-        pols = ["nn", "ee"]
-        reds = redcal.get_reds(antpos, pols=pols)
-        baselines = sum(reds, [])
-        pytest.raises(ValueError, nucal.RadialRedundantGroup, baselines, antpos)
-
-    def test_get_u_bounds(self):
-        freqs = np.linspace(50e6, 250e6, 10)
-        umodes = []
-        for bls in self.reds[0]:
-            ant1, ant2, pol = bls
-            umodes.append(
-                freqs
-                * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
-                / nucal.SPEED_OF_LIGHT
-            )
-
-        umin, umax = np.min(umodes), np.max(umodes)
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
-        _umin, _umax = radial_group.get_u_bounds(freqs)
-        assert np.isclose(umin, _umin)
-        assert np.isclose(umax, _umax)
-
-    def test_filter_groups(self):
-        radial_group = nucal.RadialRedundantGroup(
-            [red[0] for red in self.reds], self.antpos
-        )
-
-        # Minimum baseline length cut
-        rg = deepcopy(radial_group)
-        rg.filter_group(min_bl_cut=20)
-        for blmag in rg.baseline_lengths:
-            assert blmag > 20
-
-        # Max baseline length cut
-        rg = deepcopy(radial_group)
-        rg.filter_group(max_bl_cut=50)
-        for blmag in rg.baseline_lengths:
-            assert blmag < 50
-
-        # Filter by antenna number
-        rg = deepcopy(radial_group)
-        rg.filter_group(ex_ants=(0, "Jnn"))
-        for bls in rg:
-            assert 0 not in bls
-
-        # Filter all baselines by min_bl_cut
-        rg = deepcopy(radial_group)
-        rg.filter_group(min_bl_cut=1000)
-        assert len(rg) == 0
-        assert len(rg.baseline_lengths) == 0
-
-        # Filter all baselines by ex_ants
-        rg = deepcopy(radial_group)
-        rg.filter_group(ex_ants=[(i, "Jnn") for i in range(6)])
-        assert len(rg) == 0
-        assert len(rg.baseline_lengths) == 0
-
-    def test_get_item(self):
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
-        for i in range(len(radial_group)):
-            assert isinstance(radial_group[i], tuple)
-            assert len(radial_group[i]) == 3
-
 
 class TestFrequencyRedundancy:
     def setup(self):
         self.antpos = hex_array(4, outriggers=0, split_core=False)
-        self.freq_reds = nucal.FrequencyRedundancy(self.antpos)
+        self.radial_reds = nucal.FrequencyRedundancy(self.antpos)
 
     def test_init(self):
         pass
 
     def test_filter_groups(self):
-        freq_reds = deepcopy(self.freq_reds)
+        radial_reds = deepcopy(self.radial_reds)
 
         # Make sure all groups have at least 4 baselines
-        freq_reds.filter_radial_groups(min_nbls=2)
-        for group in freq_reds:
+        radial_reds.filter_radial_groups(min_nbls=2)
+        for group in radial_reds:
             assert len(group) >= 2
 
-        # Filter out antenna (0, "Jnn")
-        freq_reds = deepcopy(self.freq_reds)
-        freq_reds.filter_radial_groups(ex_ants=[(0, "Jnn")])
-        for group in freq_reds:
-            for bls in group:
-                assert 0 not in bls
+        # Filter out baseline lengths less than 20 meters
+        radial_reds = deepcopy(self.radial_reds)
+        radial_reds.filter_radial_groups(min_bl_cut=20)
+        for group in radial_reds:
+            for bl in group:
+                assert radial_reds.baseline_lengths[bl] > 20
+
+        # Filter out baseline lengths greater than 20 meters
+        radial_reds = deepcopy(self.radial_reds)
+        radial_reds.filter_radial_groups(max_bl_cut=20)
+        for group in radial_reds:
+            for bl in group:
+                assert radial_reds.baseline_lengths[bl] < 20
 
     def test_get_item(self):
         """ """
         # Check indexing
-        groups = [self.freq_reds[i] for i in range(len(self.freq_reds))]
-        for gi, grp in enumerate(self.freq_reds):
+        groups = [self.radial_reds[i] for i in range(len(self.radial_reds))]
+        for gi, grp in enumerate(self.radial_reds):
             assert groups[gi] == grp
 
     def test_get_pol(self):
-        freq_reds = nucal.FrequencyRedundancy(self.antpos, pols=["nn", "ee"])
-        for group in self.freq_reds.get_pol("nn"):
-            assert group.pol == "nn"
+        radial_reds = nucal.FrequencyRedundancy(self.antpos, pols=["nn", "ee"])
+        for group in self.radial_reds.get_pol("nn"):
+            assert group[0][-1] == "nn"
 
     def test_get_radial_group(self):
         reds = redcal.get_reds(self.antpos)
         for red in reds:
-            group = self.freq_reds.get_radial_group(red[0])
+            group = self.radial_reds.get_radial_group(red[0])
             assert red[0] in group
+
+        # Try to get baseline not in data
+        pytest.raises(KeyError, self.radial_reds.get_radial_group, (1, 1, 'nn'))
+
+        # Try to get flipped baseline
+        group1 = self.radial_reds.get_radial_group((1, 0, 'nn'))
+        group2 = self.radial_reds.get_radial_group((0, 1, 'nn'))
+
+        for bi in range(len(group1)):
+            assert group1[bi] == utils.reverse_bl(group2[bi])
 
     def test_get_redundant_group(self):
         # Loop through the redundancies and confirm that we can grab spatially redundant groups
         reds = redcal.get_reds(self.antpos)
         for red in reds:
             for bls in red:
-                group = self.freq_reds.get_redundant_group(bls)
+                group = self.radial_reds.get_redundant_group(bls)
                 assert bls in group
 
         # Make sure KeyError is raised if incorrect key not given
-        pytest.raises(KeyError, self.freq_reds.get_redundant_group, (-1, -1, "nn"))
+        pytest.raises(KeyError, self.radial_reds.get_redundant_group, (-1, -1, "nn"))
 
         # Check flipped baseline
         bls = (1, 0, "nn")
-        group = self.freq_reds.get_redundant_group(bls)
+        group = self.radial_reds.get_redundant_group(bls)
         assert bls in group
+
+    def test_set_item(self):
+        radial_reds = deepcopy(self.radial_reds)
+        # Find radial group with 1 baseline
+        radial_reds.sort(reverse=False)
+        group = deepcopy(radial_reds[0])
+
+        # Filter all groups with fewer than 3 baselines
+        radial_reds.filter_radial_groups(min_nbls=3)
+        radial_reds[0] = group
+
+        # Add baseline group with same heading as existing heading
+        antpos = linear_array(10)
+        radial_reds = nucal.FrequencyRedundancy(antpos)
+        radial_reds.filter_radial_groups(max_bl_cut=40)
+
+        bls = []
+        for i in range(10):
+            if np.linalg.norm(antpos[i] - antpos[0]) > 40:
+                bls.append((0, i, 'nn'))
+
+        pytest.raises(ValueError, radial_reds.__setitem__, 0, bls)
+
+    def test_append(self):
+        radial_reds = deepcopy(self.radial_reds)
+        # Find radial group with 1 baseline
+        radial_reds.sort(reverse=False)
+        group = deepcopy(radial_reds[0])
+
+        # Filter all groups with fewer than 10 baselines
+        radial_reds.filter_radial_groups(min_nbls=10)
+
+        # Append group
+        radial_reds.append(group)
+
+        # Try appending something else
+        pytest.raises(TypeError, radial_reds.append, "Test string")
+
+        # Add baseline group with same heading as existing heading
+        antpos = linear_array(10)
+        radial_reds = nucal.FrequencyRedundancy(antpos)
+        radial_reds.filter_radial_groups(max_bl_cut=40)
+
+        bls = []
+        for i in range(10):
+            if np.linalg.norm(antpos[i] - antpos[0]) > 40:
+                bls.append((0, i, 'nn'))
+
+        pytest.raises(ValueError, radial_reds.append, bls)
+
+
+    def test_add_radial_group(self):
+        radial_reds = deepcopy(self.radial_reds)
+        # Find radial group with 1 baseline
+        radial_reds.sort(reverse=False)
+        group1 = deepcopy(radial_reds[0])
+
+        # Find group with more baselines
+        for group in radial_reds:
+            if len(group) == 3:
+                group2 = deepcopy(group)
+                break
+
+        # Filter all groups with fewer than 10 baselines
+        radial_reds.filter_radial_groups(min_nbls=10)
+        
+        # Add group with a single baseline
+        radial_reds.add_radial_group(group1)
+
+        # Add group with more baselines
+        radial_reds.add_radial_group(group2)
+
+        # Try to add a group with baselines that are not radially redundant
+        pytest.raises(ValueError, radial_reds.add_radial_group, group1 + group2)
+
+        # Same as above but with different polarizations
+        group3 = [(0, 1, 'nn'), (0, 2, 'ee')]
+        pytest.raises(ValueError, radial_reds.add_radial_group, group3)
+
+        # Add baseline group with same heading as existing heading
+        antpos = linear_array(10)
+        radial_reds = nucal.FrequencyRedundancy(antpos)
+        radial_reds.filter_radial_groups(max_bl_cut=40)
+
+        bls = []
+        for i in range(10):
+            if np.linalg.norm(antpos[i] - antpos[0]) > 40:
+                bls.append((0, i, 'nn'))
+
+        radial_reds.add_radial_group(bls)
+
+
+    def test_sort(self):
+        radial_reds = deepcopy(self.radial_reds)
+        radial_reds.sort(reverse=False)
+        assert len(radial_reds[0]) < len(radial_reds[-1])
+        radial_reds.sort(reverse=True)
+        assert len(radial_reds[0]) > len(radial_reds[-1])

--- a/hera_cal/tests/test_nucal.py
+++ b/hera_cal/tests/test_nucal.py
@@ -1,0 +1,118 @@
+import pytest 
+import numpy as np
+from copy import deepcopy
+from hera_sim.antpos import linear_array
+
+from .. import redcal
+from .. import nucal
+
+class TestRadialRedundantGroup:
+    def setup(self):
+        self.antpos = linear_array(6)
+        self.pols = ['nn']
+        self.reds = redcal.get_reds(self.antpos, pols=self.pols)
+        
+    def test_init(self):
+        # Select group from reds
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
+        assert radial_group.pol == self.pols[0]
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, pol='nn')
+        assert radial_group.pol == self.pols[0]
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos, blvec=np.array([1, 0, 0]))
+        assert np.allclose(radial_group.blvec, np.array([1, 0, 0]))
+        
+        for bls in radial_group:
+            ant1, ant2, pol = bls
+            blvec = (self.antpos[ant2] - self.antpos[ant1]) / np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+            assert np.allclose(radial_group.blvec, blvec)
+            
+        assert len(radial_group) == len(self.reds[0])
+        
+        baseline_lengths = []
+        for bls in self.reds[0]:
+            ant1, ant2, pol = bls
+            baseline_lengths.append(np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]))
+            
+        assert np.allclose(radial_group.baseline_lengths, np.sort(baseline_lengths))
+        
+        antpos = linear_array(4)
+        pols = ['nn', 'ee']
+        reds = redcal.get_reds(antpos, pols=pols)
+        baselines = sum(reds, [])
+        pytest.raises(ValueError, nucal.RadialRedundantGroup, baselines, antpos)
+        
+    def test_get_u_bounds(self):
+        freqs = np.linspace(50e6, 250e6, 10)
+        umodes = []
+        for bls in self.reds[0]:
+            ant1, ant2, pol = bls
+            umodes.append(freqs * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]) / 2.998e8)
+            
+        umin, umax = np.min(umodes), np.max(umodes)
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
+        _umin, _umax = radial_group.get_u_bounds(freqs)
+        assert np.isclose(umin, _umin)
+        assert np.isclose(umax, _umax)
+        
+    def test_filter_groups(self):
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
+        
+        # Minimum baseline length cut
+        rg = deepcopy(radial_group)
+        rg.filter_group(min_bl_cut=20)
+        for blmag in rg.baseline_lengths:
+            assert blmag > 20
+        
+        # Max baseline length cut
+        rg = deepcopy(radial_group)
+        rg.filter_group(max_bl_cut=50)
+        for blmag in rg.baseline_lengths:
+            assert blmag < 50
+            
+        # Filter by antenna number
+        rg = deepcopy(radial_group)
+        rg.filter_group(ex_ants=(0, 'Jnn'))
+        for bls in rg:
+            assert 0 not in bls
+            
+        # Filter all baselines by min_bl_cut
+        rg = deepcopy(radial_group)
+        rg.filter_group(min_bl_cut=1000)
+        assert len(rg) == 0
+        assert len(rg.baseline_lengths) == 0
+        
+        # Filter all baselines by ex_ants
+        rg = deepcopy(radial_group)
+        rg.filter_group(ex_ants=[(i, 'Jnn') for i in range(6)])
+        assert len(rg) == 0
+        assert len(rg.baseline_lengths) == 0
+
+    def test_get_item(self):
+        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
+        for i in range(len(radial_group)):
+            assert isinstance(radial_group[i], tuple)
+            assert len(radial_group[i]) == 3
+
+
+
+def test_is_frequency_redundant():
+    antpos = {i: np.array([i, 0, 0]) for i in range(3)}
+    freqs = np.linspace(1, 2, 10)
+    
+    # Two baselines in a linear array should be redundant
+    bl1 = (0, 1, 'nn')
+    bl2 = (0, 2, 'nn')
+    assert nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+    
+    # One baseline should technically be frequency redundant with itself
+    assert nucal.is_frequency_redundant(bl1, bl1, freqs, antpos)
+    
+    # Narrowing the bandwidth should make the baselines not frequency redundant
+    freqs = np.linspace(0.5, 0.6, 10)
+    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)
+    
+    # Orthogonal baselines should not be frequency redundant
+    bl1 = (0, 1, 'nn')
+    bl2 = (0, 2, 'nn')
+    antpos = {0: np.array([0, 0, 0]), 1: np.array([1, 0, 0]), 2: np.array([0, 1, 0])}
+    assert not nucal.is_frequency_redundant(bl1, bl2, freqs, antpos)

--- a/hera_cal/tests/test_nucal.py
+++ b/hera_cal/tests/test_nucal.py
@@ -46,8 +46,7 @@ def test_get_unique_orientations():
 
     # Check to see if function identifies flipped orientations
     reds[1] = [utils.reverse_bl(bls) for bls in reds[1]]
-    print(reds)
-    radial_groups = nucal.get_unique_orientations(antpos, reds, pols=["nn", "ee"])
+    radial_groups = nucal.get_unique_orientations(antpos, reds)
     assert len(radial_groups) == 1
 
     # If multiple polarizations are requested, list should be size 2

--- a/hera_cal/tests/test_nucal.py
+++ b/hera_cal/tests/test_nucal.py
@@ -109,7 +109,9 @@ class TestRadialRedundantGroup:
         for bls in self.reds[0]:
             ant1, ant2, pol = bls
             umodes.append(
-                freqs * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1]) / 2.998e8
+                freqs
+                * np.linalg.norm(self.antpos[ant2] - self.antpos[ant1])
+                / nucal.SPEED_OF_LIGHT
             )
 
         umin, umax = np.min(umodes), np.max(umodes)
@@ -119,7 +121,9 @@ class TestRadialRedundantGroup:
         assert np.isclose(umax, _umax)
 
     def test_filter_groups(self):
-        radial_group = nucal.RadialRedundantGroup(self.reds[0], self.antpos)
+        radial_group = nucal.RadialRedundantGroup(
+            [red[0] for red in self.reds], self.antpos
+        )
 
         # Minimum baseline length cut
         rg = deepcopy(radial_group)
@@ -181,6 +185,13 @@ class TestFrequencyRedundancy:
             for bls in group:
                 assert 0 not in bls
 
+    def test_get_item(self):
+        """ """
+        # Check indexing
+        groups = [self.freq_reds[i] for i in range(len(self.freq_reds))]
+        for gi, grp in enumerate(self.freq_reds):
+            assert groups[gi] == grp
+
     def test_get_pol(self):
         freq_reds = nucal.FrequencyRedundancy(self.antpos, pols=["nn", "ee"])
         for group in self.freq_reds.get_pol("nn"):
@@ -202,3 +213,8 @@ class TestFrequencyRedundancy:
 
         # Make sure KeyError is raised if incorrect key not given
         pytest.raises(KeyError, self.freq_reds.get_redundant_group, (-1, -1, "nn"))
+
+        # Check flipped baseline
+        bls = (1, 0, "nn")
+        group = self.freq_reds.get_redundant_group(bls)
+        assert bls in group


### PR DESCRIPTION
This PR creates the nucal file, which contains utility functions for performing frequency redundancy calibration. Functions for finding groups of baselines which are radially redundant and filtering those baselines are included here.