### PR TITLE
Improve the speed of `smoothcal.solve_2d_DPSS` by adding additional filtering options in `nucal._linear_fit`

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -120,10 +120,14 @@ def solve_2D_DPSS(gains, weights, time_filters, freq_filters, method="pinv", cac
             obtained from hera_cal.smooth_cal.dpss_filters
         freq_filters: DPSS filtering vectors along the frequency axis, (Nfreqs, N_freq_vectors)
             obtained from hera_cal.smooth_cal.dpss_filters
-        method: method to use for solving the linear least squares problem. Options are 'pinv', 'lstsq', 'lu_solve'.
+        method: method to use for solving the linear least squares problem. Options are 'pinv', 'lstsq', 'lu_solve', and 'solve'.
+            'pinv' uses np.linalg.pinv to compute the least squares solution and tends to be the most reliable. 'lu_solve'
+            uses scipy.linalg.lu_solve to compute the least squares solution and tends to be the fastest. 
+            'solve' uses np.linalg.solve and 'lstsq' uses np.linalg.lstsq and have comparable results.
         cached_input: Matrix of (X^T W X)^{-1} for the input DPSS filters and weights. Useful for filtering
             many gain grids with similar flagging patterns. np.ndarray of shape (N_time_vectors * N_freq_vectors,
-            N_time_vectors * N_freq_vectors)
+            N_time_vectors * N_freq_vectors). Can be obtained using the 'cached_output' return value from a
+            previous call to this function.
         XTXinv: Matrix of (X^T W X)^{-1} for the input DPSS filters and weights. 
             Warning: This is deprecated and will be removed in a future version. Use cached_input instead.
 


### PR DESCRIPTION
This PR improves the speed of `smoothcal.solve_2D_DPSS` by using `nucal._linear_fit` to allow for additional filtering options. For the nominal inputs of `smooth_cal.CalibrationSmoother.time_freq_2D_filter`, the new `lu_solve` method is roughly 12x faster than the previously used `pinv` method.

For other uses of this function such as [full_day_rfi.ipynb](https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/full_day_rfi.ipynb) and [full_data_auto_checker.ipynb](https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/full_day_auto_checker.ipynb) where filtering scale is finer than the typical `smooth_cal` run, the new `lu_solve`  method is significantly faster with comparable results.

![Screenshot 2023-04-08 at 3 32 35 PM](https://user-images.githubusercontent.com/17678594/231260279-94d0e1a4-31ac-4e44-947f-c54b4a24653f.png)

This PR also deprecates the `XTXinv` keyword argument in favor of a more general `cached_input`, which also stores intermediate data products computed by `scipy.linalg.lu_factor`.
