### PR TITLE
Remove deprecated numpy types

### DIFF
--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -8,7 +8,7 @@ dependencies:
   - astropy
   - h5py
   - hdf5plugin
-  - numpy>=1.24.1
+  - numpy>=1.24
   - pytest
   - scipy
   - scikit-learn

--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -4,11 +4,11 @@ channels:
   - defaults
 dependencies:
   - pip
-  - aipy>=3.0.0rc2
-  - astropy>=5.0.4
+  #- aipy>=3.0.0rc2
+  - astropy
   - h5py
   - hdf5plugin
-  - numpy>=1.23
+  - numpy>=1.24.1
   - pytest
   - scipy
   - scikit-learn
@@ -20,10 +20,11 @@ dependencies:
   - future
   - pytest-cov
   - coveralls
-  #- pyuvdata<2.2.0
+  - pyuvdata==2.2.12
 
   - pip:
-    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
+    # - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata
+    - git+https://github.com/HERA-Team/aipy
     - git+https://github.com/HERA-Team/hera_filters
     - git+https://github.com/HERA-Team/linsolve
     - git+https://github.com/HERA-Team/hera_qm

--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -1885,7 +1885,7 @@ def match_red_baselines(model, model_antpos, data, data_antpos, tol=1.0, verbose
     new_model = odict()
     for i, bl in enumerate(model_bls):
         # compre bl to all model_bls
-        comparison = np.array(list(map(lambda mbl: bl == mbl, data_bls)), np.str)
+        comparison = np.array(list(map(lambda mbl: bl == mbl, data_bls)), str)
 
         # get matches
         matches = np.where((comparison == 'True') | (comparison == 'conjugated'))[0]

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -45,7 +45,7 @@ class DataContainer:
             self.__dict__.update(data.__dict__)
         else:
             self._data = odict()
-            if np.all([isinstance(k, (str, np.str)) for k in data.keys()]):  # Nested POL:{antpairs}
+            if np.all([isinstance(k, str) for k in data.keys()]):  # Nested POL:{antpairs}
                 for pol in data.keys():
                     for antpair in data[pol]:
                         self._data[make_bl(antpair, pol)] = data[pol][antpair]

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -325,7 +325,7 @@ def read_hera_calfits(filenames, ants=None, pols=None,
         ants = set((ant,) for ant in info['ants'])
         ants = set(ant + (p,) for ant in ants for p in pols)
     else:
-        ants = set((ant,) if type(ant) in (int, np.int, np.int64) else ant for ant in ants)
+        ants = set((ant,) if np.issubdtype(type(ant), np.integer) else ant for ant in ants)
         # if length 1 ants are passed in, add on polarizations
         ants_len1 = set(ant for ant in ants if len(ant) == 1)
         if len(ants_len1) > 0:

--- a/hera_cal/tests/test_reflections.py
+++ b/hera_cal/tests/test_reflections.py
@@ -28,7 +28,7 @@ def simulate_reflections(uvd=None, camp=1e-2, cdelay=155, cphase=2, add_cable=Tr
         uvd.read(os.path.join(DATA_PATH, 'PyGSM_Jy_downselect.uvh5'),
                  run_check_acceptability=False)
     else:
-        if isinstance(uvd, (str, np.str)):
+        if isinstance(uvd, str):
             _uvd = UVData()
             _uvd.read(uvd)
             uvd = _uvd

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_args = {
         'hdf5plugin',
         'astropy',
         'astropy-healpix',
-        'pyuvdata',
+        'pyuvdata<=2.2.12',
         'linsolve',
         'hera_qm',
         'scikit-learn',
@@ -61,7 +61,7 @@ setup_args = {
     ],
     'extras_require': {
         "all": [
-            'aipy>=3.0'
+            'aipy @ git+https://github.com/hera-team/aipy'
         ]
     },
     'zip_safe': False,


### PR DESCRIPTION
This PR removes types like np.int and np.float and np.str that were deprecated in numpy 1.24: https://numpy.org/devdocs/release/1.24.0-notes.html

This PR relies on https://github.com/HERA-Team/hera_filters/pull/7

This PR also fixes the pyuvdata version to 2.12.2 until we can fix the phasing issue (see #851) and moves to using the newest version of aipy on github, since the version on pypi is out of date