### PR TITLE
Faster slice func

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -583,9 +583,15 @@ class HERAData(UVData):
             polnum: i for i, polnum in enumerate(self.polarization_array)
         }
         pols = [polnum2str(polnum, x_orientation=self.x_orientation) for polnum in self.polarization_array]
-        self._polstr_indices = {
-            pol: self._polnum_indices[polstr2num(pol, x_orientation=self.x_orientation)] for pol in pols
-        }
+        self._polstr_indices = {}
+        # Add upper-case indices as well, so we don't need to use .lower() on input
+        # keys (for which there can be many tens of thousands).
+        for pol in pols:
+            indx = self._polnum_indices[polstr2num(pol, x_orientation=self.x_orientation)]
+            self._polstr_indices[pol.lower()] = indx
+            self._polstr_indices[pol.upper()] = indx
+            self._polstr_indices[pol[0].upper() + pol[1].lower()] = indx
+            self._polstr_indices[pol[0].lower() + pol[1].upper()] = indx
 
     def _get_slice(self, data_array, key):
         '''Return a copy of the Nint by Nfreq waterfall or waterfalls for a given key. Abstracts

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -584,7 +584,7 @@ class HERAData(UVData):
         }
         pols = [polnum2str(polnum, x_orientation=self.x_orientation) for polnum in self.polarization_array]
         self._polstr_indices = {
-            pol: self._polnum_indices[polstr2num(pol)] for pol in pols
+            pol: self._polnum_indices[polstr2num(pol, x_orientation=self.x_orientation)] for pol in pols
         }
 
     def _get_slice(self, data_array, key):

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -590,8 +590,7 @@ class HERAData(UVData):
             indx = self._polnum_indices[polstr2num(pol, x_orientation=self.x_orientation)]
             self._polstr_indices[pol.lower()] = indx
             self._polstr_indices[pol.upper()] = indx
-            self._polstr_indices[pol[0].upper() + pol[1].lower()] = indx
-            self._polstr_indices[pol[0].lower() + pol[1].upper()] = indx
+
 
     def _get_slice(self, data_array, key):
         '''Return a copy of the Nint by Nfreq waterfall or waterfalls for a given key. Abstracts
@@ -611,11 +610,29 @@ class HERAData(UVData):
             return {pol: self._get_slice(data_array, key + (pol,)) for pol in pols}
         elif len(key) == 3:  # asking for bl-pol
             try:
-                return np.array(data_array[self._blt_slices[tuple(key[:2])], :,
-                                           self._polstr_indices[key[2]]])
+                return np.array(
+                    data_array[
+                        self._blt_slices[tuple(key[:2])], :,
+                        self._polstr_indices.get(
+                            key[2],
+                            self._polnum_indices[
+                                polstr2num(key[2], x_orientation=self.x_orientation)
+                            ]
+                        )
+                    ]
+                )
             except KeyError:
-                return np.conj(data_array[self._blt_slices[tuple(key[1::-1])], :,
-                                          self._polstr_indices[conj_pol(key[2])]])
+                return np.conj(
+                    data_array[
+                        self._blt_slices[tuple(key[1::-1])], :,
+                        self._polstr_indices.get(
+                            conj_pol(key[2]),
+                            self._polnum_indices[
+                                polstr2num(conj_pol(key[2]), x_orientation=self.x_orientation)
+                            ]
+                        )
+                    ]
+                )
         else:
             raise KeyError('Unrecognized key type for slicing data.')
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -579,9 +579,13 @@ class HERAData(UVData):
     def _determine_pol_indexing(self):
         '''Determine the mapping between polnums and indices
         in the polarization axis of the data_array.'''
-        self._polnum_indices = {}
-        for i, polnum in enumerate(self.polarization_array):
-            self._polnum_indices[polnum] = i
+        self._polnum_indices = {
+            polnum: i for i, polnum in enumerate(self.polarization_array)
+        }
+        pols = [polnum2str(polnum, x_orientation=self.x_orientation) for polnum in self.polarization_array]
+        self._polstr_indices = {
+            pol: self._polnum_indices[polstr2num(pol)] for pol in pols
+        }
 
     def _get_slice(self, data_array, key):
         '''Return a copy of the Nint by Nfreq waterfall or waterfalls for a given key. Abstracts
@@ -601,11 +605,11 @@ class HERAData(UVData):
             return {pol: self._get_slice(data_array, key + (pol,)) for pol in pols}
         elif len(key) == 3:  # asking for bl-pol
             try:
-                return np.array(data_array[self._blt_slices[tuple(key[0:2])], :,
-                                           self._polnum_indices[polstr2num(key[2], x_orientation=self.x_orientation)]])
+                return np.array(data_array[self._blt_slices[tuple(key[:2])], :,
+                                           self._polstr_indices[key[2]]])
             except KeyError:
                 return np.conj(data_array[self._blt_slices[tuple(key[1::-1])], :,
-                                          self._polnum_indices[polstr2num(conj_pol(key[2]), x_orientation=self.x_orientation)]])
+                                          self._polstr_indices[conj_pol(key[2])]])
         else:
             raise KeyError('Unrecognized key type for slicing data.')
 


### PR DESCRIPTION
This caches the result of `polstr2num` for a particular HERAData object because I was finding that when reading a single file from H6C, when getting the slices for each baseline, it took about 12 seconds, or ~20% of the total read time. When LST binning, this can be an even higher percentage because you might only read one out of the two times -- decreasing actual read time but not decreasing the number of baselines that need to be indexed.

This PR makes the indexing time essentially negligible.

FWIW, on a single-shot read (the above was done reading 350 baselines at a time, similar to what would be done in a real pipeline), about 1/3 of the read time is taken in doing copies of the data into the datacontainers. I wonder if it would be useful to have a non-copying option.