### PR TITLE
Make amplitude calibration optional in `post_redcal_abscal`

### DIFF
--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -1598,6 +1598,14 @@ class Test_Post_Redcal_Abscal_Run(object):
             assert delta_gains[k].shape == (3, rc_gains[k].shape[1])
             assert delta_gains[k].dtype == complex
 
+        # try running without amplitude solvers
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            delta_gains = abscal.post_redcal_abscal(model, copy.deepcopy(data), wgts, rc_flags_subset, verbose=False,
+                                                    use_abs_amp_logcal=False, use_abs_amp_lincal=False)
+        for k in delta_gains:
+            np.testing.assert_array_equal(np.abs(delta_gains[k]), 1)
+
     def test_post_redcal_abscal_run_units_warning(self, tmpdir):
         tmp_path = tmpdir.strpath
         calfile_units = os.path.join(tmp_path, 'redcal_units.calfits')

--- a/hera_cal/tests/test_abscal.py
+++ b/hera_cal/tests/test_abscal.py
@@ -1604,7 +1604,7 @@ class Test_Post_Redcal_Abscal_Run(object):
             delta_gains = abscal.post_redcal_abscal(model, copy.deepcopy(data), wgts, rc_flags_subset, verbose=False,
                                                     use_abs_amp_logcal=False, use_abs_amp_lincal=False)
         for k in delta_gains:
-            np.testing.assert_array_equal(np.abs(delta_gains[k]), 1)
+            np.testing.assert_array_almost_equal(np.abs(delta_gains[k]), 1)
 
     def test_post_redcal_abscal_run_units_warning(self, tmpdir):
         tmp_path = tmpdir.strpath


### PR DESCRIPTION
This PR makes it possible to skip amplitude calibration entirely in `post_redcal_abscal`. This is useful for doing amplitude calibration with just autos completely separately from phase calibration with crosses. 