### PR TITLE
Detect and account for 180 degree phase flips in smooth_cal

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -68,7 +68,7 @@ def single_iterative_fft_dly(gains, wgts, freqs, conv_crit=1e-5, maxiter=100):
 
 
 def detect_phase_flips(phases):
-    """Detect phases that are flipped relative to the first unflagged integ
+    """Detect phases that are flipped relative to the first unflagged integration.
 
     Arguments:
         phases: phases in radians. Will handle phase wraps and phase starting point (-pi, 0, etc.)
@@ -78,10 +78,10 @@ def detect_phase_flips(phases):
         phase_flipped: boolean array the same shape as phases where True means pi radians flipped
             relative to the first unflagged phase.
     """
-    phases_between_0_and_2pi = (np.angle(np.exp(1.0j * phases)) + 2 * np.pi) % (2 * np.pi)
-    first_nonnan_phase = np.ravel(phases_between_0_and_2pi)[np.isfinite(np.ravel(phases_between_0_and_2pi))][0]
-    phase_diffs = phases_between_0_and_2pi - first_nonnan_phase
-    phase_flipped = np.abs(phase_diffs - np.pi) < np.pi / 2
+    complexes = np.exp(1.0j * phases)
+    first_nonnan = np.ravel(complexes)[np.isfinite(np.ravel(complexes))][0]
+    # check if each number is closer to first_nonnan or -first_nonnan
+    phase_flipped = np.abs(complexes - first_nonnan) > np.abs(complexes + first_nonnan)
     return phase_flipped
 
 

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -322,7 +322,7 @@ def time_filter(gains, wgts, times, filter_scale=1800.0, nMirrors=0):
 def time_freq_2D_filter(gains, wgts, freqs, times, freq_scale=10.0, time_scale=1800.0,
                         tol=1e-09, filter_mode='rect', maxiter=100, window='tukey', method='CLEAN',
                         dpss_vectors=None, fit_method="pinv", cached_input={}, eigenval_cutoff=1e-9,
-                        skip_flagged_edges=True, fix_phase_flips=True, **win_kwargs):
+                        skip_flagged_edges=True, fix_phase_flips=False, **win_kwargs):
     '''Filter calibration solutions in both time and frequency simultaneously. First rephases to remove
     a time-average delay from the gains, then performs the low-pass 2D filter in time and frequency,
     then puts back in the delay rephasor. Uses aipy.deconv.clean to account for weights/flags.
@@ -370,7 +370,7 @@ def time_freq_2D_filter(gains, wgts, freqs, times, freq_scale=10.0, time_scale=1
             Default is True
         fix_phase_flips : bool, optional
             If True, will try to find integrations whose phases appear to be 180 degrees rotated from the first unflagged
-            integration. These will be flipped before smoothing and then flipped back after smoothing. Default is True.
+            integration. These will be flipped before smoothing and then flipped back after smoothing. Default is False.
         win_kwargs : any keyword arguments for the window function selection in aipy.dsp.gen_window.
             Currently, the only window that takes a kwarg is the tukey window with a alpha=0.5 default.
 
@@ -962,7 +962,7 @@ class CalibrationSmoother():
 
     def time_freq_2D_filter(self, freq_scale=10.0, time_scale=1800.0, tol=1e-09, filter_mode='rect',
                             window='tukey', maxiter=100, method="CLEAN", fit_method='pinv', eigenval_cutoff=1e-9,
-                            skip_flagged_edges=True, fix_phase_flips=True, flag_phase_flip_ints=True, **win_kwargs):
+                            skip_flagged_edges=True, fix_phase_flips=False, flag_phase_flip_ints=False, **win_kwargs):
         '''2D time and frequency filter stored calibration solutions on a given scale in seconds and MHz respectively.
 
         Arguments:
@@ -991,9 +991,9 @@ class CalibrationSmoother():
                 Default is True, only used when method='DPSS'
             fix_phase_flips: Optional bool. If True, will try to find integrations whose phases appear to be 180 degrees
                 rotated from the first unflagged  integration. These will be flipped before smoothing and then flipped back
-                after smoothing. Will also print info about phase-flips found. Default is True.
+                after smoothing. Will also print info about phase-flips found. Default is False.
             flag_phase_flip_ints: Optional bool. If True and fix_phase_flips is also True, will flag antennas on the integrations
-                just before and just after a phase flip, since the phase flip could have occured mid-integration. Default is True.
+                just before and just after a phase flip, since the phase flip could have occured mid-integration. Default is False.
             win_kwargs : any keyword arguments for the window function selection in aipy.dsp.gen_window.
                 Currently, the only window that takes a kwarg is the tukey window with a alpha=0.5 default
         '''

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -1041,7 +1041,7 @@ class CalibrationSmoother():
                 if np.any(flipped):
                     print(f'{np.sum(flipped)} phase-flipped integrations detected on antenna {ant} between {self.time_grid[flipped][0]} and {self.time_grid[flipped][-1]}.')
                     if flag_phase_flip_ants:
-                        self.flag_grids[ant][:, :] = False
+                        self.flag_grids[ant][:, :] = True
                     # apply flags before and after phase flips
                     elif flag_phase_flip_ints:
                         most_recent_unflagged_tind = 0

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -572,10 +572,18 @@ class Test_Calibration_Smoother(object):
         cs = smooth_cal.CalibrationSmoother(calfits_list)
         cs.gain_grids[54, 'Jee'] /= np.abs(cs.gain_grids[54, 'Jee'])
         cs.gain_grids[54, 'Jee'][123:, :] *= -1
+
+        # test with flag_phase_flip_ints
         np.testing.assert_array_equal(cs.flag_grids[54, 'Jee'][122:124, :], False)
         cs.time_freq_2D_filter(method='DPSS', skip_flagged_edges=False, fix_phase_flips=True, flag_phase_flip_ints=True, eigenval_cutoff=1e-6)
         np.testing.assert_array_equal(cs.flag_grids[54, 'Jee'][122:124, :], True)
+        np.testing.assert_array_equal(cs.flag_grids[54, 'Jee'][0:122, :], False)
+        np.testing.assert_array_equal(cs.flag_grids[54, 'Jee'][124:, :], False)
         assert np.max(np.abs(np.mean(cs.gain_grids[54, 'Jee'][123:], axis=0) / np.mean(cs.gain_grids[54, 'Jee'][0:123], axis=0) + 1)) < 0.15
+
+        # test with flag_phase_flip_ants
+        cs.time_freq_2D_filter(method='DPSS', skip_flagged_edges=False, fix_phase_flips=True, flag_phase_flip_ants=True, eigenval_cutoff=1e-6)
+        np.testing.assert_array_equal(cs.flag_grids[54, 'Jee'], True)
 
     @pytest.mark.filterwarnings("ignore:Mean of empty slice")
     def test_write(self):

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -38,6 +38,21 @@ class Test_Smooth_Cal_Helper_Functions(object):
         assert a.flag_file_list == ['c']
         assert a.lst_blacklists == [(3, 4), (10, 12), (23, .5)]
 
+    def test_detect_phase_flips(self):
+        # test normal operation
+        phase_flipped = smooth_cal.detect_phase_flips(np.array([1, 1, 1, 4, 4, 4]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
+        # test phase wrapping
+        phase_flipped = smooth_cal.detect_phase_flips(np.array([1, 1, 1, -2, -2, -2]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
+        phase_flipped = smooth_cal.detect_phase_flips(np.array([1, 1, 1, 10, 10, 10]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
+        # test nan handling
+        phase_flipped = smooth_cal.detect_phase_flips(np.array([1, 1, 1, 4, np.nan, 4]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, False, True]))
+        phase_flipped = smooth_cal.detect_phase_flips(np.array([np.nan, 1, 1, 4, np.nan, 4]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, False, True]))
+
     def test_dpss_filters(self):
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 40, endpoint=False)
         freqs = np.linspace(100., 200., 50, endpoint=False) * 1e6


### PR DESCRIPTION
This PR adds automatic detection of 180 degree phase flips (on by default) before smoothing, which are incorporated in the rephasor applied before smoothing and then taken back out after smoothing.

It also adds functionality to flag integrations before and after phase flips, under the assumption that the phase flip may have happened mid-integration.

Here's a demonstration:

![image](https://github.com/HERA-Team/hera_cal/assets/5281139/c9586da7-9fff-462d-81b2-b166165ef7a7)

![image](https://github.com/HERA-Team/hera_cal/assets/5281139/d7041bcb-8506-46dd-8b48-baea2c2eb835)
