### PR TITLE
perf: don't discard imag autos Nbls times

### DIFF
--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -1229,10 +1229,11 @@ class VisClean(object):
                     resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice]) | skipped
                 else:
                     resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice])
-                # loop through resids, model, and data and make sure everything is real.
-                discard_autocorr_imag(filtered_model)
-                discard_autocorr_imag(filtered_resid)
-                discard_autocorr_imag(filtered_data)
+        
+        # loop through resids, model, and data and make sure everything is real.
+        discard_autocorr_imag(filtered_model)
+        discard_autocorr_imag(filtered_resid)
+        discard_autocorr_imag(filtered_data)
 
         if hasattr(data, 'times'):
             filtered_data.times = data.times


### PR DESCRIPTION
Un-indents the discard autocorr imag calls so they're not run for every baseline.

Interesting fact: I found that these three lines were taking >75% of the total time for doing the delay filter on H6C data.