### PR TITLE
perf: faster updating of RedundantGroups objects

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -588,7 +588,10 @@ class RedDataContainer(DataContainer):
             self.reds = RedundantGroups(red_list=reds, antpos=getattr(self, 'antpos', None))
                 
         self._reds_keyed_on_data = self.reds.keyed_on_bls(bls=self.bls())
-        
+
+        # delete unused data to avoid leaking memory
+        del self[[k for k in self._data if k not in self.reds]]
+
         # Check that the data only has one baseline per redundant group
         redkeys = {}
         for bl in self.bls():
@@ -601,8 +604,6 @@ class RedDataContainer(DataContainer):
             else:
                 redkeys[ubl] = bl
 
-        # delete unused data to avoid leaking memory
-        del self[[k for k in self._data if k not in self.reds]]
 
     def get_ubl_key(self, bl):
         '''Returns the blkey used to internally denote the data stored.

--- a/hera_cal/red_groups.py
+++ b/hera_cal/red_groups.py
@@ -309,8 +309,6 @@ class RedundantGroups:
         properties (rather than having to fully recompute them).
         """
         new_ubl = self.key_chooser(bls)
-        old_bls = self._red_key_to_bls_map[ubl]
-        
         self._remove_group(ubl)
         self._add_new_group(bls, ubl=new_ubl)
 
@@ -345,7 +343,7 @@ class RedundantGroups:
 
         rubl = reverse_bl(ubl)
         if rubl != ubl:
-            bls += self._red_key_to_bls_map[rubl]
+            bls =  bls + self._red_key_to_bls_map[rubl]
             del self._red_key_to_bls_map[rubl]
 
         for bl in bls:
@@ -558,11 +556,13 @@ class RedundantGroups:
                 chooser = self.key_chooser.chooser,
             )
 
-            to_remap = [ubl for ubl in self._red_key_to_bls_map.keys() if ubl not in bls]
+            to_remap = [ubl for ubl in self._red_key_to_bls_map.keys() if ubl not in bls and reverse_bl(ubl) not in bls]
+            # Remove all flips....
+            to_remap = [ubl for ubl in to_remap if ubl[0] <= ubl[1]]
+
             obj.key_chooser = new_chooser
             for bl in to_remap:
                 obj._reset_ubl(bl, self[bl])
-            
         if not inplace:
             return obj
         

--- a/hera_cal/red_groups.py
+++ b/hera_cal/red_groups.py
@@ -9,12 +9,13 @@ import copy
 from functools import cached_property, wraps, partial
 from frozendict import frozendict
 
-from typing import Sequence, Tuple, List
+from typing import Sequence, Tuple, List, Union
 
 AntPair = Tuple[int, int]
 Baseline = Tuple[int, int, str]
+BlLike = Union[AntPair, Baseline]
 
-def _convert_red_list(red_list: Sequence[Sequence[AntPair | Baseline]]) -> List[List[AntPair | Baseline]]:
+def _convert_red_list(red_list: Sequence[Sequence[BlLike]]) -> List[List[BlLike]]:
     """Convert a list of redundant baseline groups to a list of lists of antenna pairs."""
     return [list(bls) for bls in red_list]
 
@@ -164,7 +165,7 @@ class RedundantGroups:
             )
     """
 
-    _red_list: List[List[AntPair | Baseline]] = attrs.field(converter=_convert_red_list)
+    _red_list: List[List[BlLike]] = attrs.field(converter=_convert_red_list)
     _antpos: frozendict[int, np.ndarray] | None = attrs.field(
         default=None, 
         converter=attrs.converters.optional(frozendict),
@@ -187,7 +188,25 @@ class RedundantGroups:
                 for bl in red:
                     if len(bl) != tp:
                         raise TypeError("All baselines must have the same type, got an AntPair and a Baseline")
-                         
+
+    def __attrs_post_init__(self):
+        self._data_ants = {ant for red in self._red_list for ap in red for ant in ap[:2]}
+        self._data_bls = {bl for red in self._red_list for bl in red}
+
+        self._red_key_to_bls_map = {}
+        for red in self._red_list:
+            ubl = self.key_chooser(red)
+            self._red_key_to_bls_map[ubl] = red
+            self._red_key_to_bls_map[reverse_bl(ubl)] = [reverse_bl(r) for r in red]
+        
+        self._bl_to_red_map = {}
+        for red in self._red_list:
+            ubl = self.key_chooser(red)
+            rev = reverse_bl(ubl)
+            for bl in red:
+                self._bl_to_red_map[bl] = ubl
+                self._bl_to_red_map[reverse_bl(bl)] = rev 
+        
     @classmethod
     def from_antpos(
         cls, 
@@ -239,45 +258,110 @@ class RedundantGroups:
             )
         return cls(antpos=antpos, red_list=reds, **kwargs)
     
-    @cached_property
+    @property
     def data_ants(self) -> frozenset[int]:
-        """The list of antennas that are in the baseline groups."""    
-        return {ant for red in self._red_list for ap in red for ant in ap[:2]}
+        """The set of antennas that are in the baseline groups."""    
+        return frozenset(self._data_ants)
        
+    def _add_data_ants(self, ants: Iterable[int]):
+        """Add antennas to the list of antennas in the baseline groups.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        self._data_ants.update(ants)
 
-    @cached_property
-    def data_bls(self) -> frozenset[Baseline | AntPair]:
-        """The list of baselines in the baseline groups."""
-        return frozenset(sum(self._red_list, []))
+    def _remove_data_ants(self, ants: Iterable[int]):
+        """Remove antennas from the list of antennas in the baseline groups.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        self._data_ants.difference_update(ants)
 
-    @cached_property
-    def _red_key_to_bls_map(self) -> dict[AntPair, List[AntPair]]:
-        out = {}
-        for red in self._red_list:
-            out[self.key_chooser(red)] = red
-            out[reverse_bl(self.key_chooser(red))] = [reverse_bl(r) for r in red]
-        return out
+    @property
+    def data_bls(self) -> frozenset[BlLike]:
+        """The set of baselines in the baseline groups."""
+        return frozenset(self._data_bls)
     
-    @cached_property
-    def _bl_to_red_map(self):
-        out = {}
-        for red in self._red_list:
-            ubl = self.key_chooser(red)
-            rev = reverse_bl(ubl)
-            for bl in red:
-                out[bl] = ubl
-                out[reverse_bl(bl)] = rev 
-        return out
+    def _add_data_bls(self, bls: Iterable[BlLike]):
+        """Add baselines to the list of baselines in the baseline groups.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        self._data_bls.update(bls)
+        self._add_data_ants({ant for bl in bls for ant in bl[:2]})
+
+    def _remove_data_bls(self, bls: Iterable[BlLike]):
+        """Remove baselines from the list of baselines in the baseline groups.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        self._data_bls.difference_update(bls)
+        self._remove_data_ants({ant for bl in bls for ant in bl[:2]})
     
-    def get_ubl_key(self, key: AntPair | Baseline) -> AntPair | Baseline:
+    def _reset_ubl(self, ubl: BlLike, bls: Iterable[BlLike]):
+        """Reset the redundant group associated with a unique baseline.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        new_ubl = self.key_chooser(bls)
+        old_bls = self._red_key_to_bls_map[ubl]
+        
+        self._remove_group(ubl)
+        self._add_new_group(bls, ubl=new_ubl)
+
+    def _add_new_group(self, bls: Iterable[BlLike], ubl: BlLike | None = None):
+        """Add a new redundant group to the object.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        
+        Assumes without checking that the new group is really new, i.e. none of its
+        baselines are in other groups already (i.e. should be called from other methods
+        that do the appropriate checking).
+        """
+        if ubl is None:
+            ubl = self.key_chooser(bls)
+        rubl = reverse_bl(ubl)
+        self._red_key_to_bls_map[ubl] = bls
+        self._red_key_to_bls_map[rubl] = [reverse_bl(bl) for bl in bls]
+        for bl in bls:
+            self._bl_to_red_map[bl] = ubl
+            self._bl_to_red_map[reverse_bl(bl)] = rubl
+        self._add_data_bls(bls)
+
+    def _remove_group(self, ubl: BlLike):
+        """Remove a redundant group from the object.
+        
+        Not to be called by users, but used internally to quickly update the cached
+        properties (rather than having to fully recompute them).
+        """
+        bls = self._red_key_to_bls_map[ubl]
+        del self._red_key_to_bls_map[ubl]
+
+        rubl = reverse_bl(ubl)
+        if rubl != ubl:
+            bls += self._red_key_to_bls_map[rubl]
+            del self._red_key_to_bls_map[rubl]
+
+        for bl in bls:
+            del self._bl_to_red_map[bl]
+            
+        self._remove_data_bls(bls)
+
+    def get_ubl_key(self, key: BlLike) -> BlLike:
         '''Returns the unique baseline representing the group the key is in.'''
         return self._bl_to_red_map[key]
         
-    def get_red(self, key: AntPair | Baseline) -> Tuple[AntPair | Baseline]:
+    def get_red(self, key: BlLike) -> Tuple[BlLike]:
         '''Returns the tuple of baselines redundant with this key.'''
         return self._red_key_to_bls_map[self.get_ubl_key(key)]
         
-    def __contains__(self, key: AntPair | Baseline):
+    def __contains__(self, key: BlLike):
         '''Returns true if the baseline redundant with the key is in the data.'''
         return key in self._bl_to_red_map
     
@@ -299,10 +383,11 @@ class RedundantGroups:
             return self.extend(other._red_list, inplace=False)
         else:
             new_antpos = {**self.antpos, **other.antpos}
-            new = attrs.evolve(self, antpos=new_antpos)
-            return new.extend(other._red_list, inplace=False)            
+            obj = copy.deepcopy(self)
+            obj._antpos = new_antpos
+            return obj.extend(other._red_list, inplace=False)            
         
-    def append(self, red: Sequence[AntPair | Baseline], inplace: bool=True, pos: int | None = None) -> None:
+    def append(self, red: Sequence[BlLike], inplace: bool=True, pos: int | None = None) -> None:
         """In-place append a new redundant group to the list of redundant groups.
         
         This maintains the list-of-lists duck-typing of the redundant groups.
@@ -338,7 +423,7 @@ class RedundantGroups:
             # they all map to the same already-existing group.
             ublkey = next(iter(ubls.values()))
             obj[ublkey] = sorted(set(self[ublkey] + red))
-
+            obj._reset_ubl(ublkey, obj[ublkey])
         else:
             # We're adding a completely new group
             if pos is None:
@@ -346,13 +431,12 @@ class RedundantGroups:
             else:
                 obj._red_list.insert(pos, red)
 
-        # Reset the maps
-        obj.clear_cache()
+            self._add_new_group(red)
 
         if not inplace:
             return obj
 
-    def insert(self, pos: int, red: Sequence[AntPair | Baseline], inplace: bool=True) -> None:
+    def insert(self, pos: int, red: Sequence[BlLike], inplace: bool=True) -> None:
         """In-place insert a new redundant group to the list of redundant groups.
         
         This maintains the list-of-lists duck-typing of the redundant groups.
@@ -365,36 +449,35 @@ class RedundantGroups:
     def __iter__(self):
         return iter(self._red_list)
     
-    def __getitem__(self, key: int | AntPair | Baseline) -> List[AntPair | Baseline]:
+    def __getitem__(self, key: int | BlLike) -> List[BlLike]:
         if isinstance(key, int):
             return self._red_list[key]
         else:
             return self.get_red(key)
         
-    def __setitem__(self, key: int | AntPair | Baseline, value: List[AntPair | Baseline]):
+    def __setitem__(self, key: int | BlLike, value: List[BlLike]):
         if isinstance(key, int):
+            self._reset_ubl(self.get_ubl_key(self._red_list[key][0]), value)
             self._red_list[key] = value
         elif key in self:
             ukey = self.get_ubl_key(key)
             self._red_list = [value if red[0]==ukey else red for red in self._red_list]
+            self._reset_ubl(ukey, value)
         else:
             # We're setting a new redundant group
             self.append(value)
 
-        # Reset the maps
-        self.clear_cache()
-
-    def __delitem__(self, key: int | AntPair | Baseline):
+    def __delitem__(self, key: int | BlLike):
         if isinstance(key, int):
+            ukey = self.get_ubl_key(self._red_list[key][0])
             del self._red_list[key]
         else:
             ukey = self.get_ubl_key(key)
             self._red_list = [red for red in self._red_list if red[0] != ukey]
-        
-        # Reset the maps
-        self.clear_cache()
 
-    def index(self, key: AntPair | Baseline) -> int:
+        self._remove_group(ukey)
+        
+    def index(self, key: BlLike) -> int:
         """Return the index of a redundant group."""
         return list(self._red_key_to_bls_map.keys()).index(self.get_ubl_key(key))
     
@@ -409,13 +492,15 @@ class RedundantGroups:
         else:
             return attrs.evolve(self, red_list=new_reds)
     
-    def extend(self, reds: Sequence[Sequence[AntPair | Baseline]], inplace: bool = True) -> None:
+    def extend(self, reds: Sequence[Sequence[BlLike]], inplace: bool = True) -> None:
         """In-place extend the list of redundant groups with another list of redundant groups.
         
         This maintains the list-of-lists duck-typing of the redundant groups.
         """
+        out = self if inplace else copy.deepcopy(self)
+        
         for red in reds:
-            out = self.append(red, inplace)
+            out.append(red, inplace=True)
 
         if not inplace:
             return out
@@ -423,18 +508,10 @@ class RedundantGroups:
     def sort(self, **kwargs):
         """Sort the redundant groups in-place."""
         self._red_list.sort(**kwargs)
-        self.clear_cache()
 
     def clear_cache(self):
         """Clear the cached maps."""
-        for att in (
-            "_bl_to_red_map",
-            "_red_key_to_bls_map",
-            "data_ants",
-            "data_bls",
-        ):
-            if att in self.__dict__:
-                del self.__dict__[att]
+        self.__attrs_post_init__()
 
     def get_full_redundancies(
         self, pols: Sequence[str] | None = None, 
@@ -458,7 +535,7 @@ class RedundantGroups:
         )
 
     
-    def keyed_on_bls(self, bls: Sequence[AntPair | Baseline]) -> RedundantGroups:
+    def keyed_on_bls(self, bls: Sequence[BlLike], inplace: bool = False) -> RedundantGroups:
         """Return a new RedundantGroups object keyed on the given baselines.
         
         The returned object will have the same redundant groups as this object, but
@@ -467,13 +544,39 @@ class RedundantGroups:
         in the group are in ``bls``, then the key will be gotten from applying
         ``key_chooser`` to the entire group (as usual).
         """
-        return attrs.evolve(
-            self, key_chooser=partial(
-                _choose_key_in_bls, bls=bls, key_chooser=self.key_chooser
-            )
-        )
+        obj = self if inplace else copy.deepcopy(self)
+
         
-def _choose_key_in_bls(red, bls, key_chooser):
-    filtered_red = [bl for bl in red if bl in bls]
-    return key_chooser(filtered_red) if filtered_red else key_chooser(red)
+        
+        if not isinstance(self.key_chooser, BaselineKeyChooser):
+            # Recompute all keys        
+            obj.key_chooser = BaselineKeyChooser(bls=bls, chooser=self.key_chooser)
+            obj.clear_cache()
+        else:
+            new_chooser = BaselineKeyChooser(
+                bls = bls,
+                chooser = self.key_chooser.chooser,
+            )
+
+            to_remap = [ubl for ubl in self._red_key_to_bls_map.keys() if ubl not in bls]
+            obj.key_chooser = new_chooser
+            for bl in to_remap:
+                obj._reset_ubl(bl, self[bl])
+            
+        if not inplace:
+            return obj
+        
+@attrs.define(frozen=True)
+class BaselineKeyChooser:
+    """A callable that chooses a unique key for a redundant group.
+    
+    The callable takes a list of baselines and returns a unique key for the group.
+    """
+    bls: Sequence[BlLike] = attrs.field()
+    chooser: Callable[[Sequence[BlLike]], BlLike] = attrs.field()
+
+    def __call__(self, red: Sequence[BlLike]) -> BlLike:
+        filtered_red = [bl for bl in red if bl in self.bls]
+        return self.chooser(filtered_red) if filtered_red else self.chooser(red)
+    
     

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -477,7 +477,7 @@ def test_RedDataContainer():
     # build an incomplete datacontainer, then finish it
     rdata6 = datacontainer.RedDataContainer(deepcopy(data), reds[:-1])
     rdata6[reds[-1][0]] = deepcopy(data[reds[-1][0]])
-    rdata6.build_red_keys(reds)
+    #rdata6.build_red_keys(reds)
 
     # make sure that the data for a redundant group are being accessed from the same place in memory
     for i, rdata in enumerate([rdata1, rdata2, rdata3, rdata4, rdata5, rdata6]):

--- a/hera_cal/tests/test_red_groups.py
+++ b/hera_cal/tests/test_red_groups.py
@@ -244,6 +244,7 @@ class TestRedundantGroups:
         rg = RedundantGroups(
             [[(0, 1)], [(0, 2), (0, 3)]],
         )
+        print(rg._red_key_to_bls_map)
         del rg[(0,1)]
         print("_bl_to_red_map" in rg.__dict__)
         assert len(rg) == 1

--- a/hera_cal/tests/test_red_groups.py
+++ b/hera_cal/tests/test_red_groups.py
@@ -234,19 +234,23 @@ class TestRedundantGroups:
         rg = RedundantGroups(
             [[(0, 1)], [(0, 2), (0, 3)]],
         )
+        print(rg._red_list)
         new = rg.keyed_on_bls(bls=[(0,3)])
-
+        print(new._red_list)
         assert (0,2) in new
         assert new.get_ubl_key((0,2)) == (0,3)
         assert new.get_ubl_key((0,1)) == (0,1)
-        
+        print(new._red_list)
+
+        new.keyed_on_bls(bls=[(0, 2)], inplace=True)
+        print(new._red_list)
+        assert new.get_ubl_key((0,2)) == (0,2)
+
     def test_delitem(self):
         rg = RedundantGroups(
             [[(0, 1)], [(0, 2), (0, 3)]],
         )
-        print(rg._red_key_to_bls_map)
         del rg[(0,1)]
-        print("_bl_to_red_map" in rg.__dict__)
         assert len(rg) == 1
         assert (0,1) not in rg
         assert (0,2) in rg


### PR DESCRIPTION
This adds the ability to update the underlying dictionaries mapping baseline groups to their keys (and vice versa) in-place without re-calculating the whole dictionary. This should be quite a bit faster than the original. It also speeds up re-keying on a subset of baselines, which was the problem @tyler-a-cox was seeing previously. 