### PR TITLE
Add `RedSol` modeling functionality, begin reorganization of redcal.py

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -412,8 +412,9 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
             meanSqAmplitude = np.mean([np.abs(g1 * g2) for (a1, p1), g1 in gains.items()
                                        for (a2, p2), g2 in gains.items()
                                        if p1 == pol and p2 == pol and a1 != a2], axis=0)
-            degenMeanSqAmplitude = np.mean([np.abs(degen_gains[k1] * degen_gains[k2]) for k1 in gains.keys()
-                                            for k2 in gains.keys()
+            degenMeanSqAmplitude = np.mean([(np.ones_like(gains[k1]) if degen_gains is None
+                                             else np.abs(degen_gains[k1] * degen_gains[k2]))
+                                            for k1 in gains.keys() for k2 in gains.keys()
                                             if k1[1] == pol and k2[1] == pol and k1[0] != k2[0]], axis=0)
             gainSols[gainPols == pol] *= (degenMeanSqAmplitude / meanSqAmplitude)**.5
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -416,6 +416,7 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
     # Create new solutions dictionary
     new_gains = {ant: gainSol for ant, gainSol in zip(ants, gainSols)}
 
+
 class RedSol():
     '''Object for containing solutions to redundant calibraton, namely gains and
     unique-baseline visibilities, along with a variety of convenience methods.'''
@@ -530,8 +531,8 @@ class RedSol():
         ai, aj = split_bl(bl)
         return self.gain[ai] * np.conj(self.gain[aj])
 
-    def model(self, bl):
-        '''Return visibility model for baseline bl
+    def model_bl(self, bl):
+        '''Return visibility data model (gain * vissol) for baseline bl
 
         Arguments:
             bl: baseline to return model for
@@ -541,7 +542,7 @@ class RedSol():
         '''
         return self.gain_bl(bl) * self.vis[bl]
 
-    def calibrate(self, bl, data):
+    def calibrate_bl(self, bl, data):
         '''Return calibrated data for baseline bl
 
         Arguments:
@@ -555,7 +556,7 @@ class RedSol():
         np.divide(data, gij, out=data, where=(gij != 0))
         return data
 
-    def vis_from_data(self, data, wgts={}):
+    def get_vis_from_data(self, data, wgts={}):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object and
            stores the result as the redundant solution.
 
@@ -570,11 +571,11 @@ class RedSol():
         vis = {}
         for grp in self.reds:
             if len(wgts) != 0:
-                vis[grp[0]] = sum([wgts.get(bl, 1) * self.calibrate(bl, data[bl]) for bl in grp])
+                vis[grp[0]] = sum([wgts.get(bl, 1) * self.calibrate_bl(bl, data[bl]) for bl in grp])
                 wgt_sum = sum([wgts.get(bl, 1) for bl in grp])
                 np.divide(vis[grp[0]], wgt_sum, out=vis[grp[0]], where=(wgt_sum != 0))
             else:
-                vis[grp[0]] = sum([self.calibrate(bl, data[bl]) for bl in grp])
+                vis[grp[0]] = sum([self.calibrate_bl(bl, data[bl]) for bl in grp])
         self.vis = RedDataContainer(vis, reds=self.reds)
 
     def red_average(self, data, flags=None, nsamples=None, gain_flags=None):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -515,7 +515,8 @@ class RedSol():
             new_sol: if not inplace, RedSol with degeneracy removal/replacement performed
         """
         old_gains = self.gains
-        new_gains = remove_degen_gains(self.reds, old_gains, degen_gains=degen_sol, mode='complex')
+        new_gains = remove_degen_gains(self.reds, old_gains, degen_gains=degen_sol, mode='complex',
+                                       pol_mode=parse_pol_mode(self.reds))
         if inplace:
             calibrate_in_place(self.vis, new_gains, old_gains=old_gains)
             self.gains = new_gains

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -581,7 +581,7 @@ class RedSol():
                 wgt_sum = sum([wgts.get(bl, 1) for bl in grp])
                 np.divide(vis[grp[0]], wgt_sum, out=vis[grp[0]], where=(wgt_sum != 0))
             else:
-                vis[grp[0]] = sum([self.calibrate_bl(bl, data[bl]) for bl in grp])
+                vis[grp[0]] = np.mean([self.calibrate_bl(bl, data[bl]) for bl in grp], axis=0)
         self.vis = RedDataContainer(vis, reds=self.reds)
 
     def chisq(self, data, data_wgts, gain_flags=None):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -362,11 +362,6 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
     # Check supported pol modes
     assert pol_mode in ['1pol', '2pol', '4pol', '4pol_minV'], f'Unrecognized pol_mode: {pol_mode}'
     assert mode in ('phase', 'complex'), 'Unrecognized mode: %s' % mode
-    if degen_gains is None:
-        if mode == 'phase':
-            degen_gains = {key: np.zeros_like(val) for key, val in gains.items()}
-        else:  # complex
-            degen_gains = {key: np.ones_like(val) for key, val in gains.items()}
     ants = gains.keys()
     gainPols = np.array([ant[1] for ant in gains])  # gainPols is list of antpols, one per antenna
     antpols = list(set(gainPols))
@@ -379,9 +374,15 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
         new_gains.update(remove_degen_gains(reds, pol1_gains, degen_gains=degen_gains, mode=mode, pol_mode='1pol'))
         return new_gains
 
-    # Extract gain and model visibiltiy solutions
+    # Extract gains and degenerate gains and put into numpy arrays
     gainSols = np.array([gains[ant] for ant in ants])
-    degenGains = np.array([degen_gains[ant] for ant in ants])
+    if degen_gains is None:
+        if mode == 'phase':
+            degenGains = np.array([np.zeros_like(gains[ant]) for ant in ants])
+        else:  # complex
+            degenGains = np.array([np.ones_like(gains[ant]) for ant in ants])
+    else:
+        degenGains = np.array([degen_gains[ant] for ant in ants])
 
     # Build matrices for projecting gain degeneracies
     antpos = reds_to_antpos(reds)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -577,12 +577,8 @@ class RedSol():
         '''
         vis = {}
         for grp in self.reds:
-            if len(wgts) != 0:
-                vis[grp[0]] = sum([wgts.get(bl, 1) * self.calibrate_bl(bl, data[bl]) for bl in grp])
-                wgt_sum = sum([wgts.get(bl, 1) for bl in grp])
-                np.divide(vis[grp[0]], wgt_sum, out=vis[grp[0]], where=(wgt_sum != 0))
-            else:
-                vis[grp[0]] = np.mean([self.calibrate_bl(bl, data[bl]) for bl in grp], axis=0)
+            vis[grp[0]] = np.average([self.calibrate_bl(bl, data[bl]) for bl in grp], axis=0,
+                                     weights=([wgts.get(bl, 1) for bl in grp] if len(wgts) > 0 else None))
         self.vis = RedDataContainer(vis, reds=self.reds)
 
     def chisq(self, data, data_wgts, gain_flags=None):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -535,7 +535,7 @@ class RedSol():
             gain: gi * conj(gj)
         '''
         ai, aj = split_bl(bl)
-        return self.gain[ai] * np.conj(self.gain[aj])
+        return self.gains[ai] * np.conj(self.gains[aj])
 
     def model_bl(self, bl):
         '''Return visibility data model (gain * vissol) for baseline bl

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -340,6 +340,82 @@ def make_sol_finite(sol):
             sol[k][~np.isfinite(sol[k])] = np.ones_like(sol[k][~np.isfinite(sol[k])])
 
 
+def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1pol'):
+    """ Removes degeneracies from solutions (or replaces them with those in degen_sol).  This
+    function in nominally intended for use with firstcal, which returns (phase/delay) solutions
+    for antennas only.
+
+    Args:
+        gains: dictionary that contains gain solutions in the {(index,antpol): np.array} format.
+        degen_gains: Optional dictionary in the same format as gains. Gain amplitudes and phases
+            in degen_sol replace the values of sol in the degenerate subspace of redcal. If
+            left as None, average gain amplitudes will be 1 and average phase terms will be 0.
+            For logcal/lincal/omnical, putting firstcal solutions in here can help avoid structure
+            associated with phase-wrapping issues.
+        mode: 'phase' or 'complex', indicating whether the gains are passed as phases (e.g. delay
+            or phi in e^(i*phi)), or as the complex number itself.  If 'phase', only phase degeneracies
+            removed.  If 'complex', both phase and amplitude degeneracies are removed.
+    Returns:
+        new_gains: gains with degeneracy removal/replacement performed
+    """
+
+    # Check supported pol modes
+    assert pol_mode in ['1pol', '2pol', '4pol', '4pol_minV'], 'Unrecognized pol_mode: %s' % pol_mode
+    assert mode in ('phase', 'complex'), 'Unrecognized mode: %s' % mode
+    ants = gains.keys()
+    gainPols = np.array([ant[1] for ant in gains])  # gainPols is list of antpols, one per antenna
+    antpols = list(set(gainPols))
+
+    # if mode is 2pol, run as two 1pol remove degens
+    if pol_mode == '2pol':
+        pol_mode = '1pol'
+        pol0_gains = {k: v for k, v in gains.items() if k[1] == antpols[0]}
+        pol1_gains = {k: v for k, v in gains.items() if k[1] == antpols[1]}
+        new_gains = remove_degen_gains(reds, pol0_gains, degen_gains=degen_gains, mode=mode, pol_mode=pol_mode)
+        new_gains.update(remove_degen_gains(pol1_gains, degen_gains=degen_gains, mode=mode, pol_mode=pol_mode))
+        return new_gains
+
+    # Extract gain and model visibiltiy solutions
+    gainSols = np.array([gains[ant] for ant in ants])
+
+    # Build matrices for projecting gain degeneracies
+    antpos = reds_to_antpos(reds)
+    positions = np.array([antpos[ant[0]] for ant in gains])
+    if pol_mode == '1pol' or pol_mode == '4pol_minV':
+        # In 1pol and 4pol_minV, the phase degeneracies are 1 overall phase and 2 tip-tilt terms
+        # Rgains maps gain phases to degenerate parameters (either average phases or phase slopes)
+        Rgains = np.hstack((positions, np.ones((positions.shape[0], 1))))
+    else:  # pol_mode is '4pol'
+        # two columns give sums for two different polarizations
+        phasePols = np.vstack((gainPols == antpols[0], gainPols == antpols[1])).T
+        Rgains = np.hstack((positions, phasePols))
+    # Mgains is like (AtA)^-1 At in linear estimator formalism. It's a normalized estimator of degeneracies
+    Mgains = np.linalg.pinv(Rgains.T.dot(Rgains)).dot(Rgains.T)
+
+    # degenToRemove is the amount we need to move in the degenerate subspace
+    if degen_gains is not None:
+        degenGains = np.array([degen_gains[ant] for ant in ants])
+        if mode == 'phase':
+            # Fix phase terms only
+            degenToRemove = np.einsum('ij,jkl', Mgains, gainSols - degenGains)
+            gainSols -= np.einsum('ij,jkl', Rgains, degenToRemove)
+        else:  # working on complex data
+            # Fix phase terms
+            degenToRemove = np.einsum('ij,jkl', Mgains, np.angle(gainSols * np.conj(degenGains)))
+            gainSols *= np.exp(np.complex64(-1j) * np.einsum('ij,jkl', Rgains, degenToRemove))
+            # Fix abs terms: fixes the mean abs product of gains (as they appear in visibilities)
+            for pol in antpols:
+                meanSqAmplitude = np.mean([np.abs(g1 * g2) for (a1, p1), g1 in gains.items()
+                                           for (a2, p2), g2 in gains.items()
+                                           if p1 == pol and p2 == pol and a1 != a2], axis=0)
+                degenMeanSqAmplitude = np.mean([np.abs(degen_gains[k1] * degen_gains[k2]) for k1 in gains.keys()
+                                                for k2 in gains.keys()
+                                                if k1[1] == pol and k2[1] == pol and k1[0] != k2[0]], axis=0)
+                gainSols[gainPols == pol] *= (degenMeanSqAmplitude / meanSqAmplitude)**.5
+
+    # Create new solutions dictionary
+    new_gains = {ant: gainSol for ant, gainSol in zip(ants, gainSols)}
+
 class RedSol():
     '''Object for containing solutions to redundant calibraton, namely gains and
     unique-baseline visibilities, along with a variety of convenience methods.'''
@@ -433,12 +509,73 @@ class RedSol():
         Returns:
             new_sol: if not inplace, RedSol with degeneracy removal/replacement performed
         """
-        rc = RedundantCalibrator(self.reds)
-        new_sol = rc.remove_degen(self, degen_sol=degen_sol)
+        old_gains = self.gains
+        new_gains = remove_degen_gains(self.reds, old_gains, degen_gains=degen_sol, mode='complex')
         if inplace:
-            self.__init__(self.reds, gains=new_sol.gains, vis=new_sol.vis)
+            calibrate_in_place(self.vis, new_gains, old_gains=old_gains)
+            self.gains = new_gains
         else:
-            return new_sol
+            new_vis = deepcopy(vis)
+            return RedSol(self.reds, gains=new_gains, vis=new_vis)
+
+    def gain_bl(self, bl):
+        '''Return gain for baseline bl = (ai, aj).
+
+        Arguments:
+            bl: baseline to be split into antennas indexing gain.
+
+        Returns:
+            gain: gi * conj(gj)
+        '''
+        ai, aj = split_bl(bl)
+        return self.gain[ai] * np.conj(self.gain[aj])
+
+    def model(self, bl):
+        '''Return visibility model for baseline bl
+
+        Arguments:
+            bl: baseline to return model for
+
+        Returns:
+            vis: gi * conj(gj) * vis[bl]
+        '''
+        return self.gain_bl(bl) * self.vis[bl]
+
+    def calibrate(self, bl, data):
+        '''Return calibrated data for baseline bl
+
+        Arguments:
+            bl: baseline's gain to divide out
+            data: data to calibrate
+
+        Returns:
+            vis: data / (gi * conj(gj))
+        '''
+        gij = self.gain_bl(bl)
+        np.divide(data, gij, out=data, where=(gij != 0))
+        return data
+
+    def vis_from_data(self, data, wgts={}):
+        '''Performs redundant averaging of data using reds and gains stored in this RedSol object and
+           stores the result as the redundant solution.
+
+        Arguments:
+            data: DataContainer containing visibilities to redundantly average.
+            wgts: optional DataContainer weighting visibilities in averaging.
+                If not provided, it is assumed that all data are uniformly weighted.
+
+        Returns:
+            None
+        '''
+        vis = {}
+        for grp in self.reds:
+            if len(wgts) != 0:
+                vis[grp[0]] = sum([wgts.get(bl, 1) * self.calibrate(bl, data[bl]) for bl in grp])
+                wgt_sum = sum([wgts.get(bl, 1) for bl in grp])
+                np.divide(vis[grp[0]], wgt_sum, out=vis[grp[0]], where=(wgt_sum != 0))
+            else:
+                vis[grp[0]] = sum([self.calibrate(bl, data[bl]) for bl in grp])
+        self.vis = RedDataContainer(vis, reds=self.reds)
 
     def red_average(self, data, flags=None, nsamples=None, gain_flags=None):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object.
@@ -457,6 +594,7 @@ class RedSol():
             red_flags: RedDataContainer of flags on redundantly averaged data.
             red_nsamples: RedDataContainer of nsamples of that went into each redundantly averaged visibility
         '''
+        # XXX deprecate this function?
         # make copies of data, flags, and nsamples, which are then modified and downselected in place
         # if flags and/or nsamples, is not provided, create zeros or ones as appropriate
         red_data, red_flags, red_nsamples = {}, {}, {}
@@ -476,6 +614,7 @@ class RedSol():
                 calibrate_in_place(data_here, self.gains, data_flags=flags_here, cal_flags=gain_flags)
 
             # redundantly average and store in dictionary
+            # XXX does this average polarizations together?
             pos_red = list(set(bl[0:2] for bl in red))
             red_average(data_here, [pos_red], flags=flags_here, nsamples=nsamples_here, inplace=True)
             for bl in data_here:
@@ -1209,6 +1348,7 @@ class RedundantCalibrator:
             sol: dictionary of gain and visibility solutions in the {(index,antpol): np.array}
                 and {(ind1,ind2,pol): np.array} formats respectively
         """
+        # XXX only copy data that will be used in solver
         fc_data = deepcopy(data)
         calibrate_in_place(fc_data, sol0)
         ls = self._solver(linsolve.LogProductSolver, fc_data, wgts=wgts, detrend_phs=True, sparse=sparse)
@@ -1298,6 +1438,7 @@ class RedundantCalibrator:
             new_gains: gains with degeneracy removal/replacement performed
         """
 
+        # XXX use RedSol version, perhaps remove?
         # Check supported pol modes
         assert self.pol_mode in ['1pol', '2pol', '4pol', '4pol_minV'], 'Unrecognized pol_mode: %s' % self.pol_mode
         assert mode in ('phase', 'complex'), 'Unrecognized mode: %s' % mode
@@ -1378,6 +1519,7 @@ class RedundantCalibrator:
             new_sol: RedSol with degeneracy removal/replacement performed
         """
 
+        # XXX use RedSol version
         gains, vis = get_gains_and_vis_from_sol(sol)
         if degen_sol is None:
             degen_sol = {key: np.ones_like(val) for key, val in gains.items()}
@@ -1409,6 +1551,7 @@ class RedundantCalibrator:
             else:  # '4pol_minV'
                 return 2 + 1 + nPhaseSlopes  # 4pol_minV ties overall phase together, so just 1 overall phase
         else:
+            # XXX use reds_to_antpos
             dummy_data = DataContainer({bl: np.ones((1, 1), dtype=complex) for red in self.reds for bl in red})
             solver = self._solver(linsolve.LogProductSolver, dummy_data)
             return np.sum([A.shape[1] - np.linalg.matrix_rank(np.dot(np.squeeze(A).T, np.squeeze(A)))

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -341,8 +341,8 @@ def make_sol_finite(sol):
 
 
 def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1pol'):
-    """ Removes degeneracies from solutions (or replaces them with those in degen_sol).  This
-    function in nominally intended for use with firstcal, which returns (phase/delay) solutions
+    """ Removes degeneracies from gains (or replaces them with those in gains).  This
+    function is nominally intended for use with firstcal, which returns (phase/delay) solutions
     for antennas only.
 
     Args:
@@ -355,28 +355,33 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
         mode: 'phase' or 'complex', indicating whether the gains are passed as phases (e.g. delay
             or phi in e^(i*phi)), or as the complex number itself.  If 'phase', only phase degeneracies
             removed.  If 'complex', both phase and amplitude degeneracies are removed.
+        pol_mode: polarization mode of redundancies. Can be '1pol', '2pol', '4pol', or '4pol_minV'.
     Returns:
         new_gains: gains with degeneracy removal/replacement performed
     """
-
     # Check supported pol modes
-    assert pol_mode in ['1pol', '2pol', '4pol', '4pol_minV'], 'Unrecognized pol_mode: %s' % pol_mode
+    assert pol_mode in ['1pol', '2pol', '4pol', '4pol_minV'], f'Unrecognized pol_mode: {pol_mode}'
     assert mode in ('phase', 'complex'), 'Unrecognized mode: %s' % mode
+    if degen_gains is None:
+        if mode == 'phase':
+            degen_gains = {key: np.zeros_like(val) for key, val in gains.items()}
+        else:  # complex
+            degen_gains = {key: np.ones_like(val) for key, val in gains.items()}
     ants = gains.keys()
     gainPols = np.array([ant[1] for ant in gains])  # gainPols is list of antpols, one per antenna
     antpols = list(set(gainPols))
 
     # if mode is 2pol, run as two 1pol remove degens
     if pol_mode == '2pol':
-        pol_mode = '1pol'
         pol0_gains = {k: v for k, v in gains.items() if k[1] == antpols[0]}
         pol1_gains = {k: v for k, v in gains.items() if k[1] == antpols[1]}
-        new_gains = remove_degen_gains(reds, pol0_gains, degen_gains=degen_gains, mode=mode, pol_mode=pol_mode)
-        new_gains.update(remove_degen_gains(pol1_gains, degen_gains=degen_gains, mode=mode, pol_mode=pol_mode))
+        new_gains = remove_degen_gains(reds, pol0_gains, degen_gains=degen_gains, mode=mode, pol_mode='1pol')
+        new_gains.update(remove_degen_gains(reds, pol1_gains, degen_gains=degen_gains, mode=mode, pol_mode='1pol'))
         return new_gains
 
     # Extract gain and model visibiltiy solutions
     gainSols = np.array([gains[ant] for ant in ants])
+    degenGains = np.array([degen_gains[ant] for ant in ants])
 
     # Build matrices for projecting gain degeneracies
     antpos = reds_to_antpos(reds)
@@ -393,28 +398,27 @@ def remove_degen_gains(reds, gains, degen_gains=None, mode='phase', pol_mode='1p
     Mgains = np.linalg.pinv(Rgains.T.dot(Rgains)).dot(Rgains.T)
 
     # degenToRemove is the amount we need to move in the degenerate subspace
-    if degen_gains is not None:
-        degenGains = np.array([degen_gains[ant] for ant in ants])
-        if mode == 'phase':
-            # Fix phase terms only
-            degenToRemove = np.einsum('ij,jkl', Mgains, gainSols - degenGains)
-            gainSols -= np.einsum('ij,jkl', Rgains, degenToRemove)
-        else:  # working on complex data
-            # Fix phase terms
-            degenToRemove = np.einsum('ij,jkl', Mgains, np.angle(gainSols * np.conj(degenGains)))
-            gainSols *= np.exp(np.complex64(-1j) * np.einsum('ij,jkl', Rgains, degenToRemove))
-            # Fix abs terms: fixes the mean abs product of gains (as they appear in visibilities)
-            for pol in antpols:
-                meanSqAmplitude = np.mean([np.abs(g1 * g2) for (a1, p1), g1 in gains.items()
-                                           for (a2, p2), g2 in gains.items()
-                                           if p1 == pol and p2 == pol and a1 != a2], axis=0)
-                degenMeanSqAmplitude = np.mean([np.abs(degen_gains[k1] * degen_gains[k2]) for k1 in gains.keys()
-                                                for k2 in gains.keys()
-                                                if k1[1] == pol and k2[1] == pol and k1[0] != k2[0]], axis=0)
-                gainSols[gainPols == pol] *= (degenMeanSqAmplitude / meanSqAmplitude)**.5
+    if mode == 'phase':
+        # Fix phase terms only
+        degenToRemove = np.einsum('ij,jkl', Mgains, gainSols - degenGains)
+        gainSols -= np.einsum('ij,jkl', Rgains, degenToRemove)
+    else:  # working on complex data
+        # Fix phase terms
+        degenToRemove = np.einsum('ij,jkl', Mgains, np.angle(gainSols * np.conj(degenGains)))
+        gainSols *= np.exp(np.complex64(-1j) * np.einsum('ij,jkl', Rgains, degenToRemove))
+        # Fix abs terms: fixes the mean abs product of gains (as they appear in visibilities)
+        for pol in antpols:
+            meanSqAmplitude = np.mean([np.abs(g1 * g2) for (a1, p1), g1 in gains.items()
+                                       for (a2, p2), g2 in gains.items()
+                                       if p1 == pol and p2 == pol and a1 != a2], axis=0)
+            degenMeanSqAmplitude = np.mean([np.abs(degen_gains[k1] * degen_gains[k2]) for k1 in gains.keys()
+                                            for k2 in gains.keys()
+                                            if k1[1] == pol and k2[1] == pol and k1[0] != k2[0]], axis=0)
+            gainSols[gainPols == pol] *= (degenMeanSqAmplitude / meanSqAmplitude)**.5
 
     # Create new solutions dictionary
     new_gains = {ant: gainSol for ant, gainSol in zip(ants, gainSols)}
+    return new_gains
 
 
 class RedSol():

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -529,7 +529,7 @@ class RedSol():
         '''Return gain for baseline bl = (ai, aj).
 
         Arguments:
-            bl: baseline to be split into antennas indexing gain.
+            bl: tuple, baseline to be split into antennas indexing gain.
 
         Returns:
             gain: gi * conj(gj)
@@ -541,7 +541,7 @@ class RedSol():
         '''Return visibility data model (gain * vissol) for baseline bl
 
         Arguments:
-            bl: baseline to return model for
+            bl: tuple, baseline to return model for
 
         Returns:
             vis: gi * conj(gj) * vis[bl]
@@ -552,8 +552,8 @@ class RedSol():
         '''Return calibrated data for baseline bl
 
         Arguments:
-            bl: baseline's gain to divide out
-            data: data to calibrate
+            bl: tuple, baseline from which to divide out gains
+            data: numpy array of data to calibrate
 
         Returns:
             vis: data / (gi * conj(gj))

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1039,7 +1039,6 @@ class RedundantCalibrator:
             check_redundancy: if True, raise an error if the array is not redundantly calibratable,
                 even when allowing for an arbitrary number of phase slope degeneracies.
         """
-
         self._set_reds(reds)
         self.pol_mode = parse_pol_mode(self.reds)
 
@@ -1299,8 +1298,7 @@ class RedundantCalibrator:
             sol: dictionary of gain and visibility solutions in the {(index,antpol): np.array}
                 and {(ind1,ind2,pol): np.array} formats respectively
         """
-        # XXX only copy data that will be used in solver
-        fc_data = deepcopy(data)
+        fc_data = {bl: np.array(data[bl]) for red in self.reds for bl in red}
         calibrate_in_place(fc_data, sol0)
         ls = self._solver(linsolve.LogProductSolver, fc_data, wgts=wgts, detrend_phs=True, sparse=sparse)
         sol = ls.solve(mode=mode)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -520,7 +520,8 @@ class RedSol():
             calibrate_in_place(self.vis, new_gains, old_gains=old_gains)
             self.gains = new_gains
         else:
-            new_vis = deepcopy(vis)
+            new_vis = deepcopy(self.vis)
+            calibrate_in_place(new_vis, new_gains, old_gains=old_gains)
             return RedSol(self.reds, gains=new_gains, vis=new_vis)
 
     def gain_bl(self, bl):

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -561,8 +561,7 @@ class RedSol():
             vis: data / (gi * conj(gj))
         '''
         gij = self.gain_bl(bl)
-        np.divide(data, gij, out=data, where=(gij != 0))
-        return data
+        return np.where((gij != 0), data / gij, data)
 
     def get_vis_from_data(self, data, wgts={}):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object and

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -563,7 +563,7 @@ class RedSol():
         gij = self.gain_bl(bl)
         return np.where((gij != 0), data / gij, data)
 
-    def get_vis_from_data(self, data, wgts={}):
+    def set_vis_from_data(self, data, wgts={}):
         '''Performs redundant averaging of data using reds and gains stored in this RedSol object and
            stores the result as the redundant solution.
 

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -393,12 +393,18 @@ class TestRedSol(object):
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
         info = om.RedundantCalibrator(reds)
         gains, true_vis, d = sim_red_data(reds, gain_scatter=.05)
-        w = dict([(k, 1.) for k in d.keys()])
+
         meta, sol = info.logcal(d)
         sol = info.remove_degen(sol, degen_sol=dict(list(gains.items()) + list(true_vis.items())))
         for ant in gains:
             np.testing.assert_array_almost_equal(gains[ant], sol.gains[ant])
+        # try without weights
         sol.get_vis_from_data(DataContainer(d))
+        for red in reds:
+            for bl in red:
+                np.testing.assert_array_almost_equal(true_vis[red[0]], sol.vis[bl])
+        # try with weights
+        sol.get_vis_from_data(DataContainer(d), wgts={bl: 1.0 + i for i, bl in enumerate(d)})
         for red in reds:
             for bl in red:
                 np.testing.assert_array_almost_equal(true_vis[red[0]], sol.vis[bl])

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -387,7 +387,7 @@ class TestRedSol(object):
         assert rs[1, 'Jee'][0, 0] == 1
         assert rs[0, 1, 'ee'][0, 0] == 0
 
-    def test_red_average(self):
+    def test_get_vis_from_data(self):
         NANTS = 18
         antpos = linear_array(NANTS)
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
@@ -396,12 +396,12 @@ class TestRedSol(object):
         w = dict([(k, 1.) for k in d.keys()])
         meta, sol = info.logcal(d)
         sol = info.remove_degen(sol, degen_sol=dict(list(gains.items()) + list(true_vis.items())))
-        red_d, red_f, red_ns = sol.red_average(DataContainer(d))
+        for ant in gains:
+            np.testing.assert_array_almost_equal(gains[ant], sol.gains[ant])
+        sol.get_vis_from_data(DataContainer(d))
         for red in reds:
             for bl in red:
-                np.testing.assert_array_almost_equal(true_vis[red[0]], red_d[bl])
-                np.testing.assert_array_equal(False, red_f[bl])
-                np.testing.assert_array_equal(len(red), red_ns[bl])
+                np.testing.assert_array_almost_equal(true_vis[red[0]], sol.vis[bl])
 
     def test_remove_degen(self):
         NANTS = 18

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -387,7 +387,7 @@ class TestRedSol(object):
         assert rs[1, 'Jee'][0, 0] == 1
         assert rs[0, 1, 'ee'][0, 0] == 0
 
-    def test_get_vis_from_data(self):
+    def test_set_vis_from_data(self):
         NANTS = 18
         antpos = linear_array(NANTS)
         reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
@@ -399,12 +399,12 @@ class TestRedSol(object):
         for ant in gains:
             np.testing.assert_array_almost_equal(gains[ant], sol.gains[ant])
         # try without weights
-        sol.get_vis_from_data(DataContainer(d))
+        sol.set_vis_from_data(DataContainer(d))
         for red in reds:
             for bl in red:
                 np.testing.assert_array_almost_equal(true_vis[red[0]], sol.vis[bl])
         # try with weights
-        sol.get_vis_from_data(DataContainer(d), wgts={bl: 1.0 + i for i, bl in enumerate(d)})
+        sol.set_vis_from_data(DataContainer(d), wgts={bl: 1.0 + i for i, bl in enumerate(d)})
         for red in reds:
             for bl in red:
                 np.testing.assert_array_almost_equal(true_vis[red[0]], sol.vis[bl])

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -452,6 +452,14 @@ class TestRedSol(object):
         assert items[2][0] == (0, 1, 'ee')
         np.testing.assert_array_equal(items[2][1], 3 * np.ones((1, 1)))
 
+    def test_gain_model_calibrate_bl(self):
+        antpos = linear_array(3)
+        reds = om.get_reds(antpos, pols=['ee'], pol_mode='1pol')
+        rs = om.RedSol(reds, gains={(0, 'Jee'): np.ones((1, 1)), (1, 'Jee'): 2j * np.ones((1, 1))}, vis={(0, 1, 'ee'): 3 * np.ones((1, 1))})
+        assert rs.gain_bl((0, 1, 'ee'))[0, 0] == -2.0j
+        assert rs.model_bl((0, 1, 'ee'))[0, 0] == -6.0j
+        assert rs.calibrate_bl((0, 1, 'ee'), 10j * np.ones((1, 1)))[0, 0] == -5
+
     def test_chisq(self):
         NANTS = 18
         antpos = linear_array(NANTS)

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -851,6 +851,10 @@ class TestRedundantCalibrator(object):
         for k in dlys:
             np.testing.assert_almost_equal(dlys[k], true_dlys[k], decimal=10)
 
+        rc.pol_mode = 'unrecognized_pol_mode'
+        with pytest.raises(AssertionError):
+            rc.remove_degen_gains(dlys)
+
     def test_remove_degen_firstcal_2D(self):
         pol = 'xx'
         xhat = np.array([1., 0, 0])
@@ -930,10 +934,6 @@ class TestRedundantCalibrator(object):
                 np.testing.assert_almost_equal(val, gains[key], decimal=10)
             if len(key) == 3:
                 np.testing.assert_almost_equal(val, true_vis[key], decimal=10)
-
-        rc.pol_mode = 'unrecognized_pol_mode'
-        with pytest.raises(AssertionError):
-            sol_rd = rc.remove_degen(sol)
 
     def test_lincal_hex_end_to_end_4pol_with_remove_degen_and_firstcal(self):
         antpos = hex_array(3, split_core=False, outriggers=0)

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -967,7 +967,7 @@ def chisq(data, model, data_wgts=None, gains=None, gain_flags=None, split_by_ant
             if gain_flags is not None:
                 wgts = data_wgts[bl] * ~(gain_flags[ant1]) * ~(gain_flags[ant2])
             else:
-                wgts = copy.deepcopy(data_wgts[bl])
+                wgts = data_wgts[bl]
 
             # calculate chi^2
             chisq_here = np.asarray(np.abs(model_here - data[bl]) ** 2 * wgts, dtype=np.float64)


### PR DESCRIPTION
This PR builds on @AaronParsons's first pass in f8652c6f50dd8ff1d78c9d88789cbec942b01291 to add modeling functionality to the `RedSol` object. It also:

- Moves `remove_degen_gains to the top level of redcal.py, which `RedSol.remove_degen` calls. 
- Makes `RedundantCalibrator.remove_degen_gains` call `remove_degen_gains` under the hood.
- Makes `RedundantCalibrator.remove_degen` call `RedSol.remove_degen` under the hood.
- Avoids the creation of unnecessary arrays in utils.chisq
- Avoids unnecessary copying in logcal
- Updates unit tests as appropriate.