### PR TITLE
Fix some errors with coming pyuvdata changes.

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -185,7 +185,7 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
             df.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
                                    filled_outfilename=filled_outfilename, partial_write=Nbls_per_load < len(baseline_list),
                                    clobber=clobber, add_to_history=add_to_history,
-                                   extra_attrs={'Nfreqs': df.Nfreqs, 'freq_array': df.hd.freq_array, 'channel_width': df.hd.channel_width})
+                                   extra_attrs={'Nfreqs': df.Nfreqs, 'freq_array': df.hd.freq_array, 'channel_width': df.hd.channel_width,  'flex_spw_id_array': df.hd.flex_spw_id_array})
             df.hd.data_array = None  # this forces a reload in the next loop
 
 

--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -1487,7 +1487,7 @@ def load_tophat_frfilter_and_write(datafile_list, case, baseline_list=None, calf
             frfil.write_filtered_data(res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
                                       filled_outfilename=filled_outfilename, partial_write=Nbls_per_load < len(baseline_list),
                                       clobber=clobber, add_to_history=add_to_history,
-                                      extra_attrs={'Nfreqs': frfil.hd.Nfreqs, 'freq_array': frfil.hd.freq_array, 'channel_width': frfil.hd.channel_width})
+                                      extra_attrs={'Nfreqs': frfil.hd.Nfreqs, 'freq_array': frfil.hd.freq_array, 'channel_width': frfil.hd.channel_width,  'flex_spw_id_array': frfil.hd.flex_spw_id_array})
             frfil.hd.data_array = None  # this forces a reload in the next loop
 
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -235,6 +235,8 @@ class HERACal(UVCal):
             writer.freq_array = freqs_filled.flatten()
             writer.Nfreqs = len(freqs_filled)
             writer.channel_width = np.median(writer.channel_width) * np.ones_like(writer.freq_array)
+            if hasattr(writer, "flex_spw_id_array") and writer.flex_spw_id_array is not None:
+                writer.flex_spw_id_array = np.full(writer.Nfreqs, writer.spw_array[0], dtype=int)
             # insert original flags and gains into appropriate channels.
             new_gains = np.ones((writer.Nants_data, writer.Nfreqs, writer.Ntimes, writer.Njones), dtype=complex)
             new_gains[:, ~inserted, :, :] = writer.gain_array


### PR DESCRIPTION
External hera_cal tests are failing on a pyuvdata PR where we are starting to always have the `flex_spw_id_array` on UVData, UVCal and UVFlag objects. It's not yet required, but that PR is initializing it when we create objects from files.

This PR fixes some bugs in selection operations in hera_cal that are not currently handling that parameter it if it is set, resulting in it being the wrong size after the operation.