### PR TITLE
Make redcal_run_write_results write omnical visibilities with the same baselines for both pols

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1887,8 +1887,13 @@ def _redcal_run_write_results(cal, hd, firstcal_filename, omnical_filename, omni
         if verbose:
             print('Now saving omnical visibilities to', os.path.join(outdir, omnivis_filename))
         hd_out = HERAData(hd.filepaths[0], upsample=hd.upsample, downsample=hd.downsample, filetype=hd.filetype)
-        hd_out.read(bls=list(cal['v_omnical'].keys()))
-        hd_out.update(data=cal['v_omnical'], flags=cal['vf_omnical'], nsamples=cal['vns_omnical'])
+        d, f, n = hd_out.read(bls=list(set([k[0:2] for k in cal['v_omnical']])), polarizations=vispols)
+        out_data, out_flags, out_nsamples = {}, {}, {}
+        for bl in d:
+            out_data[bl] = (cal['v_omnical'][bl] if bl in cal['v_omnical'] else np.zeros_like(d[bl]))
+            out_flags[bl] = (cal['vf_omnical'][bl] if bl in cal['vf_omnical'] else np.ones_like(f[bl]))
+            out_nsamples[bl] = (cal['vns_omnical'][bl] if bl in cal['vns_omnical'] else np.zeros_like(n[bl]))
+        hd_out.update(data=out_data, flags=out_flags, nsamples=out_nsamples)
         hd_out.history += utils.history_string(add_to_history)
         hd_out.write_uvh5(os.path.join(outdir, omnivis_filename), clobber=True)
 

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1890,9 +1890,9 @@ def _redcal_run_write_results(cal, hd, firstcal_filename, omnical_filename, omni
         d, f, n = hd_out.read(bls=list(set([k[0:2] for k in cal['v_omnical']])), polarizations=vispols)
         out_data, out_flags, out_nsamples = {}, {}, {}
         for bl in d:
-            out_data[bl] = (cal['v_omnical'][bl] if bl in cal['v_omnical'] else np.zeros_like(d[bl]))
-            out_flags[bl] = (cal['vf_omnical'][bl] if bl in cal['vf_omnical'] else np.ones_like(f[bl]))
-            out_nsamples[bl] = (cal['vns_omnical'][bl] if bl in cal['vns_omnical'] else np.zeros_like(n[bl]))
+            out_data[bl] = cal['v_omnical'][bl] if bl in cal['v_omnical'] else np.zeros_like(d[bl])
+            out_flags[bl] = cal['vf_omnical'][bl] if bl in cal['vf_omnical'] else np.ones_like(f[bl])
+            out_nsamples[bl] = cal['vns_omnical'][bl] if bl in cal['vns_omnical'] else np.zeros_like(n[bl])
         hd_out.update(data=out_data, flags=out_flags, nsamples=out_nsamples)
         hd_out.history += utils.history_string(add_to_history)
         hd_out.write_uvh5(os.path.join(outdir, omnivis_filename), clobber=True)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -822,11 +822,13 @@ class OmnicalSolver(linsolve.LinProductSolver):
             if verbose:
                 print('    <CHISQ> = %f, <CONV> = %f, CNT = %d', (np.mean(chisq), np.mean(conv), update[0].size))
 
-def _wrap_phs(phs, wrap_pnt=np.pi/2):
+
+def _wrap_phs(phs, wrap_pnt=(np.pi / 2)):
     '''Adjust phase wrap point to be [-wrap_pnt, 2pi-wrap_pnt)'''
     return (phs + wrap_pnt) % (2 * np.pi) - wrap_pnt
 
-def _flip_frac(offsets, flipped=set(), flip_pnt=np.pi/2):
+
+def _flip_frac(offsets, flipped=set(), flip_pnt=(np.pi / 2)):
     '''Calculate the fraction of (bl1, bl2) pairings an antenna is involved
     in which have large phase offsets.'''
     cnt = {}
@@ -841,7 +843,8 @@ def _flip_frac(offsets, flipped=set(), flip_pnt=np.pi/2):
     flip_frac = [(k, v / tot[k]) for k, v in cnt.items()]
     return flip_frac
 
-def _find_flipped(offsets, flip_pnt=np.pi/2, maxiter=100):
+
+def _find_flipped(offsets, flip_pnt=(np.pi / 2), maxiter=100):
     '''Given a dict of (bl1, bl2) keys and phase offset vals, identify
     antennas which are likely to have a np.pi phase offset.'''
     flipped = set()
@@ -859,7 +862,8 @@ def _find_flipped(offsets, flip_pnt=np.pi/2, maxiter=100):
             break
     return flipped
 
-def _firstcal_align_bls(bls, freqs, data, norm=True, wrap_pnt=np.pi/2):
+
+def _firstcal_align_bls(bls, freqs, data, norm=True, wrap_pnt=(np.pi / 2)):
     '''Given a redundant group of bls, find per-baseline dly/off params that
     bring them into phase alignment using hierarchical pairing.'''
     fftfreqs = np.fft.fftfreq(freqs.shape[-1], np.median(np.diff(freqs)))
@@ -1023,7 +1027,7 @@ class RedundantCalibrator:
             ubl_sols[blgrp[0]] = np.average(d_gp, axis=0)  # XXX add option for median here?
         return ubl_sols
 
-    def firstcal(self, data, freqs, maxiter=100, sparse=False, mode='default', flip_pnt=np.pi/2):
+    def firstcal(self, data, freqs, maxiter=100, sparse=False, mode='default', flip_pnt=(np.pi / 2)):
         """Solve for a calibration solution parameterized by a single delay and phase offset
         per antenna using the phase difference between nominally redundant measurements.
         Delays are solved in a single iteration, but phase offsets are solved for
@@ -1851,7 +1855,7 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, e
 
 
 def _redcal_run_write_results(cal, hd, firstcal_filename, omnical_filename, omnivis_filename,
-                              meta_filename, outdir, clobber=False, verbose=False, add_to_history=''):
+                              meta_filename, outdir, vispols=None, clobber=False, verbose=False, add_to_history=''):
     '''Helper function for writing the results of redcal_run.'''
     # get antnums2antnames dictionary
     antnums2antnames = dict(zip(hd.antenna_numbers, hd.antenna_names))

--- a/hera_cal/tests/test_redcal.py
+++ b/hera_cal/tests/test_redcal.py
@@ -1816,7 +1816,7 @@ class TestRunMethods(object):
 
             hd = io.HERAData(os.path.splitext(input_data)[0] + prefix + '.omni_vis.uvh5')
             data, flags, nsamples = hd.read()
-            for bl in data.keys():
+            for bl in cal_here['v_omnical']:
                 np.testing.assert_array_almost_equal(data[bl], cal_here['v_omnical'][bl])
                 np.testing.assert_array_almost_equal(flags[bl], cal_here['vf_omnical'][bl])
                 np.testing.assert_array_almost_equal(nsamples[bl], cal_here['vns_omnical'][bl])


### PR DESCRIPTION
This was breaking RTP when most of one polarization was flagged but not the other.

Now missing unique baseline visibilities are in the output file, but flagged (with zero nsamples).