### PR TITLE
Update logic for identifying phase flips

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -78,11 +78,20 @@ def detect_phase_flips(phases):
         phase_flipped: boolean array the same shape as phases where True means pi radians flipped
             relative to the first unflagged phase.
     """
-    complexes = np.exp(1.0j * phases)
-    first_nonnan = np.ravel(complexes)[np.isfinite(np.ravel(complexes))][0]
-    # check if each number is closer to first_nonnan or -first_nonnan
-    phase_flipped = np.abs(complexes - first_nonnan) > np.abs(complexes + first_nonnan)
-    return phase_flipped
+    original_shape = np.array(phases).shape
+    complexes = np.exp(1.0j * np.ravel(phases))
+    phase_flipped = np.zeros(len(complexes), dtype=bool)
+    currently_flipped = False
+    previous_non_nan = np.nan  # ensures that first non-nan integration is not flipped
+    for i in range(len(complexes)):
+        if not np.isnan(complexes[i]):
+            flip_here = np.abs(complexes[i] - previous_non_nan) > np.abs(complexes[i] + previous_non_nan)
+            phase_flipped[i] = currently_flipped ^ flip_here
+            currently_flipped = phase_flipped[i]
+            previous_non_nan = complexes[i]
+        else:
+            phase_flipped[i] = currently_flipped
+    return phase_flipped.reshape(original_shape)
 
 
 def dpss_filters(freqs, times, freq_scale=10, time_scale=1800, eigenval_cutoff=1e-9):

--- a/hera_cal/tests/test_smooth_cal.py
+++ b/hera_cal/tests/test_smooth_cal.py
@@ -49,9 +49,9 @@ class Test_Smooth_Cal_Helper_Functions(object):
         np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
         # test nan handling
         phase_flipped = smooth_cal.detect_phase_flips(np.array([1, 1, 1, 4, np.nan, 4]))
-        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, False, True]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
         phase_flipped = smooth_cal.detect_phase_flips(np.array([np.nan, 1, 1, 4, np.nan, 4]))
-        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, False, True]))
+        np.testing.assert_array_equal(phase_flipped, np.array([False, False, False, True, True, True]))
 
     def test_dpss_filters(self):
         times = np.linspace(0, 10 * 10 / 60. / 60. / 24., 40, endpoint=False)


### PR DESCRIPTION
In analyzing a day outside H6C IDR2 (specifically 2459906), I found that phase shifts in the calibration solution due to bright sources (e.g. the galactic anticenter) could trigger the detection of phase flipping:

![image](https://github.com/HERA-Team/hera_cal/assets/5281139/f909dde9-4f0b-4181-aa57-bd62e364d8b4)

This is not the intended behavior, so I changed the logic to identify phase flips based on changes of 90 degrees in the phase from one integration to the next. I have verified on 2459866 and 2459870 that the same integrations are being identified as phase flipped with the new logic as with the old.

The new method is very, very slightly slower, but not in a way that increases the runtime of smooth_cal by more than a few seconds compared to the ~30 min runtime of the smooth_cal notebook (which is I/O dominated anyway).

Doing this enabled a more natural way to handle completely flagged integrations, which is to give them have the same flipped-status as the most-recent non-flagged integration. So I've made that change, which required editing a unit test, but should have few practical implications. 



