### PR TITLE
Minor speed-up and memory savings to predict_chisq_per_bl

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1451,10 +1451,10 @@ def predict_chisq_per_bl(reds):
 
     A = solver.ls_amp.get_A()[:, :, 0]
     B = solver.ls_phs.get_A()[:, :, 0]
-    A_data_resolution = A.dot(np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T))
-    B_data_resolution = B.dot(np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T))
+    A_data_resolution = (A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T)).sum(0)
+    B_data_resolution = (B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T)).sum(0)
 
-    predicted_chisq_per_bl = 1.0 - np.diag(A_data_resolution + B_data_resolution) / 2.0
+    predicted_chisq_per_bl = 1.0 - (A_data_resolution + B_data_resolution) / 2.0
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}
 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1451,10 +1451,10 @@ def predict_chisq_per_bl(reds):
 
     A = solver.ls_amp.get_A()[:, :, 0]
     B = solver.ls_phs.get_A()[:, :, 0]
-    A_data_resolution = (A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T)).sum(0)
-    B_data_resolution = (B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T)).sum(0)
+    A_data_resolution_diag_sum = np.sum(A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T))
+    B_data_resolution_diag_sum = np.sum(B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T))
 
-    predicted_chisq_per_bl = 1.0 - (A_data_resolution + B_data_resolution) / 2.0
+    predicted_chisq_per_bl = 1.0 - (A_data_resolution_diag_sum + B_data_resolution_diag_sum) / 2.0
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}
 
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1451,8 +1451,8 @@ def predict_chisq_per_bl(reds):
 
     A = solver.ls_amp.get_A()[:, :, 0]
     B = solver.ls_phs.get_A()[:, :, 0]
-    A_data_resolution_diag_sum = np.sum(A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T))
-    B_data_resolution_diag_sum = np.sum(B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T))
+    A_data_resolution_diag_sum = np.sum(A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T), axis=0)
+    B_data_resolution_diag_sum = np.sum(B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T), axis=0)
 
     predicted_chisq_per_bl = 1.0 - (A_data_resolution_diag_sum + B_data_resolution_diag_sum) / 2.0
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1451,8 +1451,8 @@ def predict_chisq_per_bl(reds):
 
     A = solver.ls_amp.get_A()[:, :, 0]
     B = solver.ls_phs.get_A()[:, :, 0]
-    A_data_resolution_diag_sum = np.sum(A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T), axis=0)
-    B_data_resolution_diag_sum = np.sum(B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T), axis=0)
+    A_data_resolution_diag_sum = (A.T * np.linalg.pinv(A.T.dot(A), hermitian=True).dot(A.T)).sum(axis=0)
+    B_data_resolution_diag_sum = (B.T * np.linalg.pinv(B.T.dot(B), hermitian=True).dot(B.T)).sum(axis=0)
 
     predicted_chisq_per_bl = 1.0 - (A_data_resolution_diag_sum + B_data_resolution_diag_sum) / 2.0
     return {bl: dof for bl, dof in zip(bls, predicted_chisq_per_bl)}


### PR DESCRIPTION
Very short PR that reduces the memory usage and increases the performance of `predict_chisq_per_bl` by only computing the main diagonal of the `ls_amp` and `ls_phs` projection matrices. Prior to this PR, the function computed the entire matrix when only the diagonal is needed, leading to nbls x nbls matrices being formed. Improvement is negligible for a few antennas, but becomes more useful for many antennas. 

<img width="701" alt="Screen Shot 2022-09-22 at 5 05 16 PM" src="https://user-images.githubusercontent.com/17678594/191871789-c1a1bc30-abe8-4d1a-9b69-eaff981e72b5.png">

<img width="687" alt="Screen Shot 2022-09-22 at 5 05 27 PM" src="https://user-images.githubusercontent.com/17678594/191871791-d60261ab-e24e-466f-b8e3-81e708b88697.png">
