### PR TITLE
feat: allow setting freq_scale to zero to avoid smoothing

### DIFF
--- a/scripts/smooth_cal_run.py
+++ b/scripts/smooth_cal_run.py
@@ -38,11 +38,18 @@ def run():
                                 chan_blacklists=a.chan_blacklists, pick_refant=a.pick_refant, freq_threshold=a.freq_threshold,
                                 time_threshold=a.time_threshold, ant_threshold=a.ant_threshold, verbose=a.verbose)
         if a.axis == 'both':
-            cs.time_freq_2D_filter(freq_scale=a.freq_scale, time_scale=a.time_scale, tol=a.tol,
-                                filter_mode=a.filter_mode, window=a.window, maxiter=a.maxiter, method=a.method, **filter_kwargs)
-        else:
+            if a.freq_scale > 0 and a.time_scale > 0:
+                cs.time_freq_2D_filter(freq_scale=a.freq_scale, time_scale=a.time_scale, tol=a.tol,
+                                    filter_mode=a.filter_mode, window=a.window, maxiter=a.maxiter, method=a.method, **filter_kwargs)
+        elif a.freq_scale > 0:
             cs.filter_1d(filter_scale=a.freq_scale, tol=a.tol, skip_wgt=a.skip_wgt, mode=a.method, ax=a.axis,
                         **filter_kwargs)
+        else:
+            warnings.warn(
+                "No smoothing performed, but files still being written. Set freq_scale "
+                "to a positive value to smooth in frequency."
+            )
+            
         cs.write_smoothed_cal(output_replace=(a.infile_replace, a.outfile_replace),
                             add_to_history=' '.join(sys.argv), clobber=a.clobber)
     else:


### PR DESCRIPTION
This just makes it possible to set `time_scale` and/or `freq_scale` to zero to avoid actually doing smoothing. While this is maybe a little counter-intuitive, it makes it easier to have pipelines with a `CAL_SMOOTH` step where the refant is chosen, and `.smooth.calfits` files are written, but without actually doing smoothing. 