### PR TITLE
Add line_profiler to the test yaml to fix external tests on pyuvdata

### DIFF
--- a/ci/hera_cal_tests.yml
+++ b/ci/hera_cal_tests.yml
@@ -20,6 +20,7 @@ dependencies:
   - future
   - pytest-cov
   - coveralls
+  - line_profiler
   # - pyuvdata==2.2.12
 
   - pip:


### PR DESCRIPTION
They are required in setup.py, so they should be in the test yaml. We use this yaml in pyuvdata and then we install the hera_cal package using `--no-deps` so that pip cannot modify the packages installed by conda. So we have import errors in the tests because this package isn't present.