### PR TITLE
fix: future array shapes in chunk test and deprecation in numpy equals

### DIFF
--- a/.benchmarks/Linux-CPython-3.10-64bit/0001_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_220806_uncommited-changes.json
+++ b/.benchmarks/Linux-CPython-3.10-64bit/0001_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_220806_uncommited-changes.json
@@ -1,0 +1,2813 @@
+{
+    "machine_info": {
+        "node": "LAPTOP-J64LT06Q",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC 10.4.0",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.10.6",
+        "python_version": "3.10.6",
+        "python_build": [
+            "main",
+            "Aug 22 2022 20:36:39"
+        ],
+        "release": "5.15.90.1-microsoft-standard-WSL2",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.10.6.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 16,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "GenuineIntel",
+            "brand_raw": "11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz",
+            "hz_advertised_friendly": "2.3000 GHz",
+            "hz_actual_friendly": "2.3040 GHz",
+            "hz_advertised": [
+                2300000000,
+                0
+            ],
+            "hz_actual": [
+                2304008000,
+                0
+            ],
+            "stepping": 1,
+            "model": 141,
+            "family": 6,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arch_capabilities",
+                "arch_perfmon",
+                "avx",
+                "avx2",
+                "avx512_bitalg",
+                "avx512_vbmi2",
+                "avx512_vnni",
+                "avx512_vp2intersect",
+                "avx512_vpopcntdq",
+                "avx512bitalg",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512ifma",
+                "avx512vbmi",
+                "avx512vbmi2",
+                "avx512vl",
+                "avx512vnni",
+                "avx512vpopcntdq",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "clwb",
+                "cmov",
+                "constant_tsc",
+                "cpuid",
+                "cx16",
+                "cx8",
+                "de",
+                "ept",
+                "ept_ad",
+                "erms",
+                "f16c",
+                "flush_l1d",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fsrm",
+                "fxsr",
+                "gfni",
+                "ht",
+                "hypervisor",
+                "ibpb",
+                "ibrs",
+                "ibrs_enhanced",
+                "invpcid",
+                "invpcid_single",
+                "lahf_lm",
+                "lm",
+                "mca",
+                "mce",
+                "mmx",
+                "movbe",
+                "movdir64b",
+                "movdiri",
+                "msr",
+                "mtrr",
+                "nonstop_tsc",
+                "nopl",
+                "nx",
+                "osxsave",
+                "pae",
+                "pat",
+                "pcid",
+                "pclmulqdq",
+                "pdcm",
+                "pdpe1gb",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdpid",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "sep",
+                "sha",
+                "sha_ni",
+                "smap",
+                "smep",
+                "ss",
+                "ssbd",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "stibp",
+                "syscall",
+                "tpr_shadow",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_reliable",
+                "tscdeadline",
+                "umip",
+                "vaes",
+                "vme",
+                "vmx",
+                "vnmi",
+                "vpclmulqdq",
+                "vpid",
+                "x2apic",
+                "xgetbv1",
+                "xsave",
+                "xsavec",
+                "xsaveopt",
+                "xsaves",
+                "xtopology"
+            ],
+            "l3_cache_size": 25165824,
+            "l2_cache_size": 10485760,
+            "l1_data_cache_size": 393216,
+            "l1_instruction_cache_size": 262144,
+            "l2_cache_line_size": 256,
+            "l2_cache_associativity": 7
+        }
+    },
+    "commit_info": {
+        "id": "3a0f8a44c3a469bd3e3d27009467f90515500b11",
+        "time": "2023-05-10T10:32:33-07:00",
+        "author_time": "2023-05-10T10:32:33-07:00",
+        "dirty": true,
+        "project": "hera_cal",
+        "branch": "lstbin-improvements"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_increasing_lsts_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_increasing_lsts_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 6.680600000000001e-05,
+                    "tottime_per": 6.680600000000001e-05,
+                    "cumtime": 0.000165601,
+                    "cumtime_per": 0.000165601,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "11/10",
+                    "ncalls": 11,
+                    "tottime": 1.0677000000000001e-05,
+                    "tottime_per": 1.0677000000000002e-06,
+                    "cumtime": 6.215100000000001e-05,
+                    "cumtime_per": 6.215100000000001e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4180000000000001e-05,
+                    "tottime_per": 1.4180000000000001e-05,
+                    "cumtime": 3.1187000000000005e-05,
+                    "cumtime_per": 3.1187000000000005e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 3.548e-06,
+                    "tottime_per": 5.913333333333334e-07,
+                    "cumtime": 2.9648e-05,
+                    "cumtime_per": 4.941333333333334e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.0144000000000001e-05,
+                    "tottime_per": 1.4491428571428574e-06,
+                    "cumtime": 2.2746000000000002e-05,
+                    "cumtime_per": 3.2494285714285717e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 3.856e-06,
+                    "tottime_per": 6.426666666666667e-07,
+                    "cumtime": 1.9487e-05,
+                    "cumtime_per": 3.2478333333333335e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.354e-06,
+                    "tottime_per": 1.354e-06,
+                    "cumtime": 1.5974e-05,
+                    "cumtime_per": 1.5974e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.916e-06,
+                    "tottime_per": 3.916e-06,
+                    "cumtime": 1.3878000000000002e-05,
+                    "cumtime_per": 1.3878000000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5130000000000002e-06,
+                    "tottime_per": 1.5130000000000002e-06,
+                    "cumtime": 1.3141e-05,
+                    "cumtime_per": 1.3141e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0025000000000001e-05,
+                    "tottime_per": 1.0025000000000001e-05,
+                    "cumtime": 1.0680000000000001e-05,
+                    "cumtime_per": 1.0680000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1150000000000001e-06,
+                    "tottime_per": 1.1150000000000001e-06,
+                    "cumtime": 9.91e-06,
+                    "cumtime_per": 9.91e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 9.017e-06,
+                    "tottime_per": 1.2881428571428571e-06,
+                    "cumtime": 9.017e-06,
+                    "cumtime_per": 1.2881428571428571e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.452e-06,
+                    "tottime_per": 2.452e-06,
+                    "cumtime": 8.948000000000001e-06,
+                    "cumtime_per": 8.948000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.060000000000001e-07,
+                    "tottime_per": 9.060000000000001e-07,
+                    "cumtime": 8.021e-06,
+                    "cumtime_per": 8.021e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.6300000000000002e-06,
+                    "tottime_per": 2.6300000000000002e-06,
+                    "cumtime": 5.801e-06,
+                    "cumtime_per": 5.801e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.15e-07,
+                    "tottime_per": 7.15e-07,
+                    "cumtime": 5.4400000000000004e-06,
+                    "cumtime_per": 5.4400000000000004e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 6.760000000000001e-07,
+                    "tottime_per": 6.760000000000001e-07,
+                    "cumtime": 3.936e-06,
+                    "cumtime_per": 3.936e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1770000000000001e-06,
+                    "tottime_per": 1.1770000000000001e-06,
+                    "cumtime": 3.878e-06,
+                    "cumtime_per": 3.878e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.2020000000000003e-06,
+                    "tottime_per": 2.2020000000000003e-06,
+                    "cumtime": 3.26e-06,
+                    "cumtime_per": 3.26e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 2.915e-06,
+                    "tottime_per": 4.1642857142857144e-07,
+                    "cumtime": 2.915e-06,
+                    "cumtime_per": 4.1642857142857144e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.166e-06,
+                    "tottime_per": 1.083e-06,
+                    "cumtime": 2.582e-06,
+                    "cumtime_per": 1.291e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.618e-06,
+                    "tottime_per": 1.618e-06,
+                    "cumtime": 1.618e-06,
+                    "cumtime_per": 1.618e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "19",
+                    "ncalls": 19,
+                    "tottime": 1.347e-06,
+                    "tottime_per": 7.089473684210526e-08,
+                    "cumtime": 1.347e-06,
+                    "cumtime_per": 7.089473684210526e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2930000000000002e-06,
+                    "tottime_per": 1.2930000000000002e-06,
+                    "cumtime": 1.2930000000000002e-06,
+                    "cumtime_per": 1.2930000000000002e-06,
+                    "function_name": "~:0(<built-in method numpy.zeros>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.29e-07,
+                    "tottime_per": 7.29e-07,
+                    "cumtime": 1.139e-06,
+                    "cumtime_per": 1.139e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                }
+            ],
+            "stats": {
+                "min": 7.921699943835847e-05,
+                "max": 0.000519174001965439,
+                "mean": 9.062959124674811e-05,
+                "stddev": 1.3429730511784498e-05,
+                "rounds": 3320,
+                "median": 8.70160001795739e-05,
+                "iqr": 2.956501703010872e-06,
+                "q1": 8.617549974587746e-05,
+                "q3": 8.913200144888833e-05,
+                "iqr_outliers": 546,
+                "stddev_outliers": 236,
+                "outliers": "236;546",
+                "ld15iqr": 8.185099795809947e-05,
+                "hd15iqr": 9.361800039187074e-05,
+                "ops": 11033.92375761025,
+                "total": 0.30089024293920374,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.1353e-05,
+                    "tottime_per": 8.1353e-05,
+                    "cumtime": 0.000197826,
+                    "cumtime_per": 0.000197826,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.2144000000000001e-05,
+                    "tottime_per": 1.1040000000000001e-06,
+                    "cumtime": 7.4399e-05,
+                    "cumtime_per": 6.763545454545455e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.378e-06,
+                    "tottime_per": 6.254285714285714e-07,
+                    "cumtime": 3.6205e-05,
+                    "cumtime_per": 5.172142857142858e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.6000000000000003e-05,
+                    "tottime_per": 1.6000000000000003e-05,
+                    "cumtime": 3.5989000000000004e-05,
+                    "cumtime_per": 3.5989000000000004e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.2449e-05,
+                    "tottime_per": 1.556125e-06,
+                    "cumtime": 2.7619e-05,
+                    "cumtime_per": 3.452375e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.966e-06,
+                    "tottime_per": 7.094285714285715e-07,
+                    "cumtime": 2.4351e-05,
+                    "cumtime_per": 3.478714285714286e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.122e-06,
+                    "tottime_per": 1.122e-06,
+                    "cumtime": 1.8723e-05,
+                    "cumtime_per": 1.8723e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.736e-06,
+                    "tottime_per": 4.736e-06,
+                    "cumtime": 1.6863e-05,
+                    "cumtime_per": 1.6863e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.898e-06,
+                    "tottime_per": 1.898e-06,
+                    "cumtime": 1.4940000000000001e-05,
+                    "cumtime_per": 1.4940000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1454e-05,
+                    "tottime_per": 1.1454e-05,
+                    "cumtime": 1.2086e-05,
+                    "cumtime_per": 1.2086e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.171e-06,
+                    "tottime_per": 1.171e-06,
+                    "cumtime": 1.181e-05,
+                    "cumtime_per": 1.181e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0820000000000001e-05,
+                    "tottime_per": 1.3525000000000002e-06,
+                    "cumtime": 1.0820000000000001e-05,
+                    "cumtime_per": 1.3525000000000002e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.0190000000000002e-06,
+                    "tottime_per": 3.0190000000000002e-06,
+                    "cumtime": 1.0514000000000001e-05,
+                    "cumtime_per": 1.0514000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.401e-06,
+                    "tottime_per": 1.401e-06,
+                    "cumtime": 9.635e-06,
+                    "cumtime_per": 9.635e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.96e-07,
+                    "tottime_per": 9.96e-07,
+                    "cumtime": 6.998000000000001e-06,
+                    "cumtime_per": 6.998000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.281e-06,
+                    "tottime_per": 3.281e-06,
+                    "cumtime": 6.959000000000001e-06,
+                    "cumtime_per": 6.959000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.12e-07,
+                    "tottime_per": 9.12e-07,
+                    "cumtime": 5.083e-06,
+                    "cumtime_per": 5.083e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.288e-06,
+                    "tottime_per": 1.288e-06,
+                    "cumtime": 4.501000000000001e-06,
+                    "cumtime_per": 4.501000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.5960000000000002e-06,
+                    "tottime_per": 2.5960000000000002e-06,
+                    "cumtime": 4.171e-06,
+                    "cumtime_per": 4.171e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.738e-06,
+                    "tottime_per": 4.6725e-07,
+                    "cumtime": 3.738e-06,
+                    "cumtime_per": 4.6725e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.5850000000000002e-06,
+                    "tottime_per": 1.2925000000000001e-06,
+                    "cumtime": 3.0210000000000004e-06,
+                    "cumtime_per": 1.5105000000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.087e-06,
+                    "tottime_per": 2.087e-06,
+                    "cumtime": 2.087e-06,
+                    "cumtime_per": 2.087e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 1.615e-06,
+                    "tottime_per": 7.340909090909091e-08,
+                    "cumtime": 1.615e-06,
+                    "cumtime_per": 7.340909090909091e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.082e-06,
+                    "tottime_per": 1.082e-06,
+                    "cumtime": 1.483e-06,
+                    "cumtime_per": 1.483e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.412e-06,
+                    "tottime_per": 1.412e-06,
+                    "cumtime": 1.412e-06,
+                    "cumtime_per": 1.412e-06,
+                    "function_name": "~:0(<method 'searchsorted' of 'numpy.ndarray' objects>)"
+                }
+            ],
+            "stats": {
+                "min": 8.843500108923763e-05,
+                "max": 0.00040014100159169175,
+                "mean": 9.736616126072903e-05,
+                "stddev": 8.954597624161419e-06,
+                "rounds": 7038,
+                "median": 9.62644971878035e-05,
+                "iqr": 1.372001861454919e-06,
+                "q1": 9.556499935570173e-05,
+                "q3": 9.693700121715665e-05,
+                "iqr_outliers": 1099,
+                "stddev_outliers": 314,
+                "outliers": "314;1099",
+                "ld15iqr": 9.350899927085266e-05,
+                "hd15iqr": 9.899600263452157e-05,
+                "ops": 10270.508635152826,
+                "total": 0.6852630429530109,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_flagging",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_flagging",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.988400000000001e-05,
+                    "tottime_per": 7.988400000000001e-05,
+                    "cumtime": 0.00019815700000000002,
+                    "cumtime_per": 0.00019815700000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.2037e-05,
+                    "tottime_per": 1.0942727272727274e-06,
+                    "cumtime": 7.7314e-05,
+                    "cumtime_per": 7.028545454545454e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.858e-06,
+                    "tottime_per": 6.939999999999999e-07,
+                    "cumtime": 3.8344000000000004e-05,
+                    "cumtime_per": 5.477714285714286e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.6059e-05,
+                    "tottime_per": 1.6059e-05,
+                    "cumtime": 3.6869e-05,
+                    "cumtime_per": 3.6869e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.3387e-05,
+                    "tottime_per": 1.673375e-06,
+                    "cumtime": 2.9224000000000003e-05,
+                    "cumtime_per": 3.6530000000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.191e-06,
+                    "tottime_per": 7.415714285714286e-07,
+                    "cumtime": 2.599e-05,
+                    "cumtime_per": 3.712857142857143e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2170000000000002e-06,
+                    "tottime_per": 1.2170000000000002e-06,
+                    "cumtime": 1.9777e-05,
+                    "cumtime_per": 1.9777e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.797e-06,
+                    "tottime_per": 4.797e-06,
+                    "cumtime": 1.7575e-05,
+                    "cumtime_per": 1.7575e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.398e-06,
+                    "tottime_per": 1.398e-06,
+                    "cumtime": 1.5069000000000001e-05,
+                    "cumtime_per": 1.5069000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2127000000000001e-05,
+                    "tottime_per": 1.2127000000000001e-05,
+                    "cumtime": 1.2751e-05,
+                    "cumtime_per": 1.2751e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.275e-06,
+                    "tottime_per": 1.275e-06,
+                    "cumtime": 1.1749e-05,
+                    "cumtime_per": 1.1749e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0858e-05,
+                    "tottime_per": 1.35725e-06,
+                    "cumtime": 1.0858e-05,
+                    "cumtime_per": 1.35725e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.501e-06,
+                    "tottime_per": 3.501e-06,
+                    "cumtime": 1.0826000000000001e-05,
+                    "cumtime_per": 1.0826000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.188e-06,
+                    "tottime_per": 1.188e-06,
+                    "cumtime": 9.613000000000001e-06,
+                    "cumtime_per": 9.613000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4560000000000001e-06,
+                    "tottime_per": 1.4560000000000001e-06,
+                    "cumtime": 7.684000000000001e-06,
+                    "cumtime_per": 7.684000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.029e-06,
+                    "tottime_per": 3.029e-06,
+                    "cumtime": 6.319e-06,
+                    "cumtime_per": 6.319e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.49e-07,
+                    "tottime_per": 8.49e-07,
+                    "cumtime": 5.383e-06,
+                    "cumtime_per": 5.383e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.136e-06,
+                    "tottime_per": 3.136e-06,
+                    "cumtime": 4.534e-06,
+                    "cumtime_per": 4.534e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.57e-06,
+                    "tottime_per": 1.57e-06,
+                    "cumtime": 4.4890000000000006e-06,
+                    "cumtime_per": 4.4890000000000006e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 4.171e-06,
+                    "tottime_per": 5.21375e-07,
+                    "cumtime": 4.171e-06,
+                    "cumtime_per": 5.21375e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.482e-06,
+                    "tottime_per": 1.241e-06,
+                    "cumtime": 2.842e-06,
+                    "cumtime_per": 1.421e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.938e-06,
+                    "tottime_per": 1.938e-06,
+                    "cumtime": 1.938e-06,
+                    "cumtime_per": 1.938e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 1.864e-06,
+                    "tottime_per": 8.472727272727273e-08,
+                    "cumtime": 1.864e-06,
+                    "cumtime_per": 8.472727272727273e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.229e-06,
+                    "tottime_per": 1.229e-06,
+                    "cumtime": 1.229e-06,
+                    "cumtime_per": 1.229e-06,
+                    "function_name": "~:0(<method 'searchsorted' of 'numpy.ndarray' objects>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1550000000000002e-06,
+                    "tottime_per": 1.6500000000000003e-07,
+                    "cumtime": 1.1550000000000002e-06,
+                    "cumtime_per": 1.6500000000000003e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2302(_any_dispatcher)"
+                }
+            ],
+            "stats": {
+                "min": 9.083300028578378e-05,
+                "max": 0.00027086800037068315,
+                "mean": 9.7145743533806e-05,
+                "stddev": 8.08285474587903e-06,
+                "rounds": 7148,
+                "median": 9.548799971526023e-05,
+                "iqr": 1.5684981917729601e-06,
+                "q1": 9.475250044488348e-05,
+                "q3": 9.632099863665644e-05,
+                "iqr_outliers": 864,
+                "stddev_outliers": 422,
+                "outliers": "422;864",
+                "ld15iqr": 9.240300278179348e-05,
+                "hd15iqr": 9.868500274023972e-05,
+                "ops": 10293.811788593779,
+                "total": 0.6943977747796453,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_nsamples_zero",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_nsamples_zero",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.1931e-05,
+                    "tottime_per": 2.1931e-05,
+                    "cumtime": 0.051049144000000005,
+                    "cumtime_per": 0.051049144000000005,
+                    "function_name": "hera_cal/hera_cal/tests/test_lstbin_simple.py:19(get_lst_align_data)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.902e-06,
+                    "tottime_per": 8.902e-06,
+                    "cumtime": 0.050874627000000006,
+                    "cumtime_per": 0.050874627000000006,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:187(make_dataset)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.2899000000000001e-05,
+                    "tottime_per": 6.449500000000001e-06,
+                    "cumtime": 0.050865507000000004,
+                    "cumtime_per": 0.025432753500000002,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:172(make_day)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 7.959000000000001e-06,
+                    "tottime_per": 3.979500000000001e-06,
+                    "cumtime": 0.050817303,
+                    "cumtime_per": 0.0254086515,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:120(create_uvd_identifiable)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.2862000000000002e-05,
+                    "tottime_per": 1.1431000000000001e-05,
+                    "cumtime": 0.04949046,
+                    "cumtime_per": 0.02474523,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:84(create_uvd_ones)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.7434e-05,
+                    "tottime_per": 1.8717e-05,
+                    "cumtime": 0.049458124000000006,
+                    "cumtime_per": 0.024729062000000003,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:24(create_mock_hera_obs)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.762e-06,
+                    "tottime_per": 2.381e-06,
+                    "cumtime": 0.031501343,
+                    "cumtime_per": 0.0157506715,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:774(new)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000132907,
+                    "tottime_per": 6.64535e-05,
+                    "cumtime": 0.031496581,
+                    "cumtime_per": 0.0157482905,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:328(new_uvdata)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.00011607400000000001,
+                    "tottime_per": 1.934566666666667e-05,
+                    "cumtime": 0.01897451,
+                    "cumtime_per": 0.0031624183333333333,
+                    "function_name": "pyuvdata/pyuvdata/utils.py:3777(get_lst_for_time)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000121905,
+                    "tottime_per": 6.09525e-05,
+                    "cumtime": 0.015625582000000002,
+                    "cumtime_per": 0.007812791000000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00010214600000000001,
+                    "tottime_per": 5.1073000000000004e-05,
+                    "cumtime": 0.015499496000000001,
+                    "cumtime_per": 0.007749748000000001,
+                    "function_name": "hera_cal/hera_cal/utils.py:549(LST2JD)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.9054000000000003e-05,
+                    "tottime_per": 7.263500000000001e-06,
+                    "cumtime": 0.014319167,
+                    "cumtime_per": 0.00357979175,
+                    "function_name": "hera_cal/hera_cal/utils.py:512(JD2LST)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000320635,
+                    "tottime_per": 0.0001603175,
+                    "cumtime": 0.010495856000000001,
+                    "cumtime_per": 0.005247928000000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.9976000000000004e-05,
+                    "tottime_per": 2.4988000000000002e-05,
+                    "cumtime": 0.008291390000000001,
+                    "cumtime_per": 0.0041456950000000005,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:93(get_time_params)"
+                },
+                {
+                    "ncalls_recursion": "116/28",
+                    "ncalls": 116,
+                    "tottime": 0.000175887,
+                    "tottime_per": 6.281678571428571e-06,
+                    "cumtime": 0.007538474000000001,
+                    "cumtime_per": 0.0002692312142857143,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1624(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "3534/328",
+                    "ncalls": 3534,
+                    "tottime": 0.0034545080000000002,
+                    "tottime_per": 1.0532036585365854e-05,
+                    "cumtime": 0.006615790000000001,
+                    "cumtime_per": 2.0170091463414636e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.006474669000000001,
+                    "tottime_per": 0.0010791115000000002,
+                    "cumtime": 0.006474669000000001,
+                    "cumtime_per": 0.0010791115000000002,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/erfa/core.py:13528(gst06a)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 0.000191973,
+                    "tottime_per": 1.599775e-05,
+                    "cumtime": 0.006340618,
+                    "cumtime_per": 0.0005283848333333333,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:726(_set_scale)"
+                },
+                {
+                    "ncalls_recursion": "1255/1020",
+                    "ncalls": 1255,
+                    "tottime": 0.000941194,
+                    "tottime_per": 9.227392156862745e-07,
+                    "cumtime": 0.006217872,
+                    "cumtime_per": 6.095952941176471e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "160",
+                    "ncalls": 160,
+                    "tottime": 0.000340392,
+                    "tottime_per": 2.1274500000000003e-06,
+                    "cumtime": 0.005559187,
+                    "cumtime_per": 3.474491875e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:259(_reconstruct)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.000261975,
+                    "tottime_per": 6.549375e-05,
+                    "cumtime": 0.005493175,
+                    "cumtime_per": 0.00137329375,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "7348/6030",
+                    "ncalls": 7348,
+                    "tottime": 0.001583966,
+                    "tottime_per": 2.6268092868988393e-07,
+                    "cumtime": 0.005294279000000001,
+                    "cumtime_per": 8.779898839137646e-07,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 2.5852000000000003e-05,
+                    "tottime_per": 4.308666666666667e-06,
+                    "cumtime": 0.004832498,
+                    "cumtime_per": 0.0008054163333333334,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:2405(_get_delta_ut1_utc)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 6.181800000000001e-05,
+                    "tottime_per": 4.415571428571429e-06,
+                    "cumtime": 0.004707412,
+                    "cumtime_per": 0.0003362437142857143,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1816(__init__)"
+                },
+                {
+                    "ncalls_recursion": "114/106",
+                    "ncalls": 114,
+                    "tottime": 0.0006629670000000001,
+                    "tottime_per": 6.2544056603773595e-06,
+                    "cumtime": 0.004678945,
+                    "cumtime_per": 4.414099056603774e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                }
+            ],
+            "stats": {
+                "min": 0.02688837199821137,
+                "max": 0.03406630500103347,
+                "mean": 0.02766997933323375,
+                "stddev": 0.001251995272898054,
+                "rounds": 33,
+                "median": 0.027340384000126505,
+                "iqr": 0.0006743427484252607,
+                "q1": 0.027112676249089418,
+                "q3": 0.02778701899751468,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.02688837199821137,
+                "hd15iqr": 0.02882393400068395,
+                "ops": 36.14025106259923,
+                "total": 0.9131093179967138,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rephase",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_rephase",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.6925e-05,
+                    "tottime_per": 8.6925e-05,
+                    "cumtime": 0.000343648,
+                    "cumtime_per": 0.000343648,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.3729e-05,
+                    "tottime_per": 4.3729e-05,
+                    "cumtime": 0.000130893,
+                    "cumtime_per": 0.000130893,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.6759000000000002e-05,
+                    "tottime_per": 1.4083684210526317e-06,
+                    "cumtime": 0.000124008,
+                    "cumtime_per": 6.526736842105263e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.312e-06,
+                    "tottime_per": 6.16e-07,
+                    "cumtime": 3.6908e-05,
+                    "cumtime_per": 5.272571428571428e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4811000000000001e-05,
+                    "tottime_per": 1.4811000000000001e-05,
+                    "cumtime": 3.4593e-05,
+                    "cumtime_per": 3.4593e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.4264000000000001e-05,
+                    "tottime_per": 1.584888888888889e-06,
+                    "cumtime": 3.2582e-05,
+                    "cumtime_per": 3.6202222222222225e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.013e-06,
+                    "tottime_per": 7.161428571428571e-07,
+                    "cumtime": 2.4594000000000002e-05,
+                    "cumtime_per": 3.5134285714285717e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.802e-06,
+                    "tottime_per": 6.006666666666667e-07,
+                    "cumtime": 2.4126000000000002e-05,
+                    "cumtime_per": 8.042e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.1410000000000003e-06,
+                    "tottime_per": 1.0705000000000002e-06,
+                    "cumtime": 1.8982000000000002e-05,
+                    "cumtime_per": 9.491000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.202000000000001e-06,
+                    "tottime_per": 9.202000000000001e-06,
+                    "cumtime": 1.8473e-05,
+                    "cumtime_per": 1.8473e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.455e-06,
+                    "tottime_per": 1.455e-06,
+                    "cumtime": 1.8432000000000002e-05,
+                    "cumtime_per": 1.8432000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.9260000000000003e-06,
+                    "tottime_per": 6.420000000000001e-07,
+                    "cumtime": 1.7264000000000003e-05,
+                    "cumtime_per": 5.754666666666668e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.3700000000000005e-06,
+                    "tottime_per": 4.3700000000000005e-06,
+                    "cumtime": 1.6212e-05,
+                    "cumtime_per": 1.6212e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.158000000000001e-06,
+                    "tottime_per": 7.158000000000001e-06,
+                    "cumtime": 1.6147e-05,
+                    "cumtime_per": 1.6147e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.2360000000000003e-06,
+                    "tottime_per": 1.1180000000000001e-06,
+                    "cumtime": 1.5237000000000002e-05,
+                    "cumtime_per": 7.618500000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.7050000000000002e-06,
+                    "tottime_per": 1.7050000000000002e-06,
+                    "cumtime": 1.4421000000000001e-05,
+                    "cumtime_per": 1.4421000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.46e-06,
+                    "tottime_per": 8.200000000000001e-07,
+                    "cumtime": 1.3989000000000001e-05,
+                    "cumtime_per": 4.663e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 3.6670000000000002e-06,
+                    "tottime_per": 1.2223333333333333e-06,
+                    "cumtime": 1.3307000000000002e-05,
+                    "cumtime_per": 4.435666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.3154000000000001e-05,
+                    "tottime_per": 1.4615555555555557e-06,
+                    "cumtime": 1.3154000000000001e-05,
+                    "cumtime_per": 1.4615555555555557e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1111000000000001e-05,
+                    "tottime_per": 1.1111000000000001e-05,
+                    "cumtime": 1.1740000000000001e-05,
+                    "cumtime_per": 1.1740000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.1529000000000001e-05,
+                    "tottime_per": 3.843e-06,
+                    "cumtime": 1.1529000000000001e-05,
+                    "cumtime_per": 3.843e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1501e-05,
+                    "tottime_per": 1.643e-06,
+                    "cumtime": 1.1501e-05,
+                    "cumtime_per": 1.643e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 4.892e-06,
+                    "tottime_per": 9.784e-07,
+                    "cumtime": 1.1261000000000001e-05,
+                    "cumtime_per": 2.2522000000000002e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.741e-06,
+                    "tottime_per": 9.741e-06,
+                    "cumtime": 9.741e-06,
+                    "cumtime_per": 9.741e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:155(<listcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2900000000000001e-06,
+                    "tottime_per": 1.2900000000000001e-06,
+                    "cumtime": 8.677e-06,
+                    "cumtime_per": 8.677e-06,
+                    "function_name": "<__array_function__ internals>:177(ones_like)"
+                }
+            ],
+            "stats": {
+                "min": 0.0001677209984336514,
+                "max": 0.00039920900235301815,
+                "mean": 0.0001863692990509574,
+                "stddev": 1.8783396477488067e-05,
+                "rounds": 2060,
+                "median": 0.00018118900152330752,
+                "iqr": 5.106998287374154e-06,
+                "q1": 0.00018013850058196113,
+                "q3": 0.00018524549886933528,
+                "iqr_outliers": 332,
+                "stddev_outliers": 146,
+                "outliers": "146;332",
+                "ld15iqr": 0.00017265499991481192,
+                "hd15iqr": 0.00019314800010761246,
+                "ops": 5365.690621214272,
+                "total": 0.3839207560449722,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_lstbinedges_modulus",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_lstbinedges_modulus",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.5388e-05,
+                    "tottime_per": 8.5388e-05,
+                    "cumtime": 0.00033962600000000004,
+                    "cumtime_per": 0.00033962600000000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.4024000000000004e-05,
+                    "tottime_per": 4.4024000000000004e-05,
+                    "cumtime": 0.000127922,
+                    "cumtime_per": 0.000127922,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.7216e-05,
+                    "tottime_per": 1.432421052631579e-06,
+                    "cumtime": 0.000124258,
+                    "cumtime_per": 6.539894736842105e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.2290000000000005e-06,
+                    "tottime_per": 6.041428571428572e-07,
+                    "cumtime": 3.7046000000000004e-05,
+                    "cumtime_per": 5.292285714285715e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5720000000000002e-05,
+                    "tottime_per": 1.5720000000000002e-05,
+                    "cumtime": 3.6684e-05,
+                    "cumtime_per": 3.6684e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.4465000000000001e-05,
+                    "tottime_per": 1.6072222222222225e-06,
+                    "cumtime": 3.2818e-05,
+                    "cumtime_per": 3.6464444444444448e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.0850000000000004e-06,
+                    "tottime_per": 7.264285714285715e-07,
+                    "cumtime": 2.4558e-05,
+                    "cumtime_per": 3.5082857142857144e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.79e-06,
+                    "tottime_per": 5.966666666666666e-07,
+                    "cumtime": 2.301e-05,
+                    "cumtime_per": 7.670000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3940000000000001e-06,
+                    "tottime_per": 1.3940000000000001e-06,
+                    "cumtime": 1.9737e-05,
+                    "cumtime_per": 1.9737e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.176e-06,
+                    "tottime_per": 1.088e-06,
+                    "cumtime": 1.9552000000000002e-05,
+                    "cumtime_per": 9.776000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.189000000000001e-06,
+                    "tottime_per": 9.189000000000001e-06,
+                    "cumtime": 1.8068e-05,
+                    "cumtime_per": 1.8068e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.4770000000000005e-06,
+                    "tottime_per": 4.4770000000000005e-06,
+                    "cumtime": 1.7407e-05,
+                    "cumtime_per": 1.7407e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.934e-06,
+                    "tottime_per": 6.446666666666666e-07,
+                    "cumtime": 1.7008e-05,
+                    "cumtime_per": 5.6693333333333335e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.4610000000000002e-06,
+                    "tottime_per": 1.2305000000000001e-06,
+                    "cumtime": 1.5806e-05,
+                    "cumtime_per": 7.903e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 6.5460000000000005e-06,
+                    "tottime_per": 6.5460000000000005e-06,
+                    "cumtime": 1.4915e-05,
+                    "cumtime_per": 1.4915e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2050000000000001e-06,
+                    "tottime_per": 1.2050000000000001e-06,
+                    "cumtime": 1.3813000000000001e-05,
+                    "cumtime_per": 1.3813000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.3324000000000002e-05,
+                    "tottime_per": 1.4804444444444447e-06,
+                    "cumtime": 1.3324000000000002e-05,
+                    "cumtime_per": 1.4804444444444447e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 3.7320000000000004e-06,
+                    "tottime_per": 1.244e-06,
+                    "cumtime": 1.3115e-05,
+                    "cumtime_per": 4.371666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.347e-06,
+                    "tottime_per": 7.823333333333334e-07,
+                    "cumtime": 1.2957000000000001e-05,
+                    "cumtime_per": 4.3190000000000005e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0739e-05,
+                    "tottime_per": 1.0739e-05,
+                    "cumtime": 1.1418000000000001e-05,
+                    "cumtime_per": 1.1418000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1298000000000001e-05,
+                    "tottime_per": 1.6140000000000001e-06,
+                    "cumtime": 1.1298000000000001e-05,
+                    "cumtime_per": 1.6140000000000001e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 4.466e-06,
+                    "tottime_per": 8.932e-07,
+                    "cumtime": 1.0850000000000001e-05,
+                    "cumtime_per": 2.1700000000000004e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.061e-05,
+                    "tottime_per": 3.5366666666666665e-06,
+                    "cumtime": 1.061e-05,
+                    "cumtime_per": 3.5366666666666665e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.417e-06,
+                    "tottime_per": 9.417e-06,
+                    "cumtime": 9.417e-06,
+                    "cumtime_per": 9.417e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:155(<listcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0140000000000002e-06,
+                    "tottime_per": 1.0140000000000002e-06,
+                    "cumtime": 8.179e-06,
+                    "cumtime_per": 8.179e-06,
+                    "function_name": "<__array_function__ internals>:177(ones_like)"
+                }
+            ],
+            "stats": {
+                "min": 0.00016322000010404736,
+                "max": 0.0004504370008362457,
+                "mean": 0.00018089479632929357,
+                "stddev": 1.4886639890019225e-05,
+                "rounds": 3903,
+                "median": 0.00017779500194592401,
+                "iqr": 8.844501280691475e-06,
+                "q1": 0.00017412699799024267,
+                "q3": 0.00018297149927093415,
+                "iqr_outliers": 386,
+                "stddev_outliers": 699,
+                "outliers": "699;386",
+                "ld15iqr": 0.00016322000010404736,
+                "hd15iqr": 0.00019626799985417165,
+                "ops": 5528.074993266476,
+                "total": 0.7060323900732328,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_one_point_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_one_point_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.7311e-05,
+                    "tottime_per": 1.7311e-05,
+                    "cumtime": 0.000310461,
+                    "cumtime_per": 0.000310461,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.4272000000000006e-05,
+                    "tottime_per": 4.4272000000000006e-05,
+                    "cumtime": 0.000282997,
+                    "cumtime_per": 0.000282997,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.0335e-05,
+                    "tottime_per": 2.0335e-06,
+                    "cumtime": 0.000210623,
+                    "cumtime_per": 2.10623e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.0000000000000003e-06,
+                    "tottime_per": 1.0000000000000002e-06,
+                    "cumtime": 0.00016403700000000002,
+                    "cumtime_per": 8.201850000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.248e-06,
+                    "tottime_per": 1.624e-06,
+                    "cumtime": 0.000160568,
+                    "cumtime_per": 8.0284e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.641e-06,
+                    "tottime_per": 8.205e-07,
+                    "cumtime": 0.0001572,
+                    "cumtime_per": 7.86e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.346e-05,
+                    "tottime_per": 1.673e-05,
+                    "cumtime": 0.00015378400000000002,
+                    "cumtime_per": 7.689200000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 9.241e-06,
+                    "tottime_per": 7.700833333333333e-07,
+                    "cumtime": 7.6618e-05,
+                    "cumtime_per": 6.384833333333334e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.2119e-05,
+                    "tottime_per": 1.0099166666666668e-06,
+                    "cumtime": 6.0230000000000004e-05,
+                    "cumtime_per": 5.019166666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 1.8908000000000003e-05,
+                    "tottime_per": 1.2605333333333335e-06,
+                    "cumtime": 5.614e-05,
+                    "cumtime_per": 3.7426666666666668e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 1.6372000000000002e-05,
+                    "tottime_per": 4.0930000000000005e-06,
+                    "cumtime": 4.9446e-05,
+                    "cumtime_per": 1.23615e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.8153000000000003e-05,
+                    "tottime_per": 1.8768666666666668e-06,
+                    "cumtime": 2.8153000000000003e-05,
+                    "cumtime_per": 1.8768666666666668e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.2582e-05,
+                    "tottime_per": 1.57275e-06,
+                    "cumtime": 2.6097e-05,
+                    "cumtime_per": 3.262125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 9.514e-06,
+                    "tottime_per": 3.1713333333333334e-06,
+                    "cumtime": 2.0260000000000003e-05,
+                    "cumtime_per": 6.7533333333333345e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.899e-06,
+                    "tottime_per": 7.2475e-07,
+                    "cumtime": 1.7994e-05,
+                    "cumtime_per": 4.4985e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 6.451000000000001e-06,
+                    "tottime_per": 1.0751666666666667e-06,
+                    "cumtime": 1.666e-05,
+                    "cumtime_per": 2.7766666666666666e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.230000000000001e-07,
+                    "tottime_per": 8.230000000000001e-07,
+                    "cumtime": 1.4313000000000002e-05,
+                    "cumtime_per": 1.4313000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.6080000000000003e-06,
+                    "tottime_per": 6.520000000000001e-07,
+                    "cumtime": 1.361e-05,
+                    "cumtime_per": 3.4025e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.237e-06,
+                    "tottime_per": 1.237e-06,
+                    "cumtime": 1.2630000000000001e-05,
+                    "cumtime_per": 1.2630000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.824e-06,
+                    "tottime_per": 3.824e-06,
+                    "cumtime": 1.232e-05,
+                    "cumtime_per": 1.232e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.3290000000000001e-06,
+                    "tottime_per": 6.645000000000001e-07,
+                    "cumtime": 1.1825000000000001e-05,
+                    "cumtime_per": 5.9125000000000006e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 9.396000000000001e-06,
+                    "tottime_per": 1.1745000000000001e-06,
+                    "cumtime": 9.976e-06,
+                    "cumtime_per": 1.247e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.5780000000000002e-06,
+                    "tottime_per": 7.890000000000001e-07,
+                    "cumtime": 8.124e-06,
+                    "cumtime_per": 4.062e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 7.840000000000001e-06,
+                    "tottime_per": 5.226666666666668e-07,
+                    "cumtime": 7.840000000000001e-06,
+                    "cumtime_per": 5.226666666666668e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.521e-06,
+                    "tottime_per": 2.521e-06,
+                    "cumtime": 7.631e-06,
+                    "cumtime_per": 7.631e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.00014598200141335838,
+                "max": 0.0005297050010995008,
+                "mean": 0.00015557917589997328,
+                "stddev": 1.9881407119900317e-05,
+                "rounds": 1444,
+                "median": 0.00015163300122367218,
+                "iqr": 4.728000931208953e-06,
+                "q1": 0.00015023749983811285,
+                "q3": 0.0001549655007693218,
+                "iqr_outliers": 147,
+                "stddev_outliers": 59,
+                "outliers": "59;147",
+                "ld15iqr": 0.00014598200141335838,
+                "hd15iqr": 0.00016206699729082175,
+                "ops": 6427.595429885368,
+                "total": 0.22465632999956142,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes0]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes0]",
+            "params": {
+                "ntimes": [
+                    4
+                ]
+            },
+            "param": "ntimes0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.9976e-05,
+                    "tottime_per": 1.9976e-05,
+                    "cumtime": 0.00036671200000000005,
+                    "cumtime_per": 0.00036671200000000005,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.1123000000000005e-05,
+                    "tottime_per": 5.1123000000000005e-05,
+                    "cumtime": 0.000336471,
+                    "cumtime_per": 0.000336471,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.1461e-05,
+                    "tottime_per": 2.1461e-06,
+                    "cumtime": 0.000254586,
+                    "cumtime_per": 2.54586e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.137e-06,
+                    "tottime_per": 1.0685e-06,
+                    "cumtime": 0.000206805,
+                    "cumtime_per": 0.0001034025,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.609e-06,
+                    "tottime_per": 1.8045e-06,
+                    "cumtime": 0.00020320400000000001,
+                    "cumtime_per": 0.00010160200000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.925e-06,
+                    "tottime_per": 9.625e-07,
+                    "cumtime": 0.000199439,
+                    "cumtime_per": 9.97195e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.8667e-05,
+                    "tottime_per": 2.43335e-05,
+                    "cumtime": 0.00019536500000000002,
+                    "cumtime_per": 9.768250000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 9.665e-06,
+                    "tottime_per": 8.054166666666666e-07,
+                    "cumtime": 8.115000000000001e-05,
+                    "cumtime_per": 6.762500000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.4028e-05,
+                    "tottime_per": 8.507e-06,
+                    "cumtime": 6.944500000000001e-05,
+                    "cumtime_per": 1.7361250000000003e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.2407e-05,
+                    "tottime_per": 1.0339166666666667e-06,
+                    "cumtime": 6.404300000000001e-05,
+                    "cumtime_per": 5.336916666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.0063e-05,
+                    "tottime_per": 1.3375333333333333e-06,
+                    "cumtime": 6.0721000000000004e-05,
+                    "cumtime_per": 4.048066666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 3.0972e-05,
+                    "tottime_per": 2.0648e-06,
+                    "cumtime": 3.0972e-05,
+                    "cumtime_per": 2.0648e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.3384000000000001e-05,
+                    "tottime_per": 1.6730000000000001e-06,
+                    "cumtime": 2.7896000000000002e-05,
+                    "cumtime_per": 3.4870000000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.0232000000000001e-05,
+                    "tottime_per": 3.4106666666666672e-06,
+                    "cumtime": 2.1209e-05,
+                    "cumtime_per": 7.069666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.989e-06,
+                    "tottime_per": 7.4725e-07,
+                    "cumtime": 1.9256e-05,
+                    "cumtime_per": 4.814e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 6.740000000000001e-06,
+                    "tottime_per": 1.1233333333333335e-06,
+                    "cumtime": 1.7399e-05,
+                    "cumtime_per": 2.8998333333333336e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.972e-06,
+                    "tottime_per": 7.43e-07,
+                    "cumtime": 1.4601000000000001e-05,
+                    "cumtime_per": 3.6502500000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.81e-07,
+                    "tottime_per": 9.81e-07,
+                    "cumtime": 1.4559e-05,
+                    "cumtime_per": 1.4559e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.2330000000000005e-06,
+                    "tottime_per": 5.2330000000000005e-06,
+                    "cumtime": 1.4339000000000001e-05,
+                    "cumtime_per": 1.4339000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.23e-06,
+                    "tottime_per": 1.23e-06,
+                    "cumtime": 1.2675000000000001e-05,
+                    "cumtime_per": 1.2675000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.4820000000000002e-06,
+                    "tottime_per": 7.410000000000001e-07,
+                    "cumtime": 1.2578e-05,
+                    "cumtime_per": 6.289e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 9.970000000000001e-06,
+                    "tottime_per": 1.2462500000000001e-06,
+                    "cumtime": 1.059e-05,
+                    "cumtime_per": 1.32375e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.658e-06,
+                    "tottime_per": 8.29e-07,
+                    "cumtime": 8.609e-06,
+                    "cumtime_per": 4.3045e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 8.23e-06,
+                    "tottime_per": 5.486666666666667e-07,
+                    "cumtime": 8.23e-06,
+                    "cumtime_per": 5.486666666666667e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.6770000000000004e-06,
+                    "tottime_per": 2.6770000000000004e-06,
+                    "cumtime": 7.638e-06,
+                    "cumtime_per": 7.638e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.00014875199849484488,
+                "max": 0.0005022210025344975,
+                "mean": 0.00016167976446373824,
+                "stddev": 1.2162007207362978e-05,
+                "rounds": 2522,
+                "median": 0.00015928150060062762,
+                "iqr": 4.294994141673669e-06,
+                "q1": 0.0001577560033183545,
+                "q3": 0.00016205099746002816,
+                "iqr_outliers": 288,
+                "stddev_outliers": 185,
+                "outliers": "185;288",
+                "ld15iqr": 0.00015134900240809657,
+                "hd15iqr": 0.00016876700101420283,
+                "ops": 6185.065912959574,
+                "total": 0.40775636597754783,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes1]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes1]",
+            "params": {
+                "ntimes": [
+                    5,
+                    4
+                ]
+            },
+            "param": "ntimes1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.7503e-05,
+                    "tottime_per": 2.7503e-05,
+                    "cumtime": 0.0006219330000000001,
+                    "cumtime_per": 0.0006219330000000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 9.283e-05,
+                    "tottime_per": 4.6415e-05,
+                    "cumtime": 0.000582412,
+                    "cumtime_per": 0.000291206,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "51/19",
+                    "ncalls": 51,
+                    "tottime": 4.1037e-05,
+                    "tottime_per": 2.159842105263158e-06,
+                    "cumtime": 0.00043382900000000005,
+                    "cumtime_per": 2.2833105263157897e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.588e-06,
+                    "tottime_per": 8.97e-07,
+                    "cumtime": 0.000342837,
+                    "cumtime_per": 8.570925e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.046000000000001e-06,
+                    "tottime_per": 1.7615000000000002e-06,
+                    "cumtime": 0.000336181,
+                    "cumtime_per": 8.404525e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.366e-06,
+                    "tottime_per": 8.415e-07,
+                    "cumtime": 0.000328771,
+                    "cumtime_per": 8.219275e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 6.9714e-05,
+                    "tottime_per": 1.74285e-05,
+                    "cumtime": 0.000321225,
+                    "cumtime_per": 8.030625e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 1.8381000000000002e-05,
+                    "tottime_per": 7.658750000000001e-07,
+                    "cumtime": 0.000155904,
+                    "cumtime_per": 6.496e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 2.3964000000000003e-05,
+                    "tottime_per": 9.985e-07,
+                    "cumtime": 0.000122698,
+                    "cumtime_per": 5.112416666666666e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 3.6622e-05,
+                    "tottime_per": 1.2207333333333334e-06,
+                    "cumtime": 0.00011625900000000001,
+                    "cumtime_per": 3.875300000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.2674e-05,
+                    "tottime_per": 4.08425e-06,
+                    "cumtime": 0.000101347,
+                    "cumtime_per": 1.2668375e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 6.0898000000000005e-05,
+                    "tottime_per": 2.0299333333333337e-06,
+                    "cumtime": 6.0898000000000005e-05,
+                    "cumtime_per": 2.0299333333333337e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 2.5552000000000002e-05,
+                    "tottime_per": 1.5970000000000001e-06,
+                    "cumtime": 5.3893e-05,
+                    "cumtime_per": 3.3683125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 1.9459e-05,
+                    "tottime_per": 3.2431666666666667e-06,
+                    "cumtime": 4.1515000000000005e-05,
+                    "cumtime_per": 6.919166666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 6.054e-06,
+                    "tottime_per": 7.5675e-07,
+                    "cumtime": 3.7002e-05,
+                    "cumtime_per": 4.62525e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "11",
+                    "ncalls": 11,
+                    "tottime": 1.1094e-05,
+                    "tottime_per": 1.0085454545454546e-06,
+                    "cumtime": 3.0633e-05,
+                    "cumtime_per": 2.784818181818182e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.652e-06,
+                    "tottime_per": 8.26e-07,
+                    "cumtime": 2.9167e-05,
+                    "cumtime_per": 1.45835e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 5.404e-06,
+                    "tottime_per": 6.755e-07,
+                    "cumtime": 2.8349000000000003e-05,
+                    "cumtime_per": 3.5436250000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.362e-06,
+                    "tottime_per": 1.181e-06,
+                    "cumtime": 2.5867e-05,
+                    "cumtime_per": 1.29335e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.9470000000000003e-06,
+                    "tottime_per": 7.367500000000001e-07,
+                    "cumtime": 2.4820000000000003e-05,
+                    "cumtime_per": 6.205000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 8.207000000000001e-06,
+                    "tottime_per": 4.103500000000001e-06,
+                    "cumtime": 2.4377e-05,
+                    "cumtime_per": 1.21885e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 1.912e-05,
+                    "tottime_per": 1.195e-06,
+                    "cumtime": 2.0534e-05,
+                    "cumtime_per": 1.283375e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.3740000000000002e-06,
+                    "tottime_per": 8.435000000000001e-07,
+                    "cumtime": 1.7012000000000002e-05,
+                    "cumtime_per": 4.253000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 1.6123e-05,
+                    "tottime_per": 5.374333333333333e-07,
+                    "cumtime": 1.6123e-05,
+                    "cumtime_per": 5.374333333333333e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 4.164e-06,
+                    "tottime_per": 1.041e-06,
+                    "cumtime": 1.4493000000000002e-05,
+                    "cumtime_per": 3.6232500000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:113(_copyto)"
+                }
+            ],
+            "stats": {
+                "min": 0.00029319600071175955,
+                "max": 0.0007586370011267718,
+                "mean": 0.0003193955300735487,
+                "stddev": 3.2527025577336854e-05,
+                "rounds": 2290,
+                "median": 0.00031459199999517296,
+                "iqr": 8.414001058554277e-06,
+                "q1": 0.00030933400194044225,
+                "q3": 0.0003177480029989965,
+                "iqr_outliers": 301,
+                "stddev_outliers": 72,
+                "outliers": "72;301",
+                "ld15iqr": 0.00029685899789910764,
+                "hd15iqr": 0.0003303970006527379,
+                "ops": 3130.9141983600252,
+                "total": 0.7314157638684264,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sigma_clip_without_outliers",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAverage::test_sigma_clip_without_outliers",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.170100000000001e-05,
+                    "tottime_per": 7.170100000000001e-05,
+                    "cumtime": 0.00115332,
+                    "cumtime_per": 0.00115332,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "43/15",
+                    "ncalls": 43,
+                    "tottime": 4.1155e-05,
+                    "tottime_per": 2.7436666666666667e-06,
+                    "cumtime": 0.001018776,
+                    "cumtime_per": 6.791840000000001e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.9897000000000003e-05,
+                    "tottime_per": 1.9897000000000003e-05,
+                    "cumtime": 0.0007761160000000001,
+                    "cumtime_per": 0.0007761160000000001,
+                    "function_name": "hera_cal/hera_cal/lstbin.py:1095(sigma_clip)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.004e-06,
+                    "tottime_per": 1.002e-06,
+                    "cumtime": 0.00073443,
+                    "cumtime_per": 0.000367215,
+                    "function_name": "<__array_function__ internals>:177(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.1600000000000006e-06,
+                    "tottime_per": 2.5800000000000003e-06,
+                    "cumtime": 0.00073083,
+                    "cumtime_per": 0.000365415,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1126(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "4/2",
+                    "ncalls": 4,
+                    "tottime": 1.6283e-05,
+                    "tottime_per": 8.1415e-06,
+                    "cumtime": 0.000725445,
+                    "cumtime_per": 0.0003627225,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:3674(_ureduce)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.804e-06,
+                    "tottime_per": 1.402e-06,
+                    "cumtime": 0.000707536,
+                    "cumtime_per": 0.000353768,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1075(_nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.0899e-05,
+                    "tottime_per": 5.4495e-06,
+                    "cumtime": 0.000704732,
+                    "cumtime_per": 0.000352366,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1101(_nanmedian_small)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.466e-06,
+                    "tottime_per": 1.233e-06,
+                    "cumtime": 0.000634236,
+                    "cumtime_per": 0.000317118,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:660(median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.0087000000000004e-05,
+                    "tottime_per": 2.0043500000000002e-05,
+                    "cumtime": 0.000615471,
+                    "cumtime_per": 0.0003077355,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:743(_median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.1850000000000003e-06,
+                    "tottime_per": 1.0925000000000001e-06,
+                    "cumtime": 0.00019914300000000001,
+                    "cumtime_per": 9.957150000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.2000000000000004e-06,
+                    "tottime_per": 2.1000000000000002e-06,
+                    "cumtime": 0.00019532500000000002,
+                    "cumtime_per": 9.766250000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.1860000000000003e-06,
+                    "tottime_per": 1.0930000000000002e-06,
+                    "cumtime": 0.00019098200000000002,
+                    "cumtime_per": 9.549100000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.446e-05,
+                    "tottime_per": 7.23e-06,
+                    "cumtime": 0.00018930500000000002,
+                    "cumtime_per": 9.465250000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/utils.py:1021(_median_nancheck)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.2413e-05,
+                    "tottime_per": 2.12065e-05,
+                    "cumtime": 0.00018651600000000001,
+                    "cumtime_per": 9.325800000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.999e-06,
+                    "tottime_per": 1.4995e-06,
+                    "cumtime": 0.000179948,
+                    "cumtime_per": 8.9974e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6936(sort)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 6.888800000000001e-05,
+                    "tottime_per": 3.827111111111112e-06,
+                    "cumtime": 0.000173436,
+                    "cumtime_per": 9.635333333333334e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2972(__array_finalize__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.349e-06,
+                    "tottime_per": 8.3725e-07,
+                    "cumtime": 0.000167858,
+                    "cumtime_per": 4.19645e-05,
+                    "function_name": "<__array_function__ internals>:177(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.722e-06,
+                    "tottime_per": 1.9305e-06,
+                    "cumtime": 0.00016076800000000002,
+                    "cumtime_per": 4.0192000000000004e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/shape_base.py:56(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.1430000000000006e-06,
+                    "tottime_per": 2.5715000000000003e-06,
+                    "cumtime": 0.000143172,
+                    "cumtime_per": 7.1586e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:5622(sort)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.7413e-05,
+                    "tottime_per": 7.902166666666667e-06,
+                    "cumtime": 0.000135807,
+                    "cumtime_per": 2.2634499999999998e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:3211(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "48/46",
+                    "ncalls": 48,
+                    "tottime": 1.3787e-05,
+                    "tottime_per": 2.9971739130434783e-07,
+                    "cumtime": 0.000125768,
+                    "cumtime_per": 2.734086956521739e-06,
+                    "function_name": "~:0(<method 'view' of 'numpy.ndarray' objects>)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 1.2876e-05,
+                    "tottime_per": 9.197142857142857e-07,
+                    "cumtime": 0.000107256,
+                    "cumtime_per": 7.661142857142858e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "26",
+                    "ncalls": 26,
+                    "tottime": 6.8986e-05,
+                    "tottime_per": 2.6533076923076924e-06,
+                    "cumtime": 9.8113e-05,
+                    "cumtime_per": 3.7735769230769233e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2946(_update_from)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 6.965e-06,
+                    "tottime_per": 1.74125e-06,
+                    "cumtime": 9.233800000000001e-05,
+                    "cumtime_per": 2.3084500000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6816(__call__)"
+                }
+            ],
+            "stats": {
+                "min": 0.000537133000761969,
+                "max": 0.0009200329986924771,
+                "mean": 0.0005954967733055606,
+                "stddev": 3.5040402327127075e-05,
+                "rounds": 666,
+                "median": 0.0005892184999538586,
+                "iqr": 2.8136997570982203e-05,
+                "q1": 0.0005760210005973931,
+                "q3": 0.0006041579981683753,
+                "iqr_outliers": 45,
+                "stddev_outliers": 108,
+                "outliers": "108;45",
+                "ld15iqr": 0.000537133000761969,
+                "hd15iqr": 0.0006468240026151761,
+                "ops": 1679.2702241677491,
+                "total": 0.39660085102150333,
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2023-05-10T22:08:36.645548",
+    "version": "4.0.0"
+}

--- a/.benchmarks/Linux-CPython-3.10-64bit/0002_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_220918_uncommited-changes.json
+++ b/.benchmarks/Linux-CPython-3.10-64bit/0002_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_220918_uncommited-changes.json
@@ -1,0 +1,4750 @@
+{
+    "machine_info": {
+        "node": "LAPTOP-J64LT06Q",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC 10.4.0",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.10.6",
+        "python_version": "3.10.6",
+        "python_build": [
+            "main",
+            "Aug 22 2022 20:36:39"
+        ],
+        "release": "5.15.90.1-microsoft-standard-WSL2",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.10.6.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 16,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "GenuineIntel",
+            "brand_raw": "11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz",
+            "hz_advertised_friendly": "2.3000 GHz",
+            "hz_actual_friendly": "2.3040 GHz",
+            "hz_advertised": [
+                2300000000,
+                0
+            ],
+            "hz_actual": [
+                2304008000,
+                0
+            ],
+            "stepping": 1,
+            "model": 141,
+            "family": 6,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arch_capabilities",
+                "arch_perfmon",
+                "avx",
+                "avx2",
+                "avx512_bitalg",
+                "avx512_vbmi2",
+                "avx512_vnni",
+                "avx512_vp2intersect",
+                "avx512_vpopcntdq",
+                "avx512bitalg",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512ifma",
+                "avx512vbmi",
+                "avx512vbmi2",
+                "avx512vl",
+                "avx512vnni",
+                "avx512vpopcntdq",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "clwb",
+                "cmov",
+                "constant_tsc",
+                "cpuid",
+                "cx16",
+                "cx8",
+                "de",
+                "ept",
+                "ept_ad",
+                "erms",
+                "f16c",
+                "flush_l1d",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fsrm",
+                "fxsr",
+                "gfni",
+                "ht",
+                "hypervisor",
+                "ibpb",
+                "ibrs",
+                "ibrs_enhanced",
+                "invpcid",
+                "invpcid_single",
+                "lahf_lm",
+                "lm",
+                "mca",
+                "mce",
+                "mmx",
+                "movbe",
+                "movdir64b",
+                "movdiri",
+                "msr",
+                "mtrr",
+                "nonstop_tsc",
+                "nopl",
+                "nx",
+                "osxsave",
+                "pae",
+                "pat",
+                "pcid",
+                "pclmulqdq",
+                "pdcm",
+                "pdpe1gb",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdpid",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "sep",
+                "sha",
+                "sha_ni",
+                "smap",
+                "smep",
+                "ss",
+                "ssbd",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "stibp",
+                "syscall",
+                "tpr_shadow",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_reliable",
+                "tscdeadline",
+                "umip",
+                "vaes",
+                "vme",
+                "vmx",
+                "vnmi",
+                "vpclmulqdq",
+                "vpid",
+                "x2apic",
+                "xgetbv1",
+                "xsave",
+                "xsavec",
+                "xsaveopt",
+                "xsaves",
+                "xtopology"
+            ],
+            "l3_cache_size": 25165824,
+            "l2_cache_size": 10485760,
+            "l1_data_cache_size": 393216,
+            "l1_instruction_cache_size": 262144,
+            "l2_cache_line_size": 256,
+            "l2_cache_associativity": 7
+        }
+    },
+    "commit_info": {
+        "id": "3a0f8a44c3a469bd3e3d27009467f90515500b11",
+        "time": "2023-05-10T10:32:33-07:00",
+        "author_time": "2023-05-10T10:32:33-07:00",
+        "dirty": true,
+        "project": "hera_cal",
+        "branch": "lstbin-improvements"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_increasing_lsts_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_increasing_lsts_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.3514e-05,
+                    "tottime_per": 7.3514e-05,
+                    "cumtime": 0.00018612400000000002,
+                    "cumtime_per": 0.00018612400000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "11/10",
+                    "ncalls": 11,
+                    "tottime": 1.2191e-05,
+                    "tottime_per": 1.2191000000000001e-06,
+                    "cumtime": 7.21e-05,
+                    "cumtime_per": 7.2100000000000004e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5833000000000002e-05,
+                    "tottime_per": 1.5833000000000002e-05,
+                    "cumtime": 3.7071000000000005e-05,
+                    "cumtime_per": 3.7071000000000005e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.432e-06,
+                    "tottime_per": 7.386666666666667e-07,
+                    "cumtime": 3.2694e-05,
+                    "cumtime_per": 5.449000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1425e-05,
+                    "tottime_per": 1.6321428571428571e-06,
+                    "cumtime": 2.5475000000000003e-05,
+                    "cumtime_per": 3.6392857142857145e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.454e-06,
+                    "tottime_per": 7.423333333333334e-07,
+                    "cumtime": 2.1638000000000002e-05,
+                    "cumtime_per": 3.6063333333333335e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.105e-06,
+                    "tottime_per": 1.105e-06,
+                    "cumtime": 2.0063e-05,
+                    "cumtime_per": 2.0063e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.52e-06,
+                    "tottime_per": 4.52e-06,
+                    "cumtime": 1.7992e-05,
+                    "cumtime_per": 1.7992e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.7720000000000001e-06,
+                    "tottime_per": 1.7720000000000001e-06,
+                    "cumtime": 1.4828000000000001e-05,
+                    "cumtime_per": 1.4828000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1034000000000001e-05,
+                    "tottime_per": 1.1034000000000001e-05,
+                    "cumtime": 1.1878e-05,
+                    "cumtime_per": 1.1878e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3010000000000001e-06,
+                    "tottime_per": 1.3010000000000001e-06,
+                    "cumtime": 1.1573e-05,
+                    "cumtime_per": 1.1573e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 9.616e-06,
+                    "tottime_per": 1.3737142857142859e-06,
+                    "cumtime": 9.616e-06,
+                    "cumtime_per": 1.3737142857142859e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1180000000000001e-06,
+                    "tottime_per": 1.1180000000000001e-06,
+                    "cumtime": 9.409000000000001e-06,
+                    "cumtime_per": 9.409000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.307e-06,
+                    "tottime_per": 2.307e-06,
+                    "cumtime": 9.192000000000001e-06,
+                    "cumtime_per": 9.192000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.007e-06,
+                    "tottime_per": 1.007e-06,
+                    "cumtime": 7.5720000000000005e-06,
+                    "cumtime_per": 7.5720000000000005e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.522e-06,
+                    "tottime_per": 2.522e-06,
+                    "cumtime": 6.25e-06,
+                    "cumtime_per": 6.25e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1040000000000001e-06,
+                    "tottime_per": 1.1040000000000001e-06,
+                    "cumtime": 5.341e-06,
+                    "cumtime_per": 5.341e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.429e-06,
+                    "tottime_per": 1.429e-06,
+                    "cumtime": 5.228000000000001e-06,
+                    "cumtime_per": 5.228000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.99e-06,
+                    "tottime_per": 2.99e-06,
+                    "cumtime": 4.237e-06,
+                    "cumtime_per": 4.237e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.169e-06,
+                    "tottime_per": 1.5845e-06,
+                    "cumtime": 3.6510000000000003e-06,
+                    "cumtime_per": 1.8255000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 3.587e-06,
+                    "tottime_per": 5.124285714285714e-07,
+                    "cumtime": 3.587e-06,
+                    "cumtime_per": 5.124285714285714e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.2190000000000003e-06,
+                    "tottime_per": 2.2190000000000003e-06,
+                    "cumtime": 2.2190000000000003e-06,
+                    "cumtime_per": 2.2190000000000003e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "19",
+                    "ncalls": 19,
+                    "tottime": 1.813e-06,
+                    "tottime_per": 9.542105263157895e-08,
+                    "cumtime": 1.813e-06,
+                    "cumtime_per": 9.542105263157895e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.419e-06,
+                    "tottime_per": 1.419e-06,
+                    "cumtime": 1.419e-06,
+                    "cumtime_per": 1.419e-06,
+                    "function_name": "~:0(<built-in method numpy.zeros>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.040000000000001e-07,
+                    "tottime_per": 7.040000000000001e-07,
+                    "cumtime": 1.176e-06,
+                    "cumtime_per": 1.176e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                }
+            ],
+            "stats": {
+                "min": 8.342000000993721e-05,
+                "max": 0.0001609149985597469,
+                "mean": 8.997826177878567e-05,
+                "stddev": 1.0078966507254847e-05,
+                "rounds": 302,
+                "median": 8.704450010554865e-05,
+                "iqr": 4.289999196771532e-06,
+                "q1": 8.566399992560036e-05,
+                "q3": 8.99539991223719e-05,
+                "iqr_outliers": 28,
+                "stddev_outliers": 21,
+                "outliers": "21;28",
+                "ld15iqr": 8.342000000993721e-05,
+                "hd15iqr": 9.64760001807008e-05,
+                "ops": 11113.795490498926,
+                "total": 0.027173435057193274,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.4231e-05,
+                    "tottime_per": 7.4231e-05,
+                    "cumtime": 0.00018001100000000002,
+                    "cumtime_per": 0.00018001100000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.0861e-05,
+                    "tottime_per": 9.873636363636364e-07,
+                    "cumtime": 6.8503e-05,
+                    "cumtime_per": 6.227545454545455e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.4990000000000005e-06,
+                    "tottime_per": 6.427142857142858e-07,
+                    "cumtime": 3.4919e-05,
+                    "cumtime_per": 4.9884285714285715e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3834e-05,
+                    "tottime_per": 1.3834e-05,
+                    "cumtime": 3.3018e-05,
+                    "cumtime_per": 3.3018e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.1907000000000001e-05,
+                    "tottime_per": 1.4883750000000002e-06,
+                    "cumtime": 2.5637000000000002e-05,
+                    "cumtime_per": 3.2046250000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.984e-06,
+                    "tottime_per": 7.12e-07,
+                    "cumtime": 2.3134000000000002e-05,
+                    "cumtime_per": 3.304857142857143e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2080000000000001e-06,
+                    "tottime_per": 1.2080000000000001e-06,
+                    "cumtime": 1.7784e-05,
+                    "cumtime_per": 1.7784e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.3480000000000006e-06,
+                    "tottime_per": 4.3480000000000006e-06,
+                    "cumtime": 1.5654e-05,
+                    "cumtime_per": 1.5654e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.249e-06,
+                    "tottime_per": 1.249e-06,
+                    "cumtime": 1.3029e-05,
+                    "cumtime_per": 1.3029e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0297e-05,
+                    "tottime_per": 1.0297e-05,
+                    "cumtime": 1.0871000000000001e-05,
+                    "cumtime_per": 1.0871000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.277e-06,
+                    "tottime_per": 1.277e-06,
+                    "cumtime": 1.0585000000000001e-05,
+                    "cumtime_per": 1.0585000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 9.482e-06,
+                    "tottime_per": 1.18525e-06,
+                    "cumtime": 9.482e-06,
+                    "cumtime_per": 1.18525e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.139e-06,
+                    "tottime_per": 1.139e-06,
+                    "cumtime": 8.626e-06,
+                    "cumtime_per": 8.626e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.006e-06,
+                    "tottime_per": 3.006e-06,
+                    "cumtime": 8.324e-06,
+                    "cumtime_per": 8.324e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.330000000000001e-07,
+                    "tottime_per": 9.330000000000001e-07,
+                    "cumtime": 5.973e-06,
+                    "cumtime_per": 5.973e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.2930000000000003e-06,
+                    "tottime_per": 2.2930000000000003e-06,
+                    "cumtime": 4.877e-06,
+                    "cumtime_per": 4.877e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5520000000000001e-06,
+                    "tottime_per": 1.5520000000000001e-06,
+                    "cumtime": 4.748e-06,
+                    "cumtime_per": 4.748e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.330000000000001e-07,
+                    "tottime_per": 9.330000000000001e-07,
+                    "cumtime": 4.1730000000000005e-06,
+                    "cumtime_per": 4.1730000000000005e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.558e-06,
+                    "tottime_per": 4.4475e-07,
+                    "cumtime": 3.558e-06,
+                    "cumtime_per": 4.4475e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.031e-06,
+                    "tottime_per": 2.031e-06,
+                    "cumtime": 3.2400000000000003e-06,
+                    "cumtime_per": 3.2400000000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.623e-06,
+                    "tottime_per": 1.3115e-06,
+                    "cumtime": 3.033e-06,
+                    "cumtime_per": 1.5165e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.621e-06,
+                    "tottime_per": 1.621e-06,
+                    "cumtime": 1.621e-06,
+                    "cumtime_per": 1.621e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 1.568e-06,
+                    "tottime_per": 7.127272727272728e-08,
+                    "cumtime": 1.568e-06,
+                    "cumtime_per": 7.127272727272728e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.328e-06,
+                    "tottime_per": 1.897142857142857e-07,
+                    "cumtime": 1.328e-06,
+                    "cumtime_per": 1.897142857142857e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2302(_any_dispatcher)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1460000000000001e-06,
+                    "tottime_per": 1.1460000000000001e-06,
+                    "cumtime": 1.1460000000000001e-06,
+                    "cumtime_per": 1.1460000000000001e-06,
+                    "function_name": "~:0(<built-in method numpy.zeros>)"
+                }
+            ],
+            "stats": {
+                "min": 8.355700265383348e-05,
+                "max": 0.00022159400032251142,
+                "mean": 9.445648445378406e-05,
+                "stddev": 1.3229738631007394e-05,
+                "rounds": 578,
+                "median": 9.135549953498412e-05,
+                "iqr": 1.1538999387994409e-05,
+                "q1": 8.661200263304636e-05,
+                "q3": 9.815100202104077e-05,
+                "iqr_outliers": 26,
+                "stddev_outliers": 41,
+                "outliers": "41;26",
+                "ld15iqr": 8.355700265383348e-05,
+                "hd15iqr": 0.00011614599861786701,
+                "ops": 10586.885651977476,
+                "total": 0.054595848014287185,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_flagging",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_flagging",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.4317e-05,
+                    "tottime_per": 7.4317e-05,
+                    "cumtime": 0.000184133,
+                    "cumtime_per": 0.000184133,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.1698e-05,
+                    "tottime_per": 1.0634545454545454e-06,
+                    "cumtime": 7.194800000000001e-05,
+                    "cumtime_per": 6.540727272727273e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.449e-06,
+                    "tottime_per": 6.355714285714286e-07,
+                    "cumtime": 3.6404e-05,
+                    "cumtime_per": 5.200571428571429e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5258e-05,
+                    "tottime_per": 1.5258e-05,
+                    "cumtime": 3.4405e-05,
+                    "cumtime_per": 3.4405e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.2882000000000001e-05,
+                    "tottime_per": 1.6102500000000002e-06,
+                    "cumtime": 2.7571e-05,
+                    "cumtime_per": 3.446375e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.855e-06,
+                    "tottime_per": 6.935714285714286e-07,
+                    "cumtime": 2.4254000000000002e-05,
+                    "cumtime_per": 3.464857142857143e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.302e-06,
+                    "tottime_per": 1.302e-06,
+                    "cumtime": 1.8044000000000002e-05,
+                    "cumtime_per": 1.8044000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.292000000000001e-06,
+                    "tottime_per": 4.292000000000001e-06,
+                    "cumtime": 1.5752e-05,
+                    "cumtime_per": 1.5752e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2990000000000002e-06,
+                    "tottime_per": 1.2990000000000002e-06,
+                    "cumtime": 1.3993000000000001e-05,
+                    "cumtime_per": 1.3993000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1047000000000001e-05,
+                    "tottime_per": 1.1047000000000001e-05,
+                    "cumtime": 1.1643e-05,
+                    "cumtime_per": 1.1643e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1240000000000002e-06,
+                    "tottime_per": 1.1240000000000002e-06,
+                    "cumtime": 1.1121e-05,
+                    "cumtime_per": 1.1121e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0322e-05,
+                    "tottime_per": 1.29025e-06,
+                    "cumtime": 1.0322e-05,
+                    "cumtime_per": 1.29025e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.026e-06,
+                    "tottime_per": 1.026e-06,
+                    "cumtime": 9.198e-06,
+                    "cumtime_per": 9.198e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.4610000000000002e-06,
+                    "tottime_per": 2.4610000000000002e-06,
+                    "cumtime": 8.5e-06,
+                    "cumtime_per": 8.5e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.085e-06,
+                    "tottime_per": 1.085e-06,
+                    "cumtime": 6.698e-06,
+                    "cumtime_per": 6.698e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.4570000000000004e-06,
+                    "tottime_per": 2.4570000000000004e-06,
+                    "cumtime": 5.118e-06,
+                    "cumtime_per": 5.118e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.590000000000001e-07,
+                    "tottime_per": 8.590000000000001e-07,
+                    "cumtime": 4.736e-06,
+                    "cumtime_per": 4.736e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.353e-06,
+                    "tottime_per": 1.353e-06,
+                    "cumtime": 4.2240000000000006e-06,
+                    "cumtime_per": 4.2240000000000006e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.604e-06,
+                    "tottime_per": 2.604e-06,
+                    "cumtime": 3.877e-06,
+                    "cumtime_per": 3.877e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.5740000000000004e-06,
+                    "tottime_per": 4.4675000000000005e-07,
+                    "cumtime": 3.5740000000000004e-06,
+                    "cumtime_per": 4.4675000000000005e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.381e-06,
+                    "tottime_per": 1.1905e-06,
+                    "cumtime": 2.7950000000000003e-06,
+                    "cumtime_per": 1.3975000000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 2.0550000000000002e-06,
+                    "tottime_per": 9.340909090909092e-08,
+                    "cumtime": 2.0550000000000002e-06,
+                    "cumtime_per": 9.340909090909092e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.664e-06,
+                    "tottime_per": 1.664e-06,
+                    "cumtime": 1.664e-06,
+                    "cumtime_per": 1.664e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.215e-06,
+                    "tottime_per": 1.7357142857142857e-07,
+                    "cumtime": 1.215e-06,
+                    "cumtime_per": 1.7357142857142857e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2302(_any_dispatcher)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.096e-06,
+                    "tottime_per": 1.096e-06,
+                    "cumtime": 1.096e-06,
+                    "cumtime_per": 1.096e-06,
+                    "function_name": "~:0(<method 'searchsorted' of 'numpy.ndarray' objects>)"
+                }
+            ],
+            "stats": {
+                "min": 8.660999810672365e-05,
+                "max": 0.00014807099796598777,
+                "mean": 9.084641316110922e-05,
+                "stddev": 5.439709995467473e-06,
+                "rounds": 743,
+                "median": 8.975499804364517e-05,
+                "iqr": 1.5482501112273894e-06,
+                "q1": 8.904624974093167e-05,
+                "q3": 9.059449985215906e-05,
+                "iqr_outliers": 74,
+                "stddev_outliers": 50,
+                "outliers": "50;74",
+                "ld15iqr": 8.677000005263835e-05,
+                "hd15iqr": 9.291900278185494e-05,
+                "ops": 11007.58923994694,
+                "total": 0.06749888497870415,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_nsamples_zero",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_nsamples_zero",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.2694e-05,
+                    "tottime_per": 2.2694e-05,
+                    "cumtime": 0.051332471000000005,
+                    "cumtime_per": 0.051332471000000005,
+                    "function_name": "hera_cal/hera_cal/tests/test_lstbin_simple.py:19(get_lst_align_data)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.596e-06,
+                    "tottime_per": 8.596e-06,
+                    "cumtime": 0.051128929000000004,
+                    "cumtime_per": 0.051128929000000004,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:187(make_dataset)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.0282000000000002e-05,
+                    "tottime_per": 1.5141000000000001e-05,
+                    "cumtime": 0.051120107000000005,
+                    "cumtime_per": 0.025560053500000002,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:172(make_day)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 6.882e-06,
+                    "tottime_per": 3.441e-06,
+                    "cumtime": 0.05105578,
+                    "cumtime_per": 0.02552789,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:120(create_uvd_identifiable)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.5715e-05,
+                    "tottime_per": 1.28575e-05,
+                    "cumtime": 0.049756722,
+                    "cumtime_per": 0.024878361,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:84(create_uvd_ones)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.7222000000000004e-05,
+                    "tottime_per": 1.8611000000000002e-05,
+                    "cumtime": 0.049721688,
+                    "cumtime_per": 0.024860844,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:24(create_mock_hera_obs)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 6.09e-06,
+                    "tottime_per": 3.045e-06,
+                    "cumtime": 0.031784719,
+                    "cumtime_per": 0.0158923595,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:774(new)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000133888,
+                    "tottime_per": 6.6944e-05,
+                    "cumtime": 0.031778629,
+                    "cumtime_per": 0.0158893145,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:328(new_uvdata)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.000123614,
+                    "tottime_per": 2.0602333333333334e-05,
+                    "cumtime": 0.019005901000000002,
+                    "cumtime_per": 0.003167650166666667,
+                    "function_name": "pyuvdata/pyuvdata/utils.py:3777(get_lst_for_time)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000123394,
+                    "tottime_per": 6.1697e-05,
+                    "cumtime": 0.015516506000000001,
+                    "cumtime_per": 0.0077582530000000005,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00012134400000000001,
+                    "tottime_per": 6.0672000000000005e-05,
+                    "cumtime": 0.015466199000000002,
+                    "cumtime_per": 0.007733099500000001,
+                    "function_name": "hera_cal/hera_cal/utils.py:549(LST2JD)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.1442e-05,
+                    "tottime_per": 7.8605e-06,
+                    "cumtime": 0.014261312000000002,
+                    "cumtime_per": 0.0035653280000000004,
+                    "function_name": "hera_cal/hera_cal/utils.py:512(JD2LST)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00031449500000000003,
+                    "tottime_per": 0.00015724750000000002,
+                    "cumtime": 0.01036399,
+                    "cumtime_per": 0.005181995,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.0906000000000004e-05,
+                    "tottime_per": 2.5453000000000002e-05,
+                    "cumtime": 0.008345376,
+                    "cumtime_per": 0.004172688,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:93(get_time_params)"
+                },
+                {
+                    "ncalls_recursion": "116/28",
+                    "ncalls": 116,
+                    "tottime": 0.00020229500000000001,
+                    "tottime_per": 7.224821428571429e-06,
+                    "cumtime": 0.00773183,
+                    "cumtime_per": 0.00027613678571428575,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1624(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "3534/328",
+                    "ncalls": 3534,
+                    "tottime": 0.0034429660000000004,
+                    "tottime_per": 1.049684756097561e-05,
+                    "cumtime": 0.006620927,
+                    "cumtime_per": 2.018575304878049e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 0.000202281,
+                    "tottime_per": 1.685675e-05,
+                    "cumtime": 0.006479094,
+                    "cumtime_per": 0.0005399245000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:726(_set_scale)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.006323368,
+                    "tottime_per": 0.0010538946666666666,
+                    "cumtime": 0.006323368,
+                    "cumtime_per": 0.0010538946666666666,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/erfa/core.py:13528(gst06a)"
+                },
+                {
+                    "ncalls_recursion": "1255/1020",
+                    "ncalls": 1255,
+                    "tottime": 0.0009411070000000001,
+                    "tottime_per": 9.226539215686275e-07,
+                    "cumtime": 0.0062625630000000005,
+                    "cumtime_per": 6.139767647058824e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "160",
+                    "ncalls": 160,
+                    "tottime": 0.00032871500000000004,
+                    "tottime_per": 2.0544687500000003e-06,
+                    "cumtime": 0.0055517940000000005,
+                    "cumtime_per": 3.4698712500000005e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:259(_reconstruct)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00026115700000000003,
+                    "tottime_per": 6.528925000000001e-05,
+                    "cumtime": 0.005379817,
+                    "cumtime_per": 0.00134495425,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "7348/6030",
+                    "ncalls": 7348,
+                    "tottime": 0.001557364,
+                    "tottime_per": 2.5826932006633503e-07,
+                    "cumtime": 0.005246847000000001,
+                    "cumtime_per": 8.70123880597015e-07,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 3.1173e-05,
+                    "tottime_per": 5.1955000000000005e-06,
+                    "cumtime": 0.004967685,
+                    "cumtime_per": 0.0008279475000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:2405(_get_delta_ut1_utc)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 6.7311e-05,
+                    "tottime_per": 4.807928571428572e-06,
+                    "cumtime": 0.004745999,
+                    "cumtime_per": 0.00033899992857142855,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1816(__init__)"
+                },
+                {
+                    "ncalls_recursion": "114/106",
+                    "ncalls": 114,
+                    "tottime": 0.0006557700000000001,
+                    "tottime_per": 6.186509433962265e-06,
+                    "cumtime": 0.004683327,
+                    "cumtime_per": 4.4182330188679246e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                }
+            ],
+            "stats": {
+                "min": 0.02539196999714477,
+                "max": 0.02667837900298764,
+                "mean": 0.026134455000828893,
+                "stddev": 0.0005937009720052614,
+                "rounds": 4,
+                "median": 0.026233735501591582,
+                "iqr": 0.0009519050017843256,
+                "q1": 0.02565850249993673,
+                "q3": 0.026610407501721056,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.02539196999714477,
+                "hd15iqr": 0.02667837900298764,
+                "ops": 38.26366380964453,
+                "total": 0.10453782000331557,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rephase",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_rephase",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.0152e-05,
+                    "tottime_per": 8.0152e-05,
+                    "cumtime": 0.000322157,
+                    "cumtime_per": 0.000322157,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.1498e-05,
+                    "tottime_per": 4.1498e-05,
+                    "cumtime": 0.00012129000000000001,
+                    "cumtime_per": 0.00012129000000000001,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.6188e-05,
+                    "tottime_per": 1.3783157894736843e-06,
+                    "cumtime": 0.000116978,
+                    "cumtime_per": 6.156736842105264e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.485e-06,
+                    "tottime_per": 6.407142857142857e-07,
+                    "cumtime": 3.5986000000000004e-05,
+                    "cumtime_per": 5.140857142857143e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4513000000000001e-05,
+                    "tottime_per": 1.4513000000000001e-05,
+                    "cumtime": 3.4063e-05,
+                    "cumtime_per": 3.4063e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.319e-05,
+                    "tottime_per": 1.4655555555555556e-06,
+                    "cumtime": 3.0302000000000002e-05,
+                    "cumtime_per": 3.3668888888888893e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.797e-06,
+                    "tottime_per": 6.852857142857143e-07,
+                    "cumtime": 2.2977e-05,
+                    "cumtime_per": 3.2824285714285717e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.711e-06,
+                    "tottime_per": 5.703333333333334e-07,
+                    "cumtime": 2.0756000000000003e-05,
+                    "cumtime_per": 6.918666666666668e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.049e-06,
+                    "tottime_per": 1.049e-06,
+                    "cumtime": 1.8469000000000002e-05,
+                    "cumtime_per": 1.8469000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.441e-06,
+                    "tottime_per": 1.2205e-06,
+                    "cumtime": 1.8358000000000003e-05,
+                    "cumtime_per": 9.179000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.516000000000001e-06,
+                    "tottime_per": 8.516000000000001e-06,
+                    "cumtime": 1.7313000000000002e-05,
+                    "cumtime_per": 1.7313000000000002e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.924e-06,
+                    "tottime_per": 6.413333333333334e-07,
+                    "cumtime": 1.6876000000000002e-05,
+                    "cumtime_per": 5.625333333333334e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.237e-06,
+                    "tottime_per": 5.237e-06,
+                    "cumtime": 1.6648e-05,
+                    "cumtime_per": 1.6648e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 6.394e-06,
+                    "tottime_per": 6.394e-06,
+                    "cumtime": 1.4435000000000002e-05,
+                    "cumtime_per": 1.4435000000000002e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.26e-06,
+                    "tottime_per": 1.13e-06,
+                    "cumtime": 1.4382e-05,
+                    "cumtime_per": 7.191e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.745e-06,
+                    "tottime_per": 1.745e-06,
+                    "cumtime": 1.3159e-05,
+                    "cumtime_per": 1.3159e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 3.7180000000000002e-06,
+                    "tottime_per": 1.2393333333333333e-06,
+                    "cumtime": 1.2923000000000001e-05,
+                    "cumtime_per": 4.307666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.2272e-05,
+                    "tottime_per": 1.3635555555555556e-06,
+                    "cumtime": 1.2272e-05,
+                    "cumtime_per": 1.3635555555555556e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 5.156e-06,
+                    "tottime_per": 1.0312e-06,
+                    "cumtime": 1.1634e-05,
+                    "cumtime_per": 2.3268000000000003e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.583e-06,
+                    "tottime_per": 8.61e-07,
+                    "cumtime": 1.1088000000000001e-05,
+                    "cumtime_per": 3.6960000000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.855000000000001e-06,
+                    "tottime_per": 9.855000000000001e-06,
+                    "cumtime": 1.0487000000000001e-05,
+                    "cumtime_per": 1.0487000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.007e-05,
+                    "tottime_per": 1.4385714285714285e-06,
+                    "cumtime": 1.007e-05,
+                    "cumtime_per": 1.4385714285714285e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.927000000000001e-06,
+                    "tottime_per": 8.927000000000001e-06,
+                    "cumtime": 8.927000000000001e-06,
+                    "cumtime_per": 8.927000000000001e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:155(<listcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.3440000000000003e-06,
+                    "tottime_per": 2.3440000000000003e-06,
+                    "cumtime": 8.649e-06,
+                    "cumtime_per": 8.649e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 8.505e-06,
+                    "tottime_per": 2.8350000000000004e-06,
+                    "cumtime": 8.505e-06,
+                    "cumtime_per": 2.8350000000000004e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                }
+            ],
+            "stats": {
+                "min": 0.0001637659988773521,
+                "max": 0.0002601669984869659,
+                "mean": 0.00017234117425664894,
+                "stddev": 1.1025096740093126e-05,
+                "rounds": 327,
+                "median": 0.00016892399798962288,
+                "iqr": 5.860750206920784e-06,
+                "q1": 0.00016615875119896373,
+                "q3": 0.0001720195014058845,
+                "iqr_outliers": 49,
+                "stddev_outliers": 43,
+                "outliers": "43;49",
+                "ld15iqr": 0.0001637659988773521,
+                "hd15iqr": 0.00018089600052917376,
+                "ops": 5802.443927362412,
+                "total": 0.056355563981924206,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_lstbinedges_modulus",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_lstbinedges_modulus",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.899300000000001e-05,
+                    "tottime_per": 7.899300000000001e-05,
+                    "cumtime": 0.000315913,
+                    "cumtime_per": 0.000315913,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.9432000000000005e-05,
+                    "tottime_per": 3.9432000000000005e-05,
+                    "cumtime": 0.00011771600000000001,
+                    "cumtime_per": 0.00011771600000000001,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.5091e-05,
+                    "tottime_per": 1.320578947368421e-06,
+                    "cumtime": 0.00011472500000000001,
+                    "cumtime_per": 6.0381578947368424e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.395e-05,
+                    "tottime_per": 1.395e-05,
+                    "cumtime": 3.3785e-05,
+                    "cumtime_per": 3.3785e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 3.934e-06,
+                    "tottime_per": 5.62e-07,
+                    "cumtime": 3.2833e-05,
+                    "cumtime_per": 4.690428571428572e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.2456e-05,
+                    "tottime_per": 1.384e-06,
+                    "cumtime": 2.9486000000000002e-05,
+                    "cumtime_per": 3.2762222222222225e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.4940000000000005e-06,
+                    "tottime_per": 6.420000000000001e-07,
+                    "cumtime": 2.2043000000000002e-05,
+                    "cumtime_per": 3.1490000000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.683e-06,
+                    "tottime_per": 5.61e-07,
+                    "cumtime": 2.0672e-05,
+                    "cumtime_per": 6.890666666666667e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0140000000000002e-06,
+                    "tottime_per": 1.0140000000000002e-06,
+                    "cumtime": 1.87e-05,
+                    "cumtime_per": 1.87e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.318000000000001e-06,
+                    "tottime_per": 9.318000000000001e-06,
+                    "cumtime": 1.7739e-05,
+                    "cumtime_per": 1.7739e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.7350000000000001e-06,
+                    "tottime_per": 8.675000000000001e-07,
+                    "cumtime": 1.7001000000000002e-05,
+                    "cumtime_per": 8.500500000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.751e-06,
+                    "tottime_per": 4.751e-06,
+                    "cumtime": 1.6735e-05,
+                    "cumtime_per": 1.6735e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.901e-06,
+                    "tottime_per": 6.336666666666667e-07,
+                    "cumtime": 1.6126e-05,
+                    "cumtime_per": 5.3753333333333334e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.9310000000000002e-06,
+                    "tottime_per": 1.9310000000000002e-06,
+                    "cumtime": 1.4281000000000001e-05,
+                    "cumtime_per": 1.4281000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 6.588e-06,
+                    "tottime_per": 6.588e-06,
+                    "cumtime": 1.3993000000000001e-05,
+                    "cumtime_per": 1.3993000000000001e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.0050000000000003e-06,
+                    "tottime_per": 1.0025000000000001e-06,
+                    "cumtime": 1.3942000000000001e-05,
+                    "cumtime_per": 6.971000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 3.5400000000000004e-06,
+                    "tottime_per": 1.1800000000000001e-06,
+                    "cumtime": 1.2425e-05,
+                    "cumtime_per": 4.141666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.2245e-05,
+                    "tottime_per": 1.3605555555555555e-06,
+                    "cumtime": 1.2245e-05,
+                    "cumtime_per": 1.3605555555555555e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 4.858e-06,
+                    "tottime_per": 9.716e-07,
+                    "cumtime": 1.1829000000000001e-05,
+                    "cumtime_per": 2.3658000000000003e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0708000000000001e-05,
+                    "tottime_per": 1.0708000000000001e-05,
+                    "cumtime": 1.1336000000000001e-05,
+                    "cumtime_per": 1.1336000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.6760000000000003e-06,
+                    "tottime_per": 8.920000000000001e-07,
+                    "cumtime": 1.1193000000000001e-05,
+                    "cumtime_per": 3.7310000000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.0758000000000001e-05,
+                    "tottime_per": 1.536857142857143e-06,
+                    "cumtime": 1.0758000000000001e-05,
+                    "cumtime_per": 1.536857142857143e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.4730000000000003e-06,
+                    "tottime_per": 2.4730000000000003e-06,
+                    "cumtime": 9.253000000000001e-06,
+                    "cumtime_per": 9.253000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.128000000000001e-06,
+                    "tottime_per": 9.128000000000001e-06,
+                    "cumtime": 9.128000000000001e-06,
+                    "cumtime_per": 9.128000000000001e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:155(<listcomp>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 8.517e-06,
+                    "tottime_per": 2.839e-06,
+                    "cumtime": 8.517e-06,
+                    "cumtime_per": 2.839e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                }
+            ],
+            "stats": {
+                "min": 0.0001547899992146995,
+                "max": 0.00035911400118493475,
+                "mean": 0.0001647227971419773,
+                "stddev": 1.733724367741753e-05,
+                "rounds": 345,
+                "median": 0.00016047200188040733,
+                "iqr": 1.047400201059645e-05,
+                "q1": 0.00015719324892415898,
+                "q3": 0.00016766725093475543,
+                "iqr_outliers": 18,
+                "stddev_outliers": 21,
+                "outliers": "21;18",
+                "ld15iqr": 0.0001547899992146995,
+                "hd15iqr": 0.00018398799875285476,
+                "ops": 6070.8051183594425,
+                "total": 0.05682936501398217,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_one_point_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_one_point_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.7678000000000003e-05,
+                    "tottime_per": 1.7678000000000003e-05,
+                    "cumtime": 0.000314987,
+                    "cumtime_per": 0.000314987,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.5525e-05,
+                    "tottime_per": 4.5525e-05,
+                    "cumtime": 0.00028760600000000004,
+                    "cumtime_per": 0.00028760600000000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.0343e-05,
+                    "tottime_per": 2.0343e-06,
+                    "cumtime": 0.000211105,
+                    "cumtime_per": 2.11105e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.538e-06,
+                    "tottime_per": 1.269e-06,
+                    "cumtime": 0.000165515,
+                    "cumtime_per": 8.27575e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.682e-06,
+                    "tottime_per": 1.841e-06,
+                    "cumtime": 0.000161423,
+                    "cumtime_per": 8.07115e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.7610000000000002e-06,
+                    "tottime_per": 8.805000000000001e-07,
+                    "cumtime": 0.000157627,
+                    "cumtime_per": 7.88135e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.3103000000000005e-05,
+                    "tottime_per": 1.6551500000000002e-05,
+                    "cumtime": 0.000153769,
+                    "cumtime_per": 7.68845e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 9.667e-06,
+                    "tottime_per": 8.055833333333334e-07,
+                    "cumtime": 7.6389e-05,
+                    "cumtime_per": 6.36575e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.1994e-05,
+                    "tottime_per": 9.995000000000001e-07,
+                    "cumtime": 5.9205000000000007e-05,
+                    "cumtime_per": 4.933750000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.0818000000000003e-05,
+                    "tottime_per": 1.3878666666666669e-06,
+                    "cumtime": 5.5257e-05,
+                    "cumtime_per": 3.6838e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 1.5835e-05,
+                    "tottime_per": 3.95875e-06,
+                    "cumtime": 5.025e-05,
+                    "cumtime_per": 1.25625e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.3607e-05,
+                    "tottime_per": 1.700875e-06,
+                    "cumtime": 2.7342e-05,
+                    "cumtime_per": 3.41775e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.5587e-05,
+                    "tottime_per": 1.7058e-06,
+                    "cumtime": 2.5587e-05,
+                    "cumtime_per": 1.7058e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 9.651000000000001e-06,
+                    "tottime_per": 3.2170000000000003e-06,
+                    "cumtime": 1.9973e-05,
+                    "cumtime_per": 6.657666666666666e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.9290000000000002e-06,
+                    "tottime_per": 7.322500000000001e-07,
+                    "cumtime": 1.8805e-05,
+                    "cumtime_per": 4.70125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 6.452e-06,
+                    "tottime_per": 1.0753333333333333e-06,
+                    "cumtime": 1.5890000000000002e-05,
+                    "cumtime_per": 2.6483333333333335e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0220000000000001e-06,
+                    "tottime_per": 1.0220000000000001e-06,
+                    "cumtime": 1.4763e-05,
+                    "cumtime_per": 1.4763e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.7610000000000003e-06,
+                    "tottime_per": 6.902500000000001e-07,
+                    "cumtime": 1.4227000000000001e-05,
+                    "cumtime_per": 3.5567500000000003e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.08e-06,
+                    "tottime_per": 4.08e-06,
+                    "cumtime": 1.3180000000000001e-05,
+                    "cumtime_per": 1.3180000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2530000000000001e-06,
+                    "tottime_per": 1.2530000000000001e-06,
+                    "cumtime": 1.2771e-05,
+                    "cumtime_per": 1.2771e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.418e-06,
+                    "tottime_per": 7.09e-07,
+                    "cumtime": 1.1785000000000002e-05,
+                    "cumtime_per": 5.892500000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 9.711e-06,
+                    "tottime_per": 1.213875e-06,
+                    "cumtime": 1.0345e-05,
+                    "cumtime_per": 1.293125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.5040000000000001e-06,
+                    "tottime_per": 7.520000000000001e-07,
+                    "cumtime": 7.901000000000001e-06,
+                    "cumtime_per": 3.9505000000000005e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 7.5940000000000005e-06,
+                    "tottime_per": 5.062666666666667e-07,
+                    "cumtime": 7.5940000000000005e-06,
+                    "cumtime_per": 5.062666666666667e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.624e-06,
+                    "tottime_per": 2.624e-06,
+                    "cumtime": 7.317e-06,
+                    "cumtime_per": 7.317e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.0001428380019206088,
+                "max": 0.0004623829991032835,
+                "mean": 0.0001599419402644529,
+                "stddev": 3.634966109718709e-05,
+                "rounds": 167,
+                "median": 0.0001509770008851774,
+                "iqr": 6.013000529492274e-06,
+                "q1": 0.00014922250102245016,
+                "q3": 0.00015523550155194243,
+                "iqr_outliers": 24,
+                "stddev_outliers": 9,
+                "outliers": "9;24",
+                "ld15iqr": 0.0001428380019206088,
+                "hd15iqr": 0.000167432997841388,
+                "ops": 6252.268781700218,
+                "total": 0.026710304024163634,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes0]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes0]",
+            "params": {
+                "ntimes": [
+                    4
+                ]
+            },
+            "param": "ntimes0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.766e-05,
+                    "tottime_per": 1.766e-05,
+                    "cumtime": 0.00031647800000000003,
+                    "cumtime_per": 0.00031647800000000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.6382000000000004e-05,
+                    "tottime_per": 4.6382000000000004e-05,
+                    "cumtime": 0.000289267,
+                    "cumtime_per": 0.000289267,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.139e-05,
+                    "tottime_per": 2.139e-06,
+                    "cumtime": 0.00021371,
+                    "cumtime_per": 2.1371000000000003e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.992e-06,
+                    "tottime_per": 9.96e-07,
+                    "cumtime": 0.00016803100000000002,
+                    "cumtime_per": 8.401550000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.14e-06,
+                    "tottime_per": 2.07e-06,
+                    "cumtime": 0.00016454000000000002,
+                    "cumtime_per": 8.227000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.8320000000000002e-06,
+                    "tottime_per": 9.160000000000001e-07,
+                    "cumtime": 0.000160232,
+                    "cumtime_per": 8.0116e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.5022000000000005e-05,
+                    "tottime_per": 1.7511000000000002e-05,
+                    "cumtime": 0.000156417,
+                    "cumtime_per": 7.82085e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 8.787e-06,
+                    "tottime_per": 7.322500000000001e-07,
+                    "cumtime": 7.5857e-05,
+                    "cumtime_per": 6.321416666666667e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.2273000000000001e-05,
+                    "tottime_per": 1.02275e-06,
+                    "cumtime": 5.9510000000000005e-05,
+                    "cumtime_per": 4.959166666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 1.9497e-05,
+                    "tottime_per": 1.2998e-06,
+                    "cumtime": 5.543e-05,
+                    "cumtime_per": 3.6953333333333334e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 1.5476000000000002e-05,
+                    "tottime_per": 3.8690000000000006e-06,
+                    "cumtime": 4.9809000000000004e-05,
+                    "cumtime_per": 1.2452250000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.3599000000000001e-05,
+                    "tottime_per": 1.6998750000000002e-06,
+                    "cumtime": 2.7433000000000003e-05,
+                    "cumtime_per": 3.4291250000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.7295000000000002e-05,
+                    "tottime_per": 1.8196666666666667e-06,
+                    "cumtime": 2.7295000000000002e-05,
+                    "cumtime_per": 1.8196666666666667e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 9.506e-06,
+                    "tottime_per": 3.168666666666667e-06,
+                    "cumtime": 2.0073000000000002e-05,
+                    "cumtime_per": 6.691000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.7770000000000003e-06,
+                    "tottime_per": 6.942500000000001e-07,
+                    "cumtime": 1.8834e-05,
+                    "cumtime_per": 4.7085e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 5.932e-06,
+                    "tottime_per": 9.886666666666668e-07,
+                    "cumtime": 1.6206e-05,
+                    "cumtime_per": 2.701e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.7e-06,
+                    "tottime_per": 6.75e-07,
+                    "cumtime": 1.4076e-05,
+                    "cumtime_per": 3.519e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.94e-07,
+                    "tottime_per": 8.94e-07,
+                    "cumtime": 1.4054000000000001e-05,
+                    "cumtime_per": 1.4054000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.148e-06,
+                    "tottime_per": 4.148e-06,
+                    "cumtime": 1.2635e-05,
+                    "cumtime_per": 1.2635e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.263e-06,
+                    "tottime_per": 1.263e-06,
+                    "cumtime": 1.2268e-05,
+                    "cumtime_per": 1.2268e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.3860000000000002e-06,
+                    "tottime_per": 6.930000000000001e-07,
+                    "cumtime": 1.2001e-05,
+                    "cumtime_per": 6.0005e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 9.588e-06,
+                    "tottime_per": 1.1985e-06,
+                    "cumtime": 1.027e-05,
+                    "cumtime_per": 1.28375e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.4510000000000002e-06,
+                    "tottime_per": 7.255000000000001e-07,
+                    "cumtime": 7.772000000000001e-06,
+                    "cumtime_per": 3.8860000000000006e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 7.39e-06,
+                    "tottime_per": 4.926666666666667e-07,
+                    "cumtime": 7.39e-06,
+                    "cumtime_per": 4.926666666666667e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.4400000000000004e-06,
+                    "tottime_per": 2.4400000000000004e-06,
+                    "cumtime": 7.142e-06,
+                    "cumtime_per": 7.142e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.00014565799938281998,
+                "max": 0.0006225860015547369,
+                "mean": 0.00016704224402728439,
+                "stddev": 4.821452014223098e-05,
+                "rounds": 254,
+                "median": 0.00015518049985985272,
+                "iqr": 7.193997589638457e-06,
+                "q1": 0.00015334000272559933,
+                "q3": 0.0001605340003152378,
+                "iqr_outliers": 46,
+                "stddev_outliers": 15,
+                "outliers": "15;46",
+                "ld15iqr": 0.00014565799938281998,
+                "hd15iqr": 0.0001715319995128084,
+                "ops": 5986.509615116651,
+                "total": 0.042428729982930236,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes1]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes1]",
+            "params": {
+                "ntimes": [
+                    5,
+                    4
+                ]
+            },
+            "param": "ntimes1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.5673000000000003e-05,
+                    "tottime_per": 2.5673000000000003e-05,
+                    "cumtime": 0.0005939060000000001,
+                    "cumtime_per": 0.0005939060000000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 8.9895e-05,
+                    "tottime_per": 4.49475e-05,
+                    "cumtime": 0.000556705,
+                    "cumtime_per": 0.0002783525,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "51/19",
+                    "ncalls": 51,
+                    "tottime": 3.9876e-05,
+                    "tottime_per": 2.0987368421052633e-06,
+                    "cumtime": 0.00041316700000000004,
+                    "cumtime_per": 2.174563157894737e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.264e-06,
+                    "tottime_per": 8.16e-07,
+                    "cumtime": 0.000325222,
+                    "cumtime_per": 8.13055e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.079e-06,
+                    "tottime_per": 1.76975e-06,
+                    "cumtime": 0.000318702,
+                    "cumtime_per": 7.96755e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.2330000000000002e-06,
+                    "tottime_per": 8.082500000000001e-07,
+                    "cumtime": 0.000311248,
+                    "cumtime_per": 7.7812e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 6.5807e-05,
+                    "tottime_per": 1.645175e-05,
+                    "cumtime": 0.00030402500000000003,
+                    "cumtime_per": 7.600625000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 1.7942000000000002e-05,
+                    "tottime_per": 7.475833333333335e-07,
+                    "cumtime": 0.00014821000000000002,
+                    "cumtime_per": 6.175416666666668e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 2.2894e-05,
+                    "tottime_per": 9.539166666666668e-07,
+                    "cumtime": 0.000115042,
+                    "cumtime_per": 4.793416666666666e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 3.7466000000000003e-05,
+                    "tottime_per": 1.2488666666666668e-06,
+                    "cumtime": 0.000108992,
+                    "cumtime_per": 3.6330666666666666e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 2.9668e-05,
+                    "tottime_per": 3.7085e-06,
+                    "cumtime": 9.7361e-05,
+                    "cumtime_per": 1.2170125e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 5.3627e-05,
+                    "tottime_per": 1.7875666666666666e-06,
+                    "cumtime": 5.3627e-05,
+                    "cumtime_per": 1.7875666666666666e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 2.5383e-05,
+                    "tottime_per": 1.5864375e-06,
+                    "cumtime": 5.3197000000000006e-05,
+                    "cumtime_per": 3.3248125000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 1.8709e-05,
+                    "tottime_per": 3.1181666666666667e-06,
+                    "cumtime": 3.9858000000000004e-05,
+                    "cumtime_per": 6.643000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 6.115000000000001e-06,
+                    "tottime_per": 7.643750000000001e-07,
+                    "cumtime": 3.638e-05,
+                    "cumtime_per": 4.5475e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.8260000000000002e-06,
+                    "tottime_per": 9.130000000000001e-07,
+                    "cumtime": 2.9363000000000003e-05,
+                    "cumtime_per": 1.4681500000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 5.320000000000001e-06,
+                    "tottime_per": 6.650000000000001e-07,
+                    "cumtime": 2.8252000000000003e-05,
+                    "cumtime_per": 3.5315000000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "11",
+                    "ncalls": 11,
+                    "tottime": 1.0310000000000001e-05,
+                    "tottime_per": 9.372727272727274e-07,
+                    "cumtime": 2.8115e-05,
+                    "cumtime_per": 2.555909090909091e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.5460000000000003e-06,
+                    "tottime_per": 1.2730000000000001e-06,
+                    "cumtime": 2.5888e-05,
+                    "cumtime_per": 1.2944e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.776e-06,
+                    "tottime_per": 6.94e-07,
+                    "cumtime": 2.3895e-05,
+                    "cumtime_per": 5.97375e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 7.709e-06,
+                    "tottime_per": 3.8545e-06,
+                    "cumtime": 2.2095e-05,
+                    "cumtime_per": 1.10475e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 1.9367000000000003e-05,
+                    "tottime_per": 1.2104375000000002e-06,
+                    "cumtime": 2.0660000000000002e-05,
+                    "cumtime_per": 1.2912500000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.0080000000000003e-06,
+                    "tottime_per": 7.520000000000001e-07,
+                    "cumtime": 1.6116e-05,
+                    "cumtime_per": 4.029e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 1.5230000000000002e-05,
+                    "tottime_per": 5.076666666666667e-07,
+                    "cumtime": 1.5230000000000002e-05,
+                    "cumtime_per": 5.076666666666667e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.915000000000001e-06,
+                    "tottime_per": 9.787500000000002e-07,
+                    "cumtime": 1.3229000000000002e-05,
+                    "cumtime_per": 3.3072500000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:113(_copyto)"
+                }
+            ],
+            "stats": {
+                "min": 0.00028018000011797994,
+                "max": 0.0008272869999927934,
+                "mean": 0.0003233814874840414,
+                "stddev": 6.948146009142058e-05,
+                "rounds": 158,
+                "median": 0.00030073450034251437,
+                "iqr": 3.439699867158197e-05,
+                "q1": 0.0002947870016214438,
+                "q3": 0.00032918400029302575,
+                "iqr_outliers": 12,
+                "stddev_outliers": 10,
+                "outliers": "10;12",
+                "ld15iqr": 0.00028018000011797994,
+                "hd15iqr": 0.00038428900006692857,
+                "ops": 3092.3229643729965,
+                "total": 0.05109427502247854,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sigma_clip_without_outliers",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAverage::test_sigma_clip_without_outliers",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.0395e-05,
+                    "tottime_per": 7.0395e-05,
+                    "cumtime": 0.00120037,
+                    "cumtime_per": 0.00120037,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "43/15",
+                    "ncalls": 43,
+                    "tottime": 4.2075e-05,
+                    "tottime_per": 2.805e-06,
+                    "cumtime": 0.001066134,
+                    "cumtime_per": 7.107560000000001e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.0518000000000002e-05,
+                    "tottime_per": 2.0518000000000002e-05,
+                    "cumtime": 0.000813986,
+                    "cumtime_per": 0.000813986,
+                    "function_name": "hera_cal/hera_cal/lstbin.py:1095(sigma_clip)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.02e-06,
+                    "tottime_per": 1.01e-06,
+                    "cumtime": 0.0007707180000000001,
+                    "cumtime_per": 0.00038535900000000005,
+                    "function_name": "<__array_function__ internals>:177(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.161e-06,
+                    "tottime_per": 2.5805e-06,
+                    "cumtime": 0.000767091,
+                    "cumtime_per": 0.0003835455,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1126(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "4/2",
+                    "ncalls": 4,
+                    "tottime": 1.6269e-05,
+                    "tottime_per": 8.1345e-06,
+                    "cumtime": 0.000761705,
+                    "cumtime_per": 0.0003808525,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:3674(_ureduce)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.9060000000000002e-06,
+                    "tottime_per": 1.4530000000000001e-06,
+                    "cumtime": 0.0007444950000000001,
+                    "cumtime_per": 0.00037224750000000004,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1075(_nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.1266e-05,
+                    "tottime_per": 5.633e-06,
+                    "cumtime": 0.0007415890000000001,
+                    "cumtime_per": 0.00037079450000000004,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1101(_nanmedian_small)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.5130000000000003e-06,
+                    "tottime_per": 1.2565000000000002e-06,
+                    "cumtime": 0.000669698,
+                    "cumtime_per": 0.000334849,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:660(median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.1101000000000005e-05,
+                    "tottime_per": 2.0550500000000003e-05,
+                    "cumtime": 0.000650402,
+                    "cumtime_per": 0.000325201,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:743(_median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.953e-06,
+                    "tottime_per": 9.765e-07,
+                    "cumtime": 0.000214298,
+                    "cumtime_per": 0.000107149,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.371e-06,
+                    "tottime_per": 2.1855e-06,
+                    "cumtime": 0.00021053800000000002,
+                    "cumtime_per": 0.00010526900000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.2480000000000003e-06,
+                    "tottime_per": 1.1240000000000002e-06,
+                    "cumtime": 0.000205989,
+                    "cumtime_per": 0.0001029945,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.1417e-05,
+                    "tottime_per": 2.07085e-05,
+                    "cumtime": 0.000201284,
+                    "cumtime_per": 0.000100642,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.5268e-05,
+                    "tottime_per": 7.634e-06,
+                    "cumtime": 0.00019773000000000002,
+                    "cumtime_per": 9.886500000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/utils.py:1021(_median_nancheck)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.3920000000000003e-06,
+                    "tottime_per": 1.6960000000000002e-06,
+                    "cumtime": 0.000183439,
+                    "cumtime_per": 9.17195e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6936(sort)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 7.179900000000001e-05,
+                    "tottime_per": 3.988833333333334e-06,
+                    "cumtime": 0.000177593,
+                    "cumtime_per": 9.866277777777778e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2972(__array_finalize__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.4080000000000002e-06,
+                    "tottime_per": 8.520000000000001e-07,
+                    "cumtime": 0.00017224700000000002,
+                    "cumtime_per": 4.3061750000000005e-05,
+                    "function_name": "<__array_function__ internals>:177(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.865e-06,
+                    "tottime_per": 1.96625e-06,
+                    "cumtime": 0.00016490800000000001,
+                    "cumtime_per": 4.1227000000000004e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/shape_base.py:56(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.14e-06,
+                    "tottime_per": 2.57e-06,
+                    "cumtime": 0.000146586,
+                    "cumtime_per": 7.3293e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:5622(sort)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.8603e-05,
+                    "tottime_per": 8.1005e-06,
+                    "cumtime": 0.00013774500000000002,
+                    "cumtime_per": 2.2957500000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:3211(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "48/46",
+                    "ncalls": 48,
+                    "tottime": 1.4390000000000001e-05,
+                    "tottime_per": 3.1282608695652177e-07,
+                    "cumtime": 0.000129287,
+                    "cumtime_per": 2.810586956521739e-06,
+                    "function_name": "~:0(<method 'view' of 'numpy.ndarray' objects>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 8.220000000000001e-06,
+                    "tottime_per": 2.0550000000000002e-06,
+                    "cumtime": 0.00011134300000000001,
+                    "cumtime_per": 2.7835750000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6816(__call__)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 1.2249e-05,
+                    "tottime_per": 8.749285714285715e-07,
+                    "cumtime": 0.000103479,
+                    "cumtime_per": 7.391357142857143e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "26",
+                    "ncalls": 26,
+                    "tottime": 6.9208e-05,
+                    "tottime_per": 2.6618461538461543e-06,
+                    "cumtime": 9.816600000000001e-05,
+                    "cumtime_per": 3.775615384615385e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2946(_update_from)"
+                }
+            ],
+            "stats": {
+                "min": 0.000548266001715092,
+                "max": 0.001266980998479994,
+                "mean": 0.0006242339153686771,
+                "stddev": 8.887000405992942e-05,
+                "rounds": 130,
+                "median": 0.0005977470009383978,
+                "iqr": 6.478800059994683e-05,
+                "q1": 0.0005784229979326483,
+                "q3": 0.0006432109985325951,
+                "iqr_outliers": 7,
+                "stddev_outliers": 9,
+                "outliers": "9;7",
+                "ld15iqr": 0.000548266001715092,
+                "hd15iqr": 0.0007500659994548187,
+                "ops": 1601.963583490001,
+                "total": 0.08115040899792803,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy0-pols0-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy0-pols0-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy0-pols0-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000543113,
+                    "tottime_per": 0.000543113,
+                    "cumtime": 2.788892279,
+                    "cumtime_per": 2.788892279,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.001085836,
+                    "tottime_per": 0.000542918,
+                    "cumtime": 1.531149078,
+                    "cumtime_per": 0.765574539,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.0025964580000000003,
+                    "tottime_per": 0.00043274300000000003,
+                    "cumtime": 1.254713817,
+                    "cumtime_per": 0.2091189695,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.001727468,
+                    "tottime_per": 0.001727468,
+                    "cumtime": 1.2509395440000002,
+                    "cumtime_per": 1.2509395440000002,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.34755631000000003,
+                    "tottime_per": 0.34755631000000003,
+                    "cumtime": 1.2329095350000001,
+                    "cumtime_per": 1.2329095350000001,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.000827496,
+                    "tottime_per": 2.2986e-05,
+                    "cumtime": 1.206935147,
+                    "cumtime_per": 0.03352597630555556,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.000869189,
+                    "tottime_per": 2.414413888888889e-05,
+                    "cumtime": 1.023131904,
+                    "cumtime_per": 0.028420330666666667,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.000708893,
+                    "tottime_per": 1.9691472222222224e-05,
+                    "cumtime": 1.020858958,
+                    "cumtime_per": 0.02835719327777778,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0020811790000000003,
+                    "tottime_per": 5.2029475000000006e-05,
+                    "cumtime": 0.974548068,
+                    "cumtime_per": 0.0243637017,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 6.6223e-05,
+                    "tottime_per": 1.6555750000000002e-06,
+                    "cumtime": 0.583771487,
+                    "cumtime_per": 0.014594287175000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0029171770000000004,
+                    "tottime_per": 7.292942500000002e-05,
+                    "cumtime": 0.58368454,
+                    "cumtime_per": 0.0145921135,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000353021,
+                    "tottime_per": 1.9612277777777777e-05,
+                    "cumtime": 0.529854518,
+                    "cumtime_per": 0.029436362111111114,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "325749/277617",
+                    "ncalls": 325749,
+                    "tottime": 0.061423982,
+                    "tottime_per": 2.2125439724512547e-07,
+                    "cumtime": 0.440620813,
+                    "cumtime_per": 1.587153571287061e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "157055/91826",
+                    "ncalls": 157055,
+                    "tottime": 0.06621180800000001,
+                    "tottime_per": 7.21057304031538e-07,
+                    "cumtime": 0.42104684200000003,
+                    "cumtime_per": 4.585268246466143e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.38635828600000005,
+                    "tottime_per": 4.930554951505871e-06,
+                    "cumtime": 0.38635828600000005,
+                    "cumtime_per": 4.930554951505871e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.002924615,
+                    "tottime_per": 6.646852272727274e-05,
+                    "cumtime": 0.350895856,
+                    "cumtime_per": 0.007974905818181818,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.14229818600000002,
+                    "tottime_per": 3.3154283783783786e-05,
+                    "cumtime": 0.289353376,
+                    "cumtime_per": 6.741690959925443e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.033032209,
+                    "tottime_per": 5.298123245705487e-07,
+                    "cumtime": 0.28845801600000004,
+                    "cumtime_per": 4.626654305740453e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.024100086000000003,
+                    "tottime_per": 1.0316817636986302e-05,
+                    "cumtime": 0.254182279,
+                    "cumtime_per": 0.00010881090710616439,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.01148262,
+                    "tottime_per": 4.938761290322581e-06,
+                    "cumtime": 0.23324865500000003,
+                    "cumtime_per": 0.00010032200215053765,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006498768,
+                    "tottime_per": 0.0001624692,
+                    "cumtime": 0.231410418,
+                    "cumtime_per": 0.00578526045,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.028814077,
+                    "tottime_per": 4.6215659133558956e-07,
+                    "cumtime": 0.223650691,
+                    "cumtime_per": 3.5871925032479513e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.037931747,
+                    "tottime_per": 6.08397308611481e-07,
+                    "cumtime": 0.19483661400000002,
+                    "cumtime_per": 3.1250359119123617e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.021941882000000003,
+                    "tottime_per": 1.408336456996149e-05,
+                    "cumtime": 0.190660813,
+                    "cumtime_per": 0.0001223753613607189,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00015172500000000002,
+                    "tottime_per": 3.7931250000000004e-05,
+                    "cumtime": 0.17714157800000002,
+                    "cumtime_per": 0.044285394500000005,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                }
+            ],
+            "stats": {
+                "min": 1.4632921360025648,
+                "max": 1.4632921360025648,
+                "mean": 1.4632921360025648,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.4632921360025648,
+                "iqr": 0.0,
+                "q1": 1.4632921360025648,
+                "q3": 1.4632921360025648,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.4632921360025648,
+                "hd15iqr": 1.4632921360025648,
+                "ops": 0.6833905379494551,
+                "total": 1.4632921360025648,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy1-pols1-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy1-pols1-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy",
+                    "xy",
+                    "yx"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy1-pols1-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000565712,
+                    "tottime_per": 0.000565712,
+                    "cumtime": 2.843069496,
+                    "cumtime_per": 2.843069496,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0012821330000000002,
+                    "tottime_per": 0.0006410665000000001,
+                    "cumtime": 1.6055214480000002,
+                    "cumtime_per": 0.8027607240000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.004079404,
+                    "tottime_per": 0.0006799006666666666,
+                    "cumtime": 1.312737983,
+                    "cumtime_per": 0.21878966383333334,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0008426540000000001,
+                    "tottime_per": 2.340705555555556e-05,
+                    "cumtime": 1.260711238,
+                    "cumtime_per": 0.03501975661111111,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.001527651,
+                    "tottime_per": 0.001527651,
+                    "cumtime": 1.2302923730000002,
+                    "cumtime_per": 1.2302923730000002,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.342746188,
+                    "tottime_per": 0.342746188,
+                    "cumtime": 1.212602645,
+                    "cumtime_per": 1.212602645,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.0008855330000000001,
+                    "tottime_per": 2.4598138888888892e-05,
+                    "cumtime": 1.058973042,
+                    "cumtime_per": 0.029415917833333336,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.000782799,
+                    "tottime_per": 2.1744416666666668e-05,
+                    "cumtime": 1.056641411,
+                    "cumtime_per": 0.029351150305555556,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002181216,
+                    "tottime_per": 5.45304e-05,
+                    "cumtime": 1.0101470860000001,
+                    "cumtime_per": 0.025253677150000004,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 7.377700000000001e-05,
+                    "tottime_per": 1.8444250000000001e-06,
+                    "cumtime": 0.607070011,
+                    "cumtime_per": 0.015176750275000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.003120409,
+                    "tottime_per": 7.8010225e-05,
+                    "cumtime": 0.606974118,
+                    "cumtime_per": 0.01517435295,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.00035209,
+                    "tottime_per": 1.9560555555555555e-05,
+                    "cumtime": 0.546217516,
+                    "cumtime_per": 0.030345417555555556,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "328005/279873",
+                    "ncalls": 328005,
+                    "tottime": 0.06364362800000001,
+                    "tottime_per": 2.2740181439438606e-07,
+                    "cumtime": 0.45370089700000005,
+                    "cumtime_per": 1.6210956290889083e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "157297/91980",
+                    "ncalls": 157297,
+                    "tottime": 0.06498753,
+                    "tottime_per": 7.065397912589694e-07,
+                    "cumtime": 0.41842245800000005,
+                    "cumtime_per": 4.549059121548163e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.38107415,
+                    "tottime_per": 4.863120852475753e-06,
+                    "cumtime": 0.38107415,
+                    "cumtime_per": 4.863120852475753e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.003190884,
+                    "tottime_per": 7.252009090909091e-05,
+                    "cumtime": 0.36099466300000005,
+                    "cumtime_per": 0.00820442415909091,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.145130866,
+                    "tottime_per": 3.381427446411929e-05,
+                    "cumtime": 0.297101856,
+                    "cumtime_per": 6.922224044734389e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.032684105000000005,
+                    "tottime_per": 5.242289925738208e-07,
+                    "cumtime": 0.281715255,
+                    "cumtime_per": 4.5185053811731115e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.024779826,
+                    "tottime_per": 1.0607802226027397e-05,
+                    "cumtime": 0.260842887,
+                    "cumtime_per": 0.00011166219477739727,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.011874322000000001,
+                    "tottime_per": 5.107235268817205e-06,
+                    "cumtime": 0.25188013600000003,
+                    "cumtime_per": 0.00010833554236559142,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006287992,
+                    "tottime_per": 0.0001571998,
+                    "cumtime": 0.238300753,
+                    "cumtime_per": 0.005957518825,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.028094142000000003,
+                    "tottime_per": 4.506093637223925e-07,
+                    "cumtime": 0.21821857500000003,
+                    "cumtime_per": 3.5000653600012835e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.022665869,
+                    "tottime_per": 1.454805455712452e-05,
+                    "cumtime": 0.196677282,
+                    "cumtime_per": 0.00012623702310654686,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.036262677,
+                    "tottime_per": 5.816266540491122e-07,
+                    "cumtime": 0.190124433,
+                    "cumtime_per": 3.049455996278891e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.0029772820000000004,
+                    "tottime_per": 0.00016540455555555557,
+                    "cumtime": 0.184692977,
+                    "cumtime_per": 0.010260720944444445,
+                    "function_name": "hera_cal/hera_cal/io.py:708(build_datacontainers)"
+                }
+            ],
+            "stats": {
+                "min": 1.431700365999859,
+                "max": 1.431700365999859,
+                "mean": 1.431700365999859,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.431700365999859,
+                "iqr": 0.0,
+                "q1": 1.431700365999859,
+                "q3": 1.431700365999859,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.431700365999859,
+                "hd15iqr": 1.431700365999859,
+                "ops": 0.6984701713766961,
+                "total": 1.431700365999859,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy2-pols2-freq_range2]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy2-pols2-freq_range2]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": [
+                    150000000.0,
+                    180000000.0
+                ]
+            },
+            "param": "0-True-0.0-flag_strategy2-pols2-freq_range2",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0009040640000000001,
+                    "tottime_per": 0.0009040640000000001,
+                    "cumtime": 3.2079598000000003,
+                    "cumtime_per": 3.2079598000000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.001456557,
+                    "tottime_per": 0.0007282785,
+                    "cumtime": 1.8114662080000001,
+                    "cumtime_per": 0.9057331040000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.003482592,
+                    "tottime_per": 0.000580432,
+                    "cumtime": 1.4839150010000002,
+                    "cumtime_per": 0.24731916683333335,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001129108,
+                    "tottime_per": 3.136411111111111e-05,
+                    "cumtime": 1.42668788,
+                    "cumtime_per": 0.03963021888888889,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0022683110000000003,
+                    "tottime_per": 0.0022683110000000003,
+                    "cumtime": 1.388090891,
+                    "cumtime_per": 1.388090891,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.364281134,
+                    "tottime_per": 0.364281134,
+                    "cumtime": 1.300231069,
+                    "cumtime_per": 1.300231069,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.0010385280000000002,
+                    "tottime_per": 2.8848000000000006e-05,
+                    "cumtime": 1.217544667,
+                    "cumtime_per": 0.03382068519444445,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0009408140000000001,
+                    "tottime_per": 2.6133722222222225e-05,
+                    "cumtime": 1.2147592280000001,
+                    "cumtime_per": 0.03374331188888889,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002642039,
+                    "tottime_per": 6.6050975e-05,
+                    "cumtime": 1.1629635040000001,
+                    "cumtime_per": 0.029074087600000003,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 8.8325e-05,
+                    "tottime_per": 2.208125e-06,
+                    "cumtime": 0.683048257,
+                    "cumtime_per": 0.017076206425,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.003608992,
+                    "tottime_per": 9.02248e-05,
+                    "cumtime": 0.682937271,
+                    "cumtime_per": 0.017073431775,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000456303,
+                    "tottime_per": 2.5350166666666667e-05,
+                    "cumtime": 0.6151991880000001,
+                    "cumtime_per": 0.03417773266666667,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "346359/292971",
+                    "ncalls": 346359,
+                    "tottime": 0.075084863,
+                    "tottime_per": 2.5628769741715053e-07,
+                    "cumtime": 0.529450418,
+                    "cumtime_per": 1.8071768809882209e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "157245/91962",
+                    "ncalls": 157245,
+                    "tottime": 0.069743421,
+                    "tottime_per": 7.58393912703073e-07,
+                    "cumtime": 0.45455632900000004,
+                    "cumtime_per": 4.942871283791131e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.407947469,
+                    "tottime_per": 5.206067751403778e-06,
+                    "cumtime": 0.407947469,
+                    "cumtime_per": 5.206067751403778e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.0038025800000000003,
+                    "tottime_per": 8.642227272727274e-05,
+                    "cumtime": 0.399743507,
+                    "cumtime_per": 0.009085079704545454,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.15738190100000002,
+                    "tottime_per": 3.6668662861137e-05,
+                    "cumtime": 0.326662471,
+                    "cumtime_per": 7.610961579683132e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.034118284,
+                    "tottime_per": 5.472321683481162e-07,
+                    "cumtime": 0.29872659500000004,
+                    "cumtime_per": 4.791354756443775e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.027800136000000003,
+                    "tottime_per": 1.1900743150684932e-05,
+                    "cumtime": 0.287225318,
+                    "cumtime_per": 0.00012295604366438357,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.013506005000000001,
+                    "tottime_per": 5.8090344086021516e-06,
+                    "cumtime": 0.282877412,
+                    "cumtime_per": 0.0001216677040860215,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006889691000000001,
+                    "tottime_per": 0.000172242275,
+                    "cumtime": 0.262643868,
+                    "cumtime_per": 0.0065660967,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.029453103,
+                    "tottime_per": 4.724060981282179e-07,
+                    "cumtime": 0.23176015000000003,
+                    "cumtime_per": 3.717262258007603e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.025543593000000003,
+                    "tottime_per": 1.639511745827985e-05,
+                    "cumtime": 0.22407442800000002,
+                    "cumtime_per": 0.00014382184082156613,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "17946",
+                    "ncalls": 17946,
+                    "tottime": 0.016343125,
+                    "tottime_per": 9.106834392065084e-07,
+                    "cumtime": 0.205117148,
+                    "cumtime_per": 1.142968616961997e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.038556469,
+                    "tottime_per": 6.184173897701574e-07,
+                    "cumtime": 0.20230704700000002,
+                    "cumtime_per": 3.244856159879385e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                }
+            ],
+            "stats": {
+                "min": 1.7001880540010461,
+                "max": 1.7001880540010461,
+                "mean": 1.7001880540010461,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.7001880540010461,
+                "iqr": 0.0,
+                "q1": 1.7001880540010461,
+                "q3": 1.7001880540010461,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.7001880540010461,
+                "hd15iqr": 1.7001880540010461,
+                "ops": 0.5881702307263622,
+                "total": 1.7001880540010461,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy3-pols3-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy3-pols3-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    2,
+                    1,
+                    3
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy3-pols3-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.001072039,
+                    "tottime_per": 0.001072039,
+                    "cumtime": 3.1658815290000004,
+                    "cumtime_per": 3.1658815290000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.001510496,
+                    "tottime_per": 0.000755248,
+                    "cumtime": 1.8215802200000002,
+                    "cumtime_per": 0.9107901100000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.0039340370000000005,
+                    "tottime_per": 0.0006556728333333334,
+                    "cumtime": 1.496702176,
+                    "cumtime_per": 0.24945036266666668,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001230453,
+                    "tottime_per": 3.417925e-05,
+                    "cumtime": 1.435672247,
+                    "cumtime_per": 0.03987978463888889,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0025874920000000003,
+                    "tottime_per": 0.0025874920000000003,
+                    "cumtime": 1.336879839,
+                    "cumtime_per": 1.336879839,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.001222468,
+                    "tottime_per": 3.3957444444444443e-05,
+                    "cumtime": 1.2249768870000002,
+                    "cumtime_per": 0.03402713575000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.341671867,
+                    "tottime_per": 0.341671867,
+                    "cumtime": 1.2242741300000002,
+                    "cumtime_per": 1.2242741300000002,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001392114,
+                    "tottime_per": 3.8669833333333334e-05,
+                    "cumtime": 1.221629785,
+                    "cumtime_per": 0.033934160694444444,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0030837190000000004,
+                    "tottime_per": 7.709297500000001e-05,
+                    "cumtime": 1.1662148410000002,
+                    "cumtime_per": 0.029155371025000005,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.000126024,
+                    "tottime_per": 3.1506e-06,
+                    "cumtime": 0.7085563890000001,
+                    "cumtime_per": 0.017713909725,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0039263430000000005,
+                    "tottime_per": 9.815857500000001e-05,
+                    "cumtime": 0.708407749,
+                    "cumtime_per": 0.017710193725,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.0004907000000000001,
+                    "tottime_per": 2.7261111111111115e-05,
+                    "cumtime": 0.6355898130000001,
+                    "cumtime_per": 0.03531054516666667,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "325749/277617",
+                    "ncalls": 325749,
+                    "tottime": 0.06778445000000001,
+                    "tottime_per": 2.441653429004708e-07,
+                    "cumtime": 0.515354816,
+                    "cumtime_per": 1.8563517940183778e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "157055/91826",
+                    "ncalls": 157055,
+                    "tottime": 0.068635266,
+                    "tottime_per": 7.47449153834426e-07,
+                    "cumtime": 0.443270151,
+                    "cumtime_per": 4.8272836778254526e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.004239321,
+                    "tottime_per": 9.634820454545454e-05,
+                    "cumtime": 0.40658822800000005,
+                    "cumtime_per": 0.009240641545454547,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.38034833500000004,
+                    "tottime_per": 4.853858282286882e-06,
+                    "cumtime": 0.38034833500000004,
+                    "cumtime_per": 4.853858282286882e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.155817589,
+                    "tottime_per": 3.63041912861137e-05,
+                    "cumtime": 0.325956732,
+                    "cumtime_per": 7.594518452935696e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.013802799000000001,
+                    "tottime_per": 5.936687741935484e-06,
+                    "cumtime": 0.29117069,
+                    "cumtime_per": 0.0001252347053763441,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.028101193000000003,
+                    "tottime_per": 1.2029620291095892e-05,
+                    "cumtime": 0.286184959,
+                    "cumtime_per": 0.00012251068450342466,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.032819084000000005,
+                    "tottime_per": 5.263939564052802e-07,
+                    "cumtime": 0.283240469,
+                    "cumtime_per": 4.54296869135644e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006909861000000001,
+                    "tottime_per": 0.000172746525,
+                    "cumtime": 0.26439470000000004,
+                    "cumtime_per": 0.006609867500000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.025589358000000003,
+                    "tottime_per": 1.6424491655969193e-05,
+                    "cumtime": 0.229253846,
+                    "cumtime_per": 0.00014714624261874198,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.028509566,
+                    "tottime_per": 4.57272458979582e-07,
+                    "cumtime": 0.21934752000000002,
+                    "cumtime_per": 3.5181728070316136e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.08615262,
+                    "tottime_per": 2.987261442441054e-05,
+                    "cumtime": 0.201767142,
+                    "cumtime_per": 6.996086754507629e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.000248489,
+                    "tottime_per": 6.212225e-05,
+                    "cumtime": 0.19737670400000001,
+                    "cumtime_per": 0.049344176000000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                }
+            ],
+            "stats": {
+                "min": 1.489820843002235,
+                "max": 1.489820843002235,
+                "mean": 1.489820843002235,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.489820843002235,
+                "iqr": 0.0,
+                "q1": 1.489820843002235,
+                "q3": 1.489820843002235,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.489820843002235,
+                "hd15iqr": 1.489820843002235,
+                "ops": 0.6712216470168553,
+                "total": 1.489820843002235,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-3.0-flag_strategy4-pols4-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-3.0-flag_strategy4-pols4-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 3.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-3.0-flag_strategy4-pols4-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0008638620000000001,
+                    "tottime_per": 0.0008638620000000001,
+                    "cumtime": 3.1188360700000004,
+                    "cumtime_per": 3.1188360700000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0013723560000000001,
+                    "tottime_per": 0.0006861780000000001,
+                    "cumtime": 1.77264854,
+                    "cumtime_per": 0.88632427,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.003160931,
+                    "tottime_per": 0.0005268218333333333,
+                    "cumtime": 1.36258034,
+                    "cumtime_per": 0.22709672333333333,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.001738289,
+                    "tottime_per": 0.001738289,
+                    "cumtime": 1.337897432,
+                    "cumtime_per": 1.337897432,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.369808579,
+                    "tottime_per": 0.369808579,
+                    "cumtime": 1.316828332,
+                    "cumtime_per": 1.316828332,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0009493430000000001,
+                    "tottime_per": 2.637063888888889e-05,
+                    "cumtime": 1.309409188,
+                    "cumtime_per": 0.03637247744444445,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.0009544660000000001,
+                    "tottime_per": 2.6512944444444447e-05,
+                    "cumtime": 1.112665582,
+                    "cumtime_per": 0.030907377277777776,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0009637970000000001,
+                    "tottime_per": 2.6772138888888892e-05,
+                    "cumtime": 1.1100028910000002,
+                    "cumtime_per": 0.030833413638888894,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002603878,
+                    "tottime_per": 6.509695e-05,
+                    "cumtime": 1.0636156780000001,
+                    "cumtime_per": 0.026590391950000004,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 8.709800000000001e-05,
+                    "tottime_per": 2.1774500000000002e-06,
+                    "cumtime": 0.6394711120000001,
+                    "cumtime_per": 0.0159867778,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0032934770000000004,
+                    "tottime_per": 8.233692500000001e-05,
+                    "cumtime": 0.639362469,
+                    "cumtime_per": 0.015984061725000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.00040153700000000004,
+                    "tottime_per": 2.2307611111111112e-05,
+                    "cumtime": 0.5703456210000001,
+                    "cumtime_per": 0.03168586783333334,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "328605/280473",
+                    "ncalls": 328605,
+                    "tottime": 0.067385268,
+                    "tottime_per": 2.402558107197484e-07,
+                    "cumtime": 0.479659616,
+                    "cumtime_per": 1.7101810726879236e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "157271/91898",
+                    "ncalls": 157271,
+                    "tottime": 0.07158423800000001,
+                    "tottime_per": 7.789531654660603e-07,
+                    "cumtime": 0.464920274,
+                    "cumtime_per": 5.059090230472916e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.411095778,
+                    "tottime_per": 5.246245252679939e-06,
+                    "cumtime": 0.411095778,
+                    "cumtime_per": 5.246245252679939e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.003618963,
+                    "tottime_per": 8.22491590909091e-05,
+                    "cumtime": 0.382096252,
+                    "cumtime_per": 0.008684005727272728,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.012686576000000001,
+                    "tottime_per": 5.45659182795699e-06,
+                    "cumtime": 0.34357621800000004,
+                    "cumtime_per": 0.00014777471741935486,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.14946797,
+                    "tottime_per": 3.482478331780056e-05,
+                    "cumtime": 0.308295914,
+                    "cumtime_per": 7.183036206896552e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.034933545,
+                    "tottime_per": 5.603083548526795e-07,
+                    "cumtime": 0.306354145,
+                    "cumtime_per": 4.913695045471314e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.025958419,
+                    "tottime_per": 1.1112336900684931e-05,
+                    "cumtime": 0.27106195,
+                    "cumtime_per": 0.00011603679366438356,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006532022,
+                    "tottime_per": 0.00016330055,
+                    "cumtime": 0.249444886,
+                    "cumtime_per": 0.0062361221500000005,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.030445209,
+                    "tottime_per": 4.883187482958282e-07,
+                    "cumtime": 0.237884736,
+                    "cumtime_per": 3.8154961104784514e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.023994824,
+                    "tottime_per": 1.5401042362002568e-05,
+                    "cumtime": 0.210570538,
+                    "cumtime_per": 0.0001351543889602054,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.039650133000000004,
+                    "tottime_per": 6.359589555231207e-07,
+                    "cumtime": 0.207439527,
+                    "cumtime_per": 3.327177362182623e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00022609300000000002,
+                    "tottime_per": 5.6523250000000005e-05,
+                    "cumtime": 0.20095358100000002,
+                    "cumtime_per": 0.050238395250000005,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                }
+            ],
+            "stats": {
+                "min": 1.8270223979998264,
+                "max": 1.8270223979998264,
+                "mean": 1.8270223979998264,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.8270223979998264,
+                "iqr": 0.0,
+                "q1": 1.8270223979998264,
+                "q3": 1.8270223979998264,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.8270223979998264,
+                "hd15iqr": 1.8270223979998264,
+                "ops": 0.5473386648651776,
+                "total": 1.8270223979998264,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-False-0.0-flag_strategy5-pols5-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-False-0.0-flag_strategy5-pols5-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": false,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-False-0.0-flag_strategy5-pols5-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0006213200000000001,
+                    "tottime_per": 0.0006213200000000001,
+                    "cumtime": 2.9229896920000003,
+                    "cumtime_per": 2.9229896920000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0012868970000000002,
+                    "tottime_per": 0.0006434485000000001,
+                    "cumtime": 1.613164062,
+                    "cumtime_per": 0.806582031,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.0032833560000000003,
+                    "tottime_per": 0.000547226,
+                    "cumtime": 1.33037621,
+                    "cumtime_per": 0.22172936833333334,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.001583771,
+                    "tottime_per": 0.001583771,
+                    "cumtime": 1.3023961940000002,
+                    "cumtime_per": 1.3023961940000002,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.363336347,
+                    "tottime_per": 0.363336347,
+                    "cumtime": 1.2843573160000001,
+                    "cumtime_per": 1.2843573160000001,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.000974958,
+                    "tottime_per": 2.708216666666667e-05,
+                    "cumtime": 1.27881649,
+                    "cumtime_per": 0.03552268027777778,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.000940809,
+                    "tottime_per": 2.6133583333333333e-05,
+                    "cumtime": 1.086068882,
+                    "cumtime_per": 0.030168580055555554,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0009063410000000001,
+                    "tottime_per": 2.5176138888888892e-05,
+                    "cumtime": 1.08348859,
+                    "cumtime_per": 0.030096905277777777,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0024135100000000002,
+                    "tottime_per": 6.033775000000001e-05,
+                    "cumtime": 1.033536221,
+                    "cumtime_per": 0.025838405525000004,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.00010584300000000001,
+                    "tottime_per": 2.6460750000000003e-06,
+                    "cumtime": 0.619780281,
+                    "cumtime_per": 0.015494507025000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.003182376,
+                    "tottime_per": 7.95594e-05,
+                    "cumtime": 0.6196526,
+                    "cumtime_per": 0.015491315,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.00042023600000000005,
+                    "tottime_per": 2.3346444444444446e-05,
+                    "cumtime": 0.564406783,
+                    "cumtime_per": 0.03135593238888889,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "325749/277617",
+                    "ncalls": 325749,
+                    "tottime": 0.065045553,
+                    "tottime_per": 2.34299603410454e-07,
+                    "cumtime": 0.46142180800000004,
+                    "cumtime_per": 1.6620805210055581e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "156959/91778",
+                    "ncalls": 156959,
+                    "tottime": 0.06898897000000001,
+                    "tottime_per": 7.516939789492037e-07,
+                    "cumtime": 0.43749200000000005,
+                    "cumtime_per": 4.766850443461397e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.408880059,
+                    "tottime_per": 5.2179691041347625e-06,
+                    "cumtime": 0.408880059,
+                    "cumtime_per": 5.2179691041347625e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.0032351880000000004,
+                    "tottime_per": 7.3527e-05,
+                    "cumtime": 0.368139047,
+                    "cumtime_per": 0.008366796522727272,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "127504/4292",
+                    "ncalls": 127504,
+                    "tottime": 0.147463285,
+                    "tottime_per": 3.435770852749301e-05,
+                    "cumtime": 0.302044556,
+                    "cumtime_per": 7.037384808946878e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.03428251,
+                    "tottime_per": 5.498662325372512e-07,
+                    "cumtime": 0.30100811,
+                    "cumtime_per": 4.827948578119236e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "2496/2336",
+                    "ncalls": 2496,
+                    "tottime": 0.025187345,
+                    "tottime_per": 1.0782253852739727e-05,
+                    "cumtime": 0.265209503,
+                    "cumtime_per": 0.00011353146532534247,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.012047633,
+                    "tottime_per": 5.181777634408602e-06,
+                    "cumtime": 0.249478208,
+                    "cumtime_per": 0.00010730245505376344,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.006441633,
+                    "tottime_per": 0.000161040825,
+                    "cumtime": 0.24216251500000002,
+                    "cumtime_per": 0.006054062875,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.029747306,
+                    "tottime_per": 4.771248977496912e-07,
+                    "cumtime": 0.233454398,
+                    "cumtime_per": 3.7444367491619488e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "62347",
+                    "ncalls": 62347,
+                    "tottime": 0.039028676000000005,
+                    "tottime_per": 6.259912425617913e-07,
+                    "cumtime": 0.203707092,
+                    "cumtime_per": 3.2673118514122572e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.022963793,
+                    "tottime_per": 1.4739276636713735e-05,
+                    "cumtime": 0.20115982000000002,
+                    "cumtime_per": 0.00012911413350449294,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.074919621,
+                    "tottime_per": 2.5977677184466023e-05,
+                    "cumtime": 0.17764464100000002,
+                    "cumtime_per": 6.159661615811373e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                }
+            ],
+            "stats": {
+                "min": 1.5898530859994935,
+                "max": 1.5898530859994935,
+                "mean": 1.5898530859994935,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.5898530859994935,
+                "iqr": 0.0,
+                "q1": 1.5898530859994935,
+                "q3": 1.5898530859994935,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.5898530859994935,
+                "hd15iqr": 1.5898530859994935,
+                "ops": 0.6289889353967129,
+                "total": 1.5898530859994935,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[3-True-0.0-flag_strategy6-pols6-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[3-True-0.0-flag_strategy6-pols6-None]",
+            "params": {
+                "random_ants_to_drop": 3,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "3-True-0.0-flag_strategy6-pols6-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000730824,
+                    "tottime_per": 0.000730824,
+                    "cumtime": 2.579766164,
+                    "cumtime_per": 2.579766164,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.0018676,
+                    "tottime_per": 0.0018676,
+                    "cumtime": 1.2986438450000002,
+                    "cumtime_per": 1.2986438450000002,
+                    "function_name": "hera_cal/hera_cal/red_groups.py:191(from_antpos)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.35840526,
+                    "tottime_per": 0.35840526,
+                    "cumtime": 1.278071559,
+                    "cumtime_per": 1.278071559,
+                    "function_name": "hera_cal/hera_cal/redcal.py:24(get_pos_reds)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0010957900000000001,
+                    "tottime_per": 0.0005478950000000001,
+                    "cumtime": 1.273645348,
+                    "cumtime_per": 0.636822674,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.0023493850000000003,
+                    "tottime_per": 0.0005873462500000001,
+                    "cumtime": 0.956105885,
+                    "cumtime_per": 0.23902647125,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 0.000812903,
+                    "tottime_per": 3.3870958333333336e-05,
+                    "cumtime": 0.9185053750000001,
+                    "cumtime_per": 0.03827105729166667,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "36/24",
+                    "ncalls": 36,
+                    "tottime": 0.0007422850000000001,
+                    "tottime_per": 3.092854166666667e-05,
+                    "cumtime": 0.7929767590000001,
+                    "cumtime_per": 0.03304069829166667,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 0.0007612220000000001,
+                    "tottime_per": 3.171758333333334e-05,
+                    "cumtime": 0.790816752,
+                    "cumtime_per": 0.032950698,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.0018327060000000001,
+                    "tottime_per": 6.545378571428572e-05,
+                    "cumtime": 0.7708751960000001,
+                    "cumtime_per": 0.027531257000000003,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 6.1579e-05,
+                    "tottime_per": 2.19925e-06,
+                    "cumtime": 0.468623255,
+                    "cumtime_per": 0.016736544821428573,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.002521217,
+                    "tottime_per": 9.004346428571429e-05,
+                    "cumtime": 0.46854564800000004,
+                    "cumtime_per": 0.016733773142857143,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "150523/86308",
+                    "ncalls": 150523,
+                    "tottime": 0.066228279,
+                    "tottime_per": 7.67348090559392e-07,
+                    "cumtime": 0.42076754600000005,
+                    "cumtime_per": 4.875185915558234e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 0.00029192000000000004,
+                    "tottime_per": 2.432666666666667e-05,
+                    "cumtime": 0.40293899000000005,
+                    "cumtime_per": 0.03357824916666667,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "78360",
+                    "ncalls": 78360,
+                    "tottime": 0.399853151,
+                    "tottime_per": 5.102771197039306e-06,
+                    "cumtime": 0.399853151,
+                    "cumtime_per": 5.102771197039306e-06,
+                    "function_name": "hera_cal/hera_cal/redcal.py:50(check_neighbors)"
+                },
+                {
+                    "ncalls_recursion": "246127/211993",
+                    "ncalls": 246127,
+                    "tottime": 0.052170440000000005,
+                    "tottime_per": 2.4609510691390757e-07,
+                    "cumtime": 0.356246995,
+                    "cumtime_per": 1.6804658408532358e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "62191",
+                    "ncalls": 62191,
+                    "tottime": 0.034024504000000004,
+                    "tottime_per": 5.4709691112862e-07,
+                    "cumtime": 0.299197327,
+                    "cumtime_per": 4.810942531877603e-06,
+                    "function_name": "<__array_function__ internals>:177(round_)"
+                },
+                {
+                    "ncalls_recursion": "32",
+                    "ncalls": 32,
+                    "tottime": 0.0027011080000000002,
+                    "tottime_per": 8.440962500000001e-05,
+                    "cumtime": 0.283878311,
+                    "cumtime_per": 0.00887119721875,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "62191",
+                    "ncalls": 62191,
+                    "tottime": 0.029366001000000003,
+                    "tottime_per": 4.72190525960348e-07,
+                    "cumtime": 0.232045145,
+                    "cumtime_per": 3.731169220626779e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3722(round_)"
+                },
+                {
+                    "ncalls_recursion": "3635/1601",
+                    "ncalls": 3635,
+                    "tottime": 0.009356797,
+                    "tottime_per": 5.8443454091193e-06,
+                    "cumtime": 0.222577142,
+                    "cumtime_per": 0.00013902382386008744,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "85216/3032",
+                    "ncalls": 85216,
+                    "tottime": 0.10420523500000001,
+                    "tottime_per": 3.436848120052771e-05,
+                    "cumtime": 0.21668054,
+                    "cumtime_per": 7.146455804749341e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "62191",
+                    "ncalls": 62191,
+                    "tottime": 0.038888529000000005,
+                    "tottime_per": 6.253079866861766e-07,
+                    "cumtime": 0.202679144,
+                    "cumtime_per": 3.2589786946664308e-06,
+                    "function_name": "<__array_function__ internals>:177(around)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.000199096,
+                    "tottime_per": 4.9774e-05,
+                    "cumtime": 0.20021909300000001,
+                    "cumtime_per": 0.050054773250000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "1740/1628",
+                    "ncalls": 1740,
+                    "tottime": 0.018807969,
+                    "tottime_per": 1.155280651105651e-05,
+                    "cumtime": 0.188590523,
+                    "cumtime_per": 0.0001158418445945946,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:227(_deepcopy_dict)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.004836759,
+                    "tottime_per": 0.00017274139285714286,
+                    "cumtime": 0.183701466,
+                    "cumtime_per": 0.006560766642857143,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1078",
+                    "ncalls": 1078,
+                    "tottime": 0.017455177000000002,
+                    "tottime_per": 1.6192186456400745e-05,
+                    "cumtime": 0.154612029,
+                    "cumtime_per": 0.00014342488775510206,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                }
+            ],
+            "stats": {
+                "min": 1.453380778999417,
+                "max": 1.453380778999417,
+                "mean": 1.453380778999417,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 1.453380778999417,
+                "iqr": 0.0,
+                "q1": 1.453380778999417,
+                "q3": 1.453380778999417,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 1.453380778999417,
+                "hd15iqr": 1.453380778999417,
+                "ops": 0.6880509323155161,
+                "total": 1.453380778999417,
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2023-05-10T22:12:32.835585",
+    "version": "4.0.0"
+}

--- a/.benchmarks/Linux-CPython-3.10-64bit/0003_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_221820_uncommited-changes.json
+++ b/.benchmarks/Linux-CPython-3.10-64bit/0003_3a0f8a44c3a469bd3e3d27009467f90515500b11_20230510_221820_uncommited-changes.json
@@ -1,0 +1,4750 @@
+{
+    "machine_info": {
+        "node": "LAPTOP-J64LT06Q",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC 10.4.0",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.10.6",
+        "python_version": "3.10.6",
+        "python_build": [
+            "main",
+            "Aug 22 2022 20:36:39"
+        ],
+        "release": "5.15.90.1-microsoft-standard-WSL2",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.10.6.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 16,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "GenuineIntel",
+            "brand_raw": "11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz",
+            "hz_advertised_friendly": "2.3000 GHz",
+            "hz_actual_friendly": "2.3040 GHz",
+            "hz_advertised": [
+                2300000000,
+                0
+            ],
+            "hz_actual": [
+                2304008000,
+                0
+            ],
+            "stepping": 1,
+            "model": 141,
+            "family": 6,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arch_capabilities",
+                "arch_perfmon",
+                "avx",
+                "avx2",
+                "avx512_bitalg",
+                "avx512_vbmi2",
+                "avx512_vnni",
+                "avx512_vp2intersect",
+                "avx512_vpopcntdq",
+                "avx512bitalg",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512ifma",
+                "avx512vbmi",
+                "avx512vbmi2",
+                "avx512vl",
+                "avx512vnni",
+                "avx512vpopcntdq",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "clwb",
+                "cmov",
+                "constant_tsc",
+                "cpuid",
+                "cx16",
+                "cx8",
+                "de",
+                "ept",
+                "ept_ad",
+                "erms",
+                "f16c",
+                "flush_l1d",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fsrm",
+                "fxsr",
+                "gfni",
+                "ht",
+                "hypervisor",
+                "ibpb",
+                "ibrs",
+                "ibrs_enhanced",
+                "invpcid",
+                "invpcid_single",
+                "lahf_lm",
+                "lm",
+                "mca",
+                "mce",
+                "mmx",
+                "movbe",
+                "movdir64b",
+                "movdiri",
+                "msr",
+                "mtrr",
+                "nonstop_tsc",
+                "nopl",
+                "nx",
+                "osxsave",
+                "pae",
+                "pat",
+                "pcid",
+                "pclmulqdq",
+                "pdcm",
+                "pdpe1gb",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdpid",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "sep",
+                "sha",
+                "sha_ni",
+                "smap",
+                "smep",
+                "ss",
+                "ssbd",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "stibp",
+                "syscall",
+                "tpr_shadow",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_reliable",
+                "tscdeadline",
+                "umip",
+                "vaes",
+                "vme",
+                "vmx",
+                "vnmi",
+                "vpclmulqdq",
+                "vpid",
+                "x2apic",
+                "xgetbv1",
+                "xsave",
+                "xsavec",
+                "xsaveopt",
+                "xsaves",
+                "xtopology"
+            ],
+            "l3_cache_size": 25165824,
+            "l2_cache_size": 10485760,
+            "l1_data_cache_size": 393216,
+            "l1_instruction_cache_size": 262144,
+            "l2_cache_line_size": 256,
+            "l2_cache_associativity": 7
+        }
+    },
+    "commit_info": {
+        "id": "3a0f8a44c3a469bd3e3d27009467f90515500b11",
+        "time": "2023-05-10T10:32:33-07:00",
+        "author_time": "2023-05-10T10:32:33-07:00",
+        "dirty": true,
+        "project": "hera_cal",
+        "branch": "lstbin-improvements"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_increasing_lsts_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_increasing_lsts_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.5679e-05,
+                    "tottime_per": 8.5679e-05,
+                    "cumtime": 0.00020947400000000002,
+                    "cumtime_per": 0.00020947400000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "11/10",
+                    "ncalls": 11,
+                    "tottime": 1.3262000000000001e-05,
+                    "tottime_per": 1.3262000000000001e-06,
+                    "cumtime": 7.918000000000001e-05,
+                    "cumtime_per": 7.918000000000001e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.6951e-05,
+                    "tottime_per": 1.6951e-05,
+                    "cumtime": 3.9907e-05,
+                    "cumtime_per": 3.9907e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.611e-06,
+                    "tottime_per": 7.685e-07,
+                    "cumtime": 3.4476e-05,
+                    "cumtime_per": 5.746e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.3187000000000001e-05,
+                    "tottime_per": 1.883857142857143e-06,
+                    "cumtime": 2.7721e-05,
+                    "cumtime_per": 3.9601428571428575e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.704e-06,
+                    "tottime_per": 7.84e-07,
+                    "cumtime": 2.2764e-05,
+                    "cumtime_per": 3.794e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.571e-06,
+                    "tottime_per": 1.571e-06,
+                    "cumtime": 2.1530000000000002e-05,
+                    "cumtime_per": 2.1530000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.2040000000000005e-06,
+                    "tottime_per": 5.2040000000000005e-06,
+                    "cumtime": 1.8962000000000002e-05,
+                    "cumtime_per": 1.8962000000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.121e-06,
+                    "tottime_per": 2.121e-06,
+                    "cumtime": 1.7101e-05,
+                    "cumtime_per": 1.7101e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3096000000000001e-05,
+                    "tottime_per": 1.3096000000000001e-05,
+                    "cumtime": 1.3842e-05,
+                    "cumtime_per": 1.3842e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.175e-06,
+                    "tottime_per": 1.175e-06,
+                    "cumtime": 1.3341000000000002e-05,
+                    "cumtime_per": 1.3341000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4510000000000002e-06,
+                    "tottime_per": 1.4510000000000002e-06,
+                    "cumtime": 1.1112000000000001e-05,
+                    "cumtime_per": 1.1112000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.5580000000000003e-06,
+                    "tottime_per": 2.5580000000000003e-06,
+                    "cumtime": 1.0369e-05,
+                    "cumtime_per": 1.0369e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.0148e-05,
+                    "tottime_per": 1.4497142857142856e-06,
+                    "cumtime": 1.0148e-05,
+                    "cumtime_per": 1.4497142857142856e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1010000000000001e-06,
+                    "tottime_per": 1.1010000000000001e-06,
+                    "cumtime": 7.57e-06,
+                    "cumtime_per": 7.57e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.747e-06,
+                    "tottime_per": 2.747e-06,
+                    "cumtime": 7.146000000000001e-06,
+                    "cumtime_per": 7.146000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.6280000000000001e-06,
+                    "tottime_per": 1.6280000000000001e-06,
+                    "cumtime": 5.485e-06,
+                    "cumtime_per": 5.485e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.0500000000000001e-06,
+                    "tottime_per": 1.0500000000000001e-06,
+                    "cumtime": 5.432000000000001e-06,
+                    "cumtime_per": 5.432000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.1320000000000003e-06,
+                    "tottime_per": 3.1320000000000003e-06,
+                    "cumtime": 4.3820000000000006e-06,
+                    "cumtime_per": 4.3820000000000006e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.175e-06,
+                    "tottime_per": 1.5875e-06,
+                    "cumtime": 3.693e-06,
+                    "cumtime_per": 1.8465e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 3.529e-06,
+                    "tottime_per": 5.041428571428572e-07,
+                    "cumtime": 3.529e-06,
+                    "cumtime_per": 5.041428571428572e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.246e-06,
+                    "tottime_per": 2.246e-06,
+                    "cumtime": 2.246e-06,
+                    "cumtime_per": 2.246e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.006e-06,
+                    "tottime_per": 2.006e-06,
+                    "cumtime": 2.006e-06,
+                    "cumtime_per": 2.006e-06,
+                    "function_name": "~:0(<built-in method numpy.zeros>)"
+                },
+                {
+                    "ncalls_recursion": "19",
+                    "ncalls": 19,
+                    "tottime": 1.918e-06,
+                    "tottime_per": 1.0094736842105264e-07,
+                    "cumtime": 1.918e-06,
+                    "cumtime_per": 1.0094736842105264e-07,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.900000000000001e-07,
+                    "tottime_per": 7.900000000000001e-07,
+                    "cumtime": 1.8430000000000002e-06,
+                    "cumtime_per": 1.8430000000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                }
+            ],
+            "stats": {
+                "min": 9.068800136446953e-05,
+                "max": 0.0002100120000250172,
+                "mean": 0.00010549453235127019,
+                "stddev": 2.4901406468490015e-05,
+                "rounds": 308,
+                "median": 9.545250031806063e-05,
+                "iqr": 4.977997377864085e-06,
+                "q1": 9.361900083604269e-05,
+                "q3": 9.859699821390677e-05,
+                "iqr_outliers": 58,
+                "stddev_outliers": 40,
+                "outliers": "40;58",
+                "ld15iqr": 9.068800136446953e-05,
+                "hd15iqr": 0.00010708999980124645,
+                "ops": 9479.164253463412,
+                "total": 0.03249231596419122,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_one_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_one_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.00011523700000000001,
+                    "tottime_per": 0.00011523700000000001,
+                    "cumtime": 0.00031417500000000003,
+                    "cumtime_per": 0.00031417500000000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.4346000000000001e-05,
+                    "tottime_per": 1.3041818181818182e-06,
+                    "cumtime": 0.000137398,
+                    "cumtime_per": 1.2490727272727273e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 2.4933e-05,
+                    "tottime_per": 3.116625e-06,
+                    "cumtime": 7.235500000000001e-05,
+                    "cumtime_per": 9.044375000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.0857e-05,
+                    "tottime_per": 3.0857e-05,
+                    "cumtime": 6.0445e-05,
+                    "cumtime_per": 6.0445e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.731000000000001e-06,
+                    "tottime_per": 8.187142857142858e-07,
+                    "cumtime": 5.7989e-05,
+                    "cumtime_per": 8.284142857142857e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5830000000000001e-06,
+                    "tottime_per": 1.5830000000000001e-06,
+                    "cumtime": 4.3887e-05,
+                    "cumtime_per": 4.3887e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.0464e-05,
+                    "tottime_per": 1.494857142857143e-06,
+                    "cumtime": 4.3395e-05,
+                    "cumtime_per": 6.199285714285714e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.754e-06,
+                    "tottime_per": 1.754e-06,
+                    "cumtime": 4.1178000000000005e-05,
+                    "cumtime_per": 4.1178000000000005e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.1777000000000004e-05,
+                    "tottime_per": 3.9721250000000005e-06,
+                    "cumtime": 3.1777000000000004e-05,
+                    "cumtime_per": 3.9721250000000005e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.8620000000000001e-06,
+                    "tottime_per": 1.8620000000000001e-06,
+                    "cumtime": 2.7546e-05,
+                    "cumtime_per": 2.7546e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.053e-06,
+                    "tottime_per": 7.053e-06,
+                    "cumtime": 2.4072000000000003e-05,
+                    "cumtime_per": 2.4072000000000003e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.1290000000000003e-06,
+                    "tottime_per": 2.1290000000000003e-06,
+                    "cumtime": 1.8552e-05,
+                    "cumtime_per": 1.8552e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4312000000000001e-05,
+                    "tottime_per": 1.4312000000000001e-05,
+                    "cumtime": 1.5288e-05,
+                    "cumtime_per": 1.5288e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.4883000000000001e-05,
+                    "tottime_per": 1.8603750000000002e-06,
+                    "cumtime": 1.4883000000000001e-05,
+                    "cumtime_per": 1.8603750000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.739e-06,
+                    "tottime_per": 3.739e-06,
+                    "cumtime": 1.0868e-05,
+                    "cumtime_per": 1.0868e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3270000000000002e-06,
+                    "tottime_per": 1.3270000000000002e-06,
+                    "cumtime": 8.629e-06,
+                    "cumtime_per": 8.629e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.059e-06,
+                    "tottime_per": 2.059e-06,
+                    "cumtime": 7.486000000000001e-06,
+                    "cumtime_per": 7.486000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.3350000000000003e-06,
+                    "tottime_per": 3.3350000000000003e-06,
+                    "cumtime": 6.634e-06,
+                    "cumtime_per": 6.634e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.17e-06,
+                    "tottime_per": 1.17e-06,
+                    "cumtime": 6.193000000000001e-06,
+                    "cumtime_per": 6.193000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.585e-06,
+                    "tottime_per": 2.2925e-06,
+                    "cumtime": 5.265e-06,
+                    "cumtime_per": 2.6325e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.332e-06,
+                    "tottime_per": 3.332e-06,
+                    "cumtime": 5.023e-06,
+                    "cumtime_per": 5.023e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 2.054e-06,
+                    "tottime_per": 9.336363636363637e-08,
+                    "cumtime": 2.054e-06,
+                    "cumtime_per": 9.336363636363637e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.003e-06,
+                    "tottime_per": 2.003e-06,
+                    "cumtime": 2.003e-06,
+                    "cumtime_per": 2.003e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.4930000000000001e-06,
+                    "tottime_per": 1.4930000000000001e-06,
+                    "cumtime": 1.4930000000000001e-06,
+                    "cumtime_per": 1.4930000000000001e-06,
+                    "function_name": "~:0(<method 'searchsorted' of 'numpy.ndarray' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.610000000000001e-07,
+                    "tottime_per": 8.610000000000001e-07,
+                    "cumtime": 1.379e-06,
+                    "cumtime_per": 1.379e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                }
+            ],
+            "stats": {
+                "min": 8.958800026448444e-05,
+                "max": 0.0003939580019505229,
+                "mean": 9.952060821552162e-05,
+                "stddev": 1.5984390461614157e-05,
+                "rounds": 628,
+                "median": 9.61559999268502e-05,
+                "iqr": 3.827997716143727e-06,
+                "q1": 9.507150207355153e-05,
+                "q3": 9.889949978969526e-05,
+                "iqr_outliers": 69,
+                "stddev_outliers": 36,
+                "outliers": "36;69",
+                "ld15iqr": 8.958800026448444e-05,
+                "hd15iqr": 0.00010470599954714999,
+                "ops": 10048.170101959206,
+                "total": 0.062498941959347576,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_flagging",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_flagging",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.356100000000001e-05,
+                    "tottime_per": 8.356100000000001e-05,
+                    "cumtime": 0.00019991300000000002,
+                    "cumtime_per": 0.00019991300000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "12/11",
+                    "ncalls": 12,
+                    "tottime": 1.1875e-05,
+                    "tottime_per": 1.0795454545454546e-06,
+                    "cumtime": 7.547000000000001e-05,
+                    "cumtime_per": 6.860909090909091e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.936000000000001e-06,
+                    "tottime_per": 7.051428571428573e-07,
+                    "cumtime": 3.9638e-05,
+                    "cumtime_per": 5.662571428571429e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5628e-05,
+                    "tottime_per": 1.5628e-05,
+                    "cumtime": 3.5728e-05,
+                    "cumtime_per": 3.5728e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.3893e-05,
+                    "tottime_per": 1.736625e-06,
+                    "cumtime": 2.8997e-05,
+                    "cumtime_per": 3.624625e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.331e-06,
+                    "tottime_per": 7.615714285714286e-07,
+                    "cumtime": 2.6758e-05,
+                    "cumtime_per": 3.8225714285714285e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.114e-06,
+                    "tottime_per": 1.114e-06,
+                    "cumtime": 1.8982000000000002e-05,
+                    "cumtime_per": 1.8982000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.408e-06,
+                    "tottime_per": 4.408e-06,
+                    "cumtime": 1.6882000000000002e-05,
+                    "cumtime_per": 1.6882000000000002e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.435e-06,
+                    "tottime_per": 1.435e-06,
+                    "cumtime": 1.4175e-05,
+                    "cumtime_per": 1.4175e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.1210000000000001e-05,
+                    "tottime_per": 1.1210000000000001e-05,
+                    "cumtime": 1.1847e-05,
+                    "cumtime_per": 1.1847e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.026e-06,
+                    "tottime_per": 1.026e-06,
+                    "cumtime": 1.0689e-05,
+                    "cumtime_per": 1.0689e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0204000000000001e-05,
+                    "tottime_per": 1.2755000000000001e-06,
+                    "cumtime": 1.0204000000000001e-05,
+                    "cumtime_per": 1.2755000000000001e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.062e-06,
+                    "tottime_per": 3.062e-06,
+                    "cumtime": 1.0178e-05,
+                    "cumtime_per": 1.0178e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.249e-06,
+                    "tottime_per": 1.249e-06,
+                    "cumtime": 8.819e-06,
+                    "cumtime_per": 8.819e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.2220000000000001e-06,
+                    "tottime_per": 1.2220000000000001e-06,
+                    "cumtime": 6.9910000000000005e-06,
+                    "cumtime_per": 6.9910000000000005e-06,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.187e-06,
+                    "tottime_per": 3.187e-06,
+                    "cumtime": 6.0210000000000005e-06,
+                    "cumtime_per": 6.0210000000000005e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.426e-06,
+                    "tottime_per": 1.426e-06,
+                    "cumtime": 4.882e-06,
+                    "cumtime_per": 4.882e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:356(issubdtype)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.91e-07,
+                    "tottime_per": 8.91e-07,
+                    "cumtime": 4.846000000000001e-06,
+                    "cumtime_per": 4.846000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.977e-06,
+                    "tottime_per": 4.97125e-07,
+                    "cumtime": 3.977e-06,
+                    "cumtime_per": 4.97125e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.77e-06,
+                    "tottime_per": 2.77e-06,
+                    "cumtime": 3.955e-06,
+                    "cumtime_per": 3.955e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:51(_wrapfunc)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.91e-06,
+                    "tottime_per": 1.455e-06,
+                    "cumtime": 3.3800000000000002e-06,
+                    "cumtime_per": 1.6900000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numerictypes.py:282(issubclass_)"
+                },
+                {
+                    "ncalls_recursion": "22",
+                    "ncalls": 22,
+                    "tottime": 2.017e-06,
+                    "tottime_per": 9.168181818181818e-08,
+                    "cumtime": 2.017e-06,
+                    "cumtime_per": 9.168181818181818e-08,
+                    "function_name": "~:0(<method 'append' of 'list' objects>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.986e-06,
+                    "tottime_per": 1.986e-06,
+                    "cumtime": 1.986e-06,
+                    "cumtime_per": 1.986e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:390(adjust_lst_bin_edges)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.009e-06,
+                    "tottime_per": 1.009e-06,
+                    "cumtime": 1.3940000000000001e-06,
+                    "cumtime_per": 1.3940000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/logging/__init__.py:1467(info)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.3e-06,
+                    "tottime_per": 1.8571428571428572e-07,
+                    "cumtime": 1.3e-06,
+                    "cumtime_per": 1.8571428571428572e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2302(_any_dispatcher)"
+                }
+            ],
+            "stats": {
+                "min": 9.160599802271463e-05,
+                "max": 0.00029560900293290615,
+                "mean": 0.00010476505386494947,
+                "stddev": 2.0229781153648475e-05,
+                "rounds": 649,
+                "median": 9.784800204215571e-05,
+                "iqr": 8.329999218403827e-06,
+                "q1": 9.598725137038855e-05,
+                "q3": 0.00010431725058879238,
+                "iqr_outliers": 87,
+                "stddev_outliers": 47,
+                "outliers": "47;87",
+                "ld15iqr": 9.160599802271463e-05,
+                "hd15iqr": 0.00011720700058504008,
+                "ops": 9545.167621343277,
+                "total": 0.0679925199583522,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_days_with_nsamples_zero",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_multi_days_with_nsamples_zero",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 3.8908e-05,
+                    "tottime_per": 3.8908e-05,
+                    "cumtime": 0.059795388000000005,
+                    "cumtime_per": 0.059795388000000005,
+                    "function_name": "hera_cal/hera_cal/tests/test_lstbin_simple.py:19(get_lst_align_data)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.3081e-05,
+                    "tottime_per": 2.3081e-05,
+                    "cumtime": 0.05942622,
+                    "cumtime_per": 0.05942622,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:187(make_dataset)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.9069e-05,
+                    "tottime_per": 9.5345e-06,
+                    "cumtime": 0.059402834,
+                    "cumtime_per": 0.029701417,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:172(make_day)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.3166e-05,
+                    "tottime_per": 6.583e-06,
+                    "cumtime": 0.059318448,
+                    "cumtime_per": 0.029659224,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:120(create_uvd_identifiable)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.4578e-05,
+                    "tottime_per": 1.7289e-05,
+                    "cumtime": 0.057430906000000004,
+                    "cumtime_per": 0.028715453000000002,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:84(create_uvd_ones)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.6165e-05,
+                    "tottime_per": 2.80825e-05,
+                    "cumtime": 0.057385530000000004,
+                    "cumtime_per": 0.028692765000000002,
+                    "function_name": "hera_cal/hera_cal/tests/mock_uvdata.py:24(create_mock_hera_obs)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 7.078000000000001e-06,
+                    "tottime_per": 3.5390000000000003e-06,
+                    "cumtime": 0.036718459,
+                    "cumtime_per": 0.0183592295,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:774(new)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00016471900000000002,
+                    "tottime_per": 8.235950000000001e-05,
+                    "cumtime": 0.036711381,
+                    "cumtime_per": 0.0183556905,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:328(new_uvdata)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.00016377700000000001,
+                    "tottime_per": 2.7296166666666668e-05,
+                    "cumtime": 0.021914786000000002,
+                    "cumtime_per": 0.003652464333333334,
+                    "function_name": "pyuvdata/pyuvdata/utils.py:3777(get_lst_for_time)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00012395100000000002,
+                    "tottime_per": 6.197550000000001e-05,
+                    "cumtime": 0.017873793000000002,
+                    "cumtime_per": 0.008936896500000001,
+                    "function_name": "hera_cal/hera_cal/utils.py:549(LST2JD)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.00014582200000000001,
+                    "tottime_per": 7.291100000000001e-05,
+                    "cumtime": 0.017571891000000003,
+                    "cumtime_per": 0.008785945500000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.9396e-05,
+                    "tottime_per": 9.849e-06,
+                    "cumtime": 0.016460096,
+                    "cumtime_per": 0.004115024,
+                    "function_name": "hera_cal/hera_cal/utils.py:512(JD2LST)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000368685,
+                    "tottime_per": 0.0001843425,
+                    "cumtime": 0.011739218000000001,
+                    "cumtime_per": 0.0058696090000000005,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 6.3429e-05,
+                    "tottime_per": 3.17145e-05,
+                    "cumtime": 0.010064257,
+                    "cumtime_per": 0.0050321285,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/initializers.py:93(get_time_params)"
+                },
+                {
+                    "ncalls_recursion": "116/28",
+                    "ncalls": 116,
+                    "tottime": 0.000197206,
+                    "tottime_per": 7.043071428571429e-06,
+                    "cumtime": 0.008849423,
+                    "cumtime_per": 0.00031605082142857144,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1624(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "3534/328",
+                    "ncalls": 3534,
+                    "tottime": 0.003874068,
+                    "tottime_per": 1.1811182926829269e-05,
+                    "cumtime": 0.007508215,
+                    "cumtime_per": 2.2890899390243903e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 0.000222849,
+                    "tottime_per": 1.8570750000000002e-05,
+                    "cumtime": 0.007490147000000001,
+                    "cumtime_per": 0.0006241789166666667,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:726(_set_scale)"
+                },
+                {
+                    "ncalls_recursion": "1255/1020",
+                    "ncalls": 1255,
+                    "tottime": 0.001135717,
+                    "tottime_per": 1.1134480392156862e-06,
+                    "cumtime": 0.007377584,
+                    "cumtime_per": 7.2329254901960786e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.0071524480000000005,
+                    "tottime_per": 0.0011920746666666667,
+                    "cumtime": 0.0071524480000000005,
+                    "cumtime_per": 0.0011920746666666667,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/erfa/core.py:13528(gst06a)"
+                },
+                {
+                    "ncalls_recursion": "160",
+                    "ncalls": 160,
+                    "tottime": 0.000378343,
+                    "tottime_per": 2.36464375e-06,
+                    "cumtime": 0.006294648000000001,
+                    "cumtime_per": 3.9341550000000006e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:259(_reconstruct)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.000323715,
+                    "tottime_per": 8.092875e-05,
+                    "cumtime": 0.006253557000000001,
+                    "cumtime_per": 0.0015633892500000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "7348/6030",
+                    "ncalls": 7348,
+                    "tottime": 0.0018440230000000002,
+                    "tottime_per": 3.058081260364843e-07,
+                    "cumtime": 0.006039893,
+                    "cumtime_per": 1.0016406301824213e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 4.4059e-05,
+                    "tottime_per": 7.343166666666667e-06,
+                    "cumtime": 0.005779996000000001,
+                    "cumtime_per": 0.0009633326666666668,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:2405(_get_delta_ut1_utc)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.4560000000000001e-05,
+                    "tottime_per": 1.8200000000000002e-06,
+                    "cumtime": 0.005574825,
+                    "cumtime_per": 0.000696853125,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/coordinates/earth.py:579(geodetic)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 7.0107e-05,
+                    "tottime_per": 5.007642857142857e-06,
+                    "cumtime": 0.005572792,
+                    "cumtime_per": 0.00039805657142857144,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/astropy/time/core.py:1816(__init__)"
+                }
+            ],
+            "stats": {
+                "min": 0.031344483999419026,
+                "max": 0.03311251900231582,
+                "mean": 0.03228033233366053,
+                "stddev": 0.0008885641499358098,
+                "rounds": 3,
+                "median": 0.03238399399924674,
+                "iqr": 0.0013260262521725963,
+                "q1": 0.031604361499375955,
+                "q3": 0.03293038775154855,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.031344483999419026,
+                "hd15iqr": 0.03311251900231582,
+                "ops": 30.97861538919918,
+                "total": 0.09684099700098159,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rephase",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_rephase",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.3497e-05,
+                    "tottime_per": 9.3497e-05,
+                    "cumtime": 0.000388062,
+                    "cumtime_per": 0.000388062,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.9347000000000002e-05,
+                    "tottime_per": 1.5445789473684212e-06,
+                    "cumtime": 0.000148454,
+                    "cumtime_per": 7.813368421052632e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.7438e-05,
+                    "tottime_per": 4.7438e-05,
+                    "cumtime": 0.000141903,
+                    "cumtime_per": 0.000141903,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.7096e-05,
+                    "tottime_per": 1.7096e-05,
+                    "cumtime": 4.5005e-05,
+                    "cumtime_per": 4.5005e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.101e-06,
+                    "tottime_per": 7.287142857142857e-07,
+                    "cumtime": 3.919e-05,
+                    "cumtime_per": 5.598571428571429e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.562e-05,
+                    "tottime_per": 1.7355555555555555e-06,
+                    "cumtime": 3.545e-05,
+                    "cumtime_per": 3.938888888888889e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.252e-06,
+                    "tottime_per": 1.252e-06,
+                    "cumtime": 2.678e-05,
+                    "cumtime_per": 2.678e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 5.1480000000000005e-06,
+                    "tottime_per": 7.354285714285715e-07,
+                    "cumtime": 2.5274000000000002e-05,
+                    "cumtime_per": 3.610571428571429e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.941e-06,
+                    "tottime_per": 6.47e-07,
+                    "cumtime": 2.4918e-05,
+                    "cumtime_per": 8.306e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.7220000000000004e-06,
+                    "tottime_per": 5.7220000000000004e-06,
+                    "cumtime": 2.4670000000000003e-05,
+                    "cumtime_per": 2.4670000000000003e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.104e-06,
+                    "tottime_per": 2.104e-06,
+                    "cumtime": 2.3091000000000003e-05,
+                    "cumtime_per": 2.3091000000000003e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.341e-06,
+                    "tottime_per": 1.1705e-06,
+                    "cumtime": 2.1972000000000002e-05,
+                    "cumtime_per": 1.0986000000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.640000000000001e-06,
+                    "tottime_per": 9.640000000000001e-06,
+                    "cumtime": 1.9842e-05,
+                    "cumtime_per": 1.9842e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.094e-06,
+                    "tottime_per": 6.98e-07,
+                    "cumtime": 1.9665000000000002e-05,
+                    "cumtime_per": 6.555000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.8947e-05,
+                    "tottime_per": 1.8947e-05,
+                    "cumtime": 1.9655e-05,
+                    "cumtime_per": 1.9655e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.5240000000000003e-06,
+                    "tottime_per": 1.2620000000000002e-06,
+                    "cumtime": 1.7848000000000003e-05,
+                    "cumtime_per": 8.924000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.520000000000001e-06,
+                    "tottime_per": 7.520000000000001e-06,
+                    "cumtime": 1.7016e-05,
+                    "cumtime_per": 1.7016e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 4.277e-06,
+                    "tottime_per": 1.4256666666666666e-06,
+                    "cumtime": 1.5321e-05,
+                    "cumtime_per": 5.107e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.4341e-05,
+                    "tottime_per": 1.5934444444444445e-06,
+                    "cumtime": 1.4341e-05,
+                    "cumtime_per": 1.5934444444444445e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.632e-06,
+                    "tottime_per": 8.773333333333334e-07,
+                    "cumtime": 1.3868e-05,
+                    "cumtime_per": 4.622666666666666e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 6.229e-06,
+                    "tottime_per": 1.2458e-06,
+                    "cumtime": 1.3352e-05,
+                    "cumtime_per": 2.6704e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.161e-06,
+                    "tottime_per": 1.161e-06,
+                    "cumtime": 1.3172e-05,
+                    "cumtime_per": 1.3172e-05,
+                    "function_name": "<__array_function__ internals>:177(searchsorted)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1838e-05,
+                    "tottime_per": 1.6911428571428573e-06,
+                    "cumtime": 1.1838e-05,
+                    "cumtime_per": 1.6911428571428573e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.1236e-05,
+                    "tottime_per": 3.7453333333333334e-06,
+                    "cumtime": 1.1236e-05,
+                    "cumtime_per": 3.7453333333333334e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.200000000000001e-07,
+                    "tottime_per": 9.200000000000001e-07,
+                    "cumtime": 1.1050000000000001e-05,
+                    "cumtime_per": 1.1050000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1319(searchsorted)"
+                }
+            ],
+            "stats": {
+                "min": 0.0001821770019887481,
+                "max": 0.0003809179979725741,
+                "mean": 0.00020353606539644115,
+                "stddev": 2.699123240719053e-05,
+                "rounds": 306,
+                "median": 0.000195091999557917,
+                "iqr": 1.0002000635722652e-05,
+                "q1": 0.00019182499818271026,
+                "q3": 0.0002018269988184329,
+                "iqr_outliers": 45,
+                "stddev_outliers": 29,
+                "outliers": "29;45",
+                "ld15iqr": 0.0001821770019887481,
+                "hd15iqr": 0.00021739099975093268,
+                "ops": 4913.134181169472,
+                "total": 0.06228203601131099,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_lstbinedges_modulus",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAlign::test_lstbinedges_modulus",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 8.775200000000001e-05,
+                    "tottime_per": 8.775200000000001e-05,
+                    "cumtime": 0.00034925500000000003,
+                    "cumtime_per": 0.00034925500000000003,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:37(lst_align)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.4799e-05,
+                    "tottime_per": 4.4799e-05,
+                    "cumtime": 0.00013303000000000002,
+                    "cumtime_per": 0.00013303000000000002,
+                    "function_name": "hera_cal/hera_cal/utils.py:878(lst_rephase_vectorized)"
+                },
+                {
+                    "ncalls_recursion": "28/19",
+                    "ncalls": 28,
+                    "tottime": 2.7565e-05,
+                    "tottime_per": 1.4507894736842105e-06,
+                    "cumtime": 0.000126208,
+                    "cumtime_per": 6.642526315789473e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.643e-06,
+                    "tottime_per": 6.632857142857143e-07,
+                    "cumtime": 3.7405000000000005e-05,
+                    "cumtime_per": 5.34357142857143e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.5789e-05,
+                    "tottime_per": 1.5789e-05,
+                    "cumtime": 3.6106e-05,
+                    "cumtime_per": 3.6106e-05,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:179(get_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.4725e-05,
+                    "tottime_per": 1.636111111111111e-06,
+                    "cumtime": 3.3127e-05,
+                    "cumtime_per": 3.680777777777778e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 4.983e-06,
+                    "tottime_per": 7.118571428571429e-07,
+                    "cumtime": 2.4443000000000003e-05,
+                    "cumtime_per": 3.4918571428571433e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.782e-06,
+                    "tottime_per": 5.94e-07,
+                    "cumtime": 2.2809e-05,
+                    "cumtime_per": 7.603000000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(einsum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.941e-06,
+                    "tottime_per": 9.705e-07,
+                    "cumtime": 1.9706e-05,
+                    "cumtime_per": 9.853e-06,
+                    "function_name": "<__array_function__ internals>:177(all)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.849e-06,
+                    "tottime_per": 9.849e-06,
+                    "cumtime": 1.9567e-05,
+                    "cumtime_per": 1.9567e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1725(top2eq_m)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.131e-06,
+                    "tottime_per": 1.131e-06,
+                    "cumtime": 1.9199e-05,
+                    "cumtime_per": 1.9199e-05,
+                    "function_name": "<__array_function__ internals>:177(digitize)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.0220000000000003e-06,
+                    "tottime_per": 6.740000000000001e-07,
+                    "cumtime": 1.857e-05,
+                    "cumtime_per": 6.19e-06,
+                    "function_name": "<__array_function__ internals>:177(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 4.907000000000001e-06,
+                    "tottime_per": 4.907000000000001e-06,
+                    "cumtime": 1.7062e-05,
+                    "cumtime_per": 1.7062e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:5451(digitize)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.667000000000001e-06,
+                    "tottime_per": 7.667000000000001e-06,
+                    "cumtime": 1.6363000000000002e-05,
+                    "cumtime_per": 1.6363000000000002e-05,
+                    "function_name": "hera_cal/hera_cal/utils.py:1707(eq2top_m)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.401e-06,
+                    "tottime_per": 1.2005e-06,
+                    "cumtime": 1.6068000000000003e-05,
+                    "cumtime_per": 8.034000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2406(all)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 4.5110000000000005e-06,
+                    "tottime_per": 1.503666666666667e-06,
+                    "cumtime": 1.4634e-05,
+                    "cumtime_per": 4.8780000000000006e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:76(zeros_like)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.886e-06,
+                    "tottime_per": 1.886e-06,
+                    "cumtime": 1.4581000000000002e-05,
+                    "cumtime_per": 1.4581000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(diff)"
+                },
+                {
+                    "ncalls_recursion": "9",
+                    "ncalls": 9,
+                    "tottime": 1.3150000000000001e-05,
+                    "tottime_per": 1.4611111111111113e-06,
+                    "cumtime": 1.3150000000000001e-05,
+                    "cumtime_per": 1.4611111111111113e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 2.4280000000000003e-06,
+                    "tottime_per": 8.093333333333334e-07,
+                    "cumtime": 1.2418e-05,
+                    "cumtime_per": 4.139333333333334e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/einsumfunc.py:1009(einsum)"
+                },
+                {
+                    "ncalls_recursion": "5",
+                    "ncalls": 5,
+                    "tottime": 5.313000000000001e-06,
+                    "tottime_per": 1.0626000000000002e-06,
+                    "cumtime": 1.2034e-05,
+                    "cumtime_per": 2.4068e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.09e-05,
+                    "tottime_per": 1.09e-05,
+                    "cumtime": 1.1633e-05,
+                    "cumtime_per": 1.1633e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:1319(diff)"
+                },
+                {
+                    "ncalls_recursion": "7",
+                    "ncalls": 7,
+                    "tottime": 1.1128000000000001e-05,
+                    "tottime_per": 1.5897142857142858e-06,
+                    "cumtime": 1.1128000000000001e-05,
+                    "cumtime_per": 1.5897142857142858e-06,
+                    "function_name": "~:0(<built-in method numpy.array>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 9.990000000000001e-06,
+                    "tottime_per": 3.3300000000000003e-06,
+                    "cumtime": 9.990000000000001e-06,
+                    "cumtime_per": 3.3300000000000003e-06,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.c_einsum>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.575e-06,
+                    "tottime_per": 9.575e-06,
+                    "cumtime": 9.575e-06,
+                    "cumtime_per": 9.575e-06,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:155(<listcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.711e-06,
+                    "tottime_per": 2.711e-06,
+                    "cumtime": 8.853e-06,
+                    "cumtime_per": 8.853e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.00017590800052857958,
+                "max": 0.0005143839989614207,
+                "mean": 0.00019854720089750147,
+                "stddev": 3.3782184332403666e-05,
+                "rounds": 244,
+                "median": 0.0001880905001598876,
+                "iqr": 2.10109992622165e-05,
+                "q1": 0.00018220150013803504,
+                "q3": 0.00020321249940025155,
+                "iqr_outliers": 14,
+                "stddev_outliers": 14,
+                "outliers": "14;14",
+                "ld15iqr": 0.00017590800052857958,
+                "hd15iqr": 0.0002357909979764372,
+                "ops": 5036.585736185939,
+                "total": 0.04844551701899036,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_one_point_per_bin",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_one_point_per_bin",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.9336000000000003e-05,
+                    "tottime_per": 1.9336000000000003e-05,
+                    "cumtime": 0.000339,
+                    "cumtime_per": 0.000339,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.2720000000000003e-05,
+                    "tottime_per": 5.2720000000000003e-05,
+                    "cumtime": 0.00030923800000000004,
+                    "cumtime_per": 0.00030923800000000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.1722e-05,
+                    "tottime_per": 2.1722e-06,
+                    "cumtime": 0.00022420100000000002,
+                    "cumtime_per": 2.2420100000000002e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.99e-06,
+                    "tottime_per": 9.95e-07,
+                    "cumtime": 0.000174212,
+                    "cumtime_per": 8.7106e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.4090000000000005e-06,
+                    "tottime_per": 2.2045000000000002e-06,
+                    "cumtime": 0.000170535,
+                    "cumtime_per": 8.52675e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.8480000000000001e-06,
+                    "tottime_per": 9.240000000000001e-07,
+                    "cumtime": 0.000165957,
+                    "cumtime_per": 8.29785e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.4646e-05,
+                    "tottime_per": 1.7323e-05,
+                    "cumtime": 0.000162084,
+                    "cumtime_per": 8.1042e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 9.418e-06,
+                    "tottime_per": 7.848333333333334e-07,
+                    "cumtime": 8.1154e-05,
+                    "cumtime_per": 6.762833333333333e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.3715000000000002e-05,
+                    "tottime_per": 1.1429166666666668e-06,
+                    "cumtime": 6.348600000000001e-05,
+                    "cumtime_per": 5.2905e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.0697000000000002e-05,
+                    "tottime_per": 1.3798000000000001e-06,
+                    "cumtime": 5.7818e-05,
+                    "cumtime_per": 3.8545333333333335e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 1.63e-05,
+                    "tottime_per": 4.075e-06,
+                    "cumtime": 5.3223e-05,
+                    "cumtime_per": 1.330575e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.4590000000000001e-05,
+                    "tottime_per": 1.8237500000000001e-06,
+                    "cumtime": 2.9385e-05,
+                    "cumtime_per": 3.673125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.7647e-05,
+                    "tottime_per": 1.8431333333333334e-06,
+                    "cumtime": 2.7647e-05,
+                    "cumtime_per": 1.8431333333333334e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.0262000000000001e-05,
+                    "tottime_per": 3.420666666666667e-06,
+                    "cumtime": 2.1029e-05,
+                    "cumtime_per": 7.0096666666666674e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.1720000000000003e-06,
+                    "tottime_per": 7.930000000000001e-07,
+                    "cumtime": 2.0456000000000002e-05,
+                    "cumtime_per": 5.1140000000000005e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 6.309e-06,
+                    "tottime_per": 1.0515e-06,
+                    "cumtime": 1.6552e-05,
+                    "cumtime_per": 2.7586666666666665e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.75e-07,
+                    "tottime_per": 9.75e-07,
+                    "cumtime": 1.4841e-05,
+                    "cumtime_per": 1.4841e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 2.74e-06,
+                    "tottime_per": 6.85e-07,
+                    "cumtime": 1.4841e-05,
+                    "cumtime_per": 3.71025e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.336e-06,
+                    "tottime_per": 5.336e-06,
+                    "cumtime": 1.4447e-05,
+                    "cumtime_per": 1.4447e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3440000000000002e-06,
+                    "tottime_per": 1.3440000000000002e-06,
+                    "cumtime": 1.2911e-05,
+                    "cumtime_per": 1.2911e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.754e-06,
+                    "tottime_per": 8.77e-07,
+                    "cumtime": 1.2604e-05,
+                    "cumtime_per": 6.302e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0156e-05,
+                    "tottime_per": 1.2695e-06,
+                    "cumtime": 1.0849e-05,
+                    "cumtime_per": 1.356125e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.728e-06,
+                    "tottime_per": 8.64e-07,
+                    "cumtime": 8.370000000000001e-06,
+                    "cumtime_per": 4.185000000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 8.211e-06,
+                    "tottime_per": 5.473999999999999e-07,
+                    "cumtime": 8.211e-06,
+                    "cumtime_per": 5.473999999999999e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.7320000000000003e-06,
+                    "tottime_per": 2.7320000000000003e-06,
+                    "cumtime": 7.739e-06,
+                    "cumtime_per": 7.739e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/numeric.py:149(ones)"
+                }
+            ],
+            "stats": {
+                "min": 0.00014899500092724338,
+                "max": 0.0005265830004645977,
+                "mean": 0.00017544556553801644,
+                "stddev": 5.8919638516710536e-05,
+                "rounds": 191,
+                "median": 0.00015518200234510005,
+                "iqr": 1.6394752492487896e-05,
+                "q1": 0.00015104549765965203,
+                "q3": 0.00016744025015213992,
+                "iqr_outliers": 23,
+                "stddev_outliers": 16,
+                "outliers": "16;23",
+                "ld15iqr": 0.00014899500092724338,
+                "hd15iqr": 0.00019345300097484142,
+                "ops": 5699.773584663871,
+                "total": 0.03351010301776114,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes0]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes0]",
+            "params": {
+                "ntimes": [
+                    4
+                ]
+            },
+            "param": "ntimes0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.9886000000000002e-05,
+                    "tottime_per": 1.9886000000000002e-05,
+                    "cumtime": 0.000373661,
+                    "cumtime_per": 0.000373661,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.1144000000000004e-05,
+                    "tottime_per": 5.1144000000000004e-05,
+                    "cumtime": 0.000343797,
+                    "cumtime_per": 0.000343797,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "26/10",
+                    "ncalls": 26,
+                    "tottime": 2.4134000000000003e-05,
+                    "tottime_per": 2.4134000000000005e-06,
+                    "cumtime": 0.00025970800000000004,
+                    "cumtime_per": 2.5970800000000006e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.996e-06,
+                    "tottime_per": 9.98e-07,
+                    "cumtime": 0.00020771500000000003,
+                    "cumtime_per": 0.00010385750000000001,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.474000000000001e-06,
+                    "tottime_per": 2.2370000000000004e-06,
+                    "cumtime": 0.00020400000000000003,
+                    "cumtime_per": 0.00010200000000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.004e-06,
+                    "tottime_per": 1.002e-06,
+                    "cumtime": 0.000199347,
+                    "cumtime_per": 9.96735e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.1725000000000005e-05,
+                    "tottime_per": 2.0862500000000002e-05,
+                    "cumtime": 0.000195266,
+                    "cumtime_per": 9.7633e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 9.743000000000001e-06,
+                    "tottime_per": 8.119166666666668e-07,
+                    "cumtime": 9.979700000000001e-05,
+                    "cumtime_per": 8.316416666666667e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 1.4316000000000002e-05,
+                    "tottime_per": 1.193e-06,
+                    "cumtime": 8.1443e-05,
+                    "cumtime_per": 6.786916666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 2.3366000000000003e-05,
+                    "tottime_per": 1.5577333333333335e-06,
+                    "cumtime": 6.7679e-05,
+                    "cumtime_per": 4.511933333333333e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 1.9134e-05,
+                    "tottime_per": 4.7835e-06,
+                    "cumtime": 5.7881000000000004e-05,
+                    "cumtime_per": 1.4470250000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 3.3754e-05,
+                    "tottime_per": 2.250266666666667e-06,
+                    "cumtime": 3.3754e-05,
+                    "cumtime_per": 2.250266666666667e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.4968000000000001e-05,
+                    "tottime_per": 1.8710000000000002e-06,
+                    "cumtime": 3.0674000000000005e-05,
+                    "cumtime_per": 3.834250000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "3",
+                    "ncalls": 3,
+                    "tottime": 1.0769000000000001e-05,
+                    "tottime_per": 3.589666666666667e-06,
+                    "cumtime": 2.3384000000000002e-05,
+                    "cumtime_per": 7.794666666666667e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.272e-06,
+                    "tottime_per": 8.18e-07,
+                    "cumtime": 2.1429e-05,
+                    "cumtime_per": 5.35725e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 6.707e-06,
+                    "tottime_per": 1.1178333333333333e-06,
+                    "cumtime": 1.8223e-05,
+                    "cumtime_per": 3.037166666666667e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.1270000000000003e-06,
+                    "tottime_per": 7.817500000000001e-07,
+                    "cumtime": 1.5644e-05,
+                    "cumtime_per": 3.911e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 9.79e-07,
+                    "tottime_per": 9.79e-07,
+                    "cumtime": 1.5554e-05,
+                    "cumtime_per": 1.5554e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 5.008e-06,
+                    "tottime_per": 5.008e-06,
+                    "cumtime": 1.4781000000000001e-05,
+                    "cumtime_per": 1.4781000000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.6140000000000001e-06,
+                    "tottime_per": 8.070000000000001e-07,
+                    "cumtime": 1.4139000000000001e-05,
+                    "cumtime_per": 7.069500000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 1.3550000000000002e-06,
+                    "tottime_per": 1.3550000000000002e-06,
+                    "cumtime": 1.3594e-05,
+                    "cumtime_per": 1.3594e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "25",
+                    "ncalls": 25,
+                    "tottime": 1.1672000000000001e-05,
+                    "tottime_per": 4.6688000000000006e-07,
+                    "cumtime": 1.1672000000000001e-05,
+                    "cumtime_per": 4.6688000000000006e-07,
+                    "function_name": "~:0(<built-in method builtins.isinstance>)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 1.0622000000000001e-05,
+                    "tottime_per": 1.3277500000000001e-06,
+                    "cumtime": 1.1319000000000001e-05,
+                    "cumtime_per": 1.4148750000000002e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.7780000000000002e-06,
+                    "tottime_per": 8.890000000000001e-07,
+                    "cumtime": 9.187e-06,
+                    "cumtime_per": 4.5935e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "15",
+                    "ncalls": 15,
+                    "tottime": 9.058e-06,
+                    "tottime_per": 6.038666666666666e-07,
+                    "cumtime": 9.058e-06,
+                    "cumtime_per": 6.038666666666666e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                }
+            ],
+            "stats": {
+                "min": 0.00015677699775551446,
+                "max": 0.0005118609988130629,
+                "mean": 0.00027114532500131734,
+                "stddev": 7.866579703218478e-05,
+                "rounds": 157,
+                "median": 0.00030924699967727065,
+                "iqr": 0.00015891924886091147,
+                "q1": 0.0001671822501521092,
+                "q3": 0.00032610149901302066,
+                "iqr_outliers": 0,
+                "stddev_outliers": 61,
+                "outliers": "61;0",
+                "ld15iqr": 0.00015677699775551446,
+                "hd15iqr": 0.0005118609988130629,
+                "ops": 3688.0591616143174,
+                "total": 0.04256981602520682,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_multi_points_per_bin[ntimes1]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_ReduceLSTBins::test_multi_points_per_bin[ntimes1]",
+            "params": {
+                "ntimes": [
+                    5,
+                    4
+                ]
+            },
+            "param": "ntimes1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.7681e-05,
+                    "tottime_per": 2.7681e-05,
+                    "cumtime": 0.000665089,
+                    "cumtime_per": 0.000665089,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:208(reduce_lst_bins)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 9.7349e-05,
+                    "tottime_per": 4.86745e-05,
+                    "cumtime": 0.0006254730000000001,
+                    "cumtime_per": 0.00031273650000000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "51/19",
+                    "ncalls": 51,
+                    "tottime": 4.363e-05,
+                    "tottime_per": 2.296315789473684e-06,
+                    "cumtime": 0.000460733,
+                    "cumtime_per": 2.4249105263157895e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 4.916e-06,
+                    "tottime_per": 1.229e-06,
+                    "cumtime": 0.000366155,
+                    "cumtime_per": 9.153875e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.851e-06,
+                    "tottime_per": 1.96275e-06,
+                    "cumtime": 0.00035747800000000005,
+                    "cumtime_per": 8.936950000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 4.337e-06,
+                    "tottime_per": 1.08425e-06,
+                    "cumtime": 0.00034919700000000004,
+                    "cumtime_per": 8.729925000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 7.2867e-05,
+                    "tottime_per": 1.821675e-05,
+                    "cumtime": 0.00034067,
+                    "cumtime_per": 8.51675e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 1.925e-05,
+                    "tottime_per": 8.020833333333333e-07,
+                    "cumtime": 0.00016303700000000002,
+                    "cumtime_per": 6.793208333333334e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 2.5446e-05,
+                    "tottime_per": 1.06025e-06,
+                    "cumtime": 0.00012722700000000002,
+                    "cumtime_per": 5.301125000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2162(sum)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 3.9559000000000005e-05,
+                    "tottime_per": 1.3186333333333336e-06,
+                    "cumtime": 0.00012020700000000001,
+                    "cumtime_per": 4.0069000000000005e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:69(_wrapreduction)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 3.3482e-05,
+                    "tottime_per": 4.18525e-06,
+                    "cumtime": 0.000110512,
+                    "cumtime_per": 1.3814e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:187(_divide_by_count)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 6.0609e-05,
+                    "tottime_per": 2.0203e-06,
+                    "cumtime": 6.0609e-05,
+                    "cumtime_per": 2.0203e-06,
+                    "function_name": "~:0(<method 'reduce' of 'numpy.ufunc' objects>)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 3.0759e-05,
+                    "tottime_per": 1.9224375e-06,
+                    "cumtime": 6.052e-05,
+                    "cumtime_per": 3.7825e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:32(seterr)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 2.2263e-05,
+                    "tottime_per": 3.7105e-06,
+                    "cumtime": 4.4666e-05,
+                    "cumtime_per": 7.4443333333333334e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:68(_replace_nan)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 7.322e-06,
+                    "tottime_per": 9.1525e-07,
+                    "cumtime": 4.2050000000000006e-05,
+                    "cumtime_per": 5.256250000000001e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:429(__enter__)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.992e-06,
+                    "tottime_per": 9.96e-07,
+                    "cumtime": 3.1650000000000004e-05,
+                    "cumtime_per": 1.5825000000000002e-05,
+                    "function_name": "<__array_function__ internals>:177(nansum)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 9.266e-06,
+                    "tottime_per": 4.633e-06,
+                    "cumtime": 3.163e-05,
+                    "cumtime_per": 1.5815e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/warnings.py:130(filterwarnings)"
+                },
+                {
+                    "ncalls_recursion": "8",
+                    "ncalls": 8,
+                    "tottime": 5.81e-06,
+                    "tottime_per": 7.2625e-07,
+                    "cumtime": 3.1602e-05,
+                    "cumtime_per": 3.95025e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:434(__exit__)"
+                },
+                {
+                    "ncalls_recursion": "11",
+                    "ncalls": 11,
+                    "tottime": 1.1012e-05,
+                    "tottime_per": 1.001090909090909e-06,
+                    "cumtime": 3.0258e-05,
+                    "cumtime_per": 2.7507272727272727e-06,
+                    "function_name": "<__array_function__ internals>:177(copyto)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.9750000000000003e-06,
+                    "tottime_per": 1.4875000000000002e-06,
+                    "cumtime": 2.7767e-05,
+                    "cumtime_per": 1.38835e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:623(nansum)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.0880000000000003e-06,
+                    "tottime_per": 7.720000000000001e-07,
+                    "cumtime": 2.6138000000000003e-05,
+                    "cumtime_per": 6.534500000000001e-06,
+                    "function_name": "<__array_function__ internals>:177(any)"
+                },
+                {
+                    "ncalls_recursion": "16",
+                    "ncalls": 16,
+                    "tottime": 2.0663000000000002e-05,
+                    "tottime_per": 1.2914375000000001e-06,
+                    "cumtime": 2.2129e-05,
+                    "cumtime_per": 1.3830625e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/_ufunc_config.py:131(geterr)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.3370000000000004e-06,
+                    "tottime_per": 8.342500000000001e-07,
+                    "cumtime": 1.7519e-05,
+                    "cumtime_per": 4.37975e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:2307(any)"
+                },
+                {
+                    "ncalls_recursion": "30",
+                    "ncalls": 30,
+                    "tottime": 1.7455e-05,
+                    "tottime_per": 5.818333333333334e-07,
+                    "cumtime": 1.7455e-05,
+                    "cumtime_per": 5.818333333333334e-07,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/core/fromnumeric.py:70(<dictcomp>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 3.987e-06,
+                    "tottime_per": 9.9675e-07,
+                    "cumtime": 1.4520000000000002e-05,
+                    "cumtime_per": 3.6300000000000004e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:113(_copyto)"
+                }
+            ],
+            "stats": {
+                "min": 0.00030958099887357093,
+                "max": 0.0007310709988814779,
+                "mean": 0.0003401180150849632,
+                "stddev": 4.708116934893602e-05,
+                "rounds": 199,
+                "median": 0.0003265939994889777,
+                "iqr": 2.104024952132022e-05,
+                "q1": 0.00032020974958868464,
+                "q3": 0.00034124999911000486,
+                "iqr_outliers": 20,
+                "stddev_outliers": 12,
+                "outliers": "12;20",
+                "ld15iqr": 0.00030958099887357093,
+                "hd15iqr": 0.00037313299981178716,
+                "ops": 2940.155933081624,
+                "total": 0.06768348500190768,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sigma_clip_without_outliers",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTAverage::test_sigma_clip_without_outliers",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 7.287400000000001e-05,
+                    "tottime_per": 7.287400000000001e-05,
+                    "cumtime": 0.0012807690000000002,
+                    "cumtime_per": 0.0012807690000000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:301(lst_average)"
+                },
+                {
+                    "ncalls_recursion": "43/15",
+                    "ncalls": 43,
+                    "tottime": 4.3140000000000004e-05,
+                    "tottime_per": 2.876e-06,
+                    "cumtime": 0.0011400520000000001,
+                    "cumtime_per": 7.600346666666668e-05,
+                    "function_name": "~:0(<built-in method numpy.core._multiarray_umath.implement_array_function>)"
+                },
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 2.1831e-05,
+                    "tottime_per": 2.1831e-05,
+                    "cumtime": 0.00090505,
+                    "cumtime_per": 0.00090505,
+                    "function_name": "hera_cal/hera_cal/lstbin.py:1095(sigma_clip)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.066e-06,
+                    "tottime_per": 1.033e-06,
+                    "cumtime": 0.000859755,
+                    "cumtime_per": 0.0004298775,
+                    "function_name": "<__array_function__ internals>:177(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.918e-06,
+                    "tottime_per": 2.459e-06,
+                    "cumtime": 0.000855955,
+                    "cumtime_per": 0.0004279775,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1126(nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "4/2",
+                    "ncalls": 4,
+                    "tottime": 1.7074e-05,
+                    "tottime_per": 8.537e-06,
+                    "cumtime": 0.000850802,
+                    "cumtime_per": 0.000425401,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/function_base.py:3674(_ureduce)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.18e-06,
+                    "tottime_per": 1.59e-06,
+                    "cumtime": 0.0008314590000000001,
+                    "cumtime_per": 0.00041572950000000005,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1075(_nanmedian)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.2015000000000001e-05,
+                    "tottime_per": 6.0075000000000005e-06,
+                    "cumtime": 0.000828279,
+                    "cumtime_per": 0.0004141395,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1101(_nanmedian_small)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.724e-06,
+                    "tottime_per": 1.362e-06,
+                    "cumtime": 0.0007482550000000001,
+                    "cumtime_per": 0.00037412750000000004,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:660(median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.6772000000000005e-05,
+                    "tottime_per": 2.8386000000000002e-05,
+                    "cumtime": 0.0007279890000000001,
+                    "cumtime_per": 0.00036399450000000003,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/extras.py:743(_median)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 3.4660000000000004e-06,
+                    "tottime_per": 1.7330000000000002e-06,
+                    "cumtime": 0.00022585200000000002,
+                    "cumtime_per": 0.00011292600000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6936(sort)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 6.9520000000000005e-06,
+                    "tottime_per": 1.7380000000000001e-06,
+                    "cumtime": 0.000210136,
+                    "cumtime_per": 5.2534e-05,
+                    "function_name": "<__array_function__ internals>:177(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.5720000000000002e-05,
+                    "tottime_per": 7.860000000000001e-06,
+                    "cumtime": 0.00020444000000000001,
+                    "cumtime_per": 0.00010222000000000001,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/utils.py:1021(_median_nancheck)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 8.534e-06,
+                    "tottime_per": 2.1335e-06,
+                    "cumtime": 0.00019896100000000002,
+                    "cumtime_per": 4.9740250000000005e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/shape_base.py:56(take_along_axis)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 1.969e-06,
+                    "tottime_per": 9.845e-07,
+                    "cumtime": 0.00019470200000000002,
+                    "cumtime_per": 9.735100000000001e-05,
+                    "function_name": "<__array_function__ internals>:177(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.948e-06,
+                    "tottime_per": 2.474e-06,
+                    "cumtime": 0.00019087000000000002,
+                    "cumtime_per": 9.543500000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1777(nanstd)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 7.8706e-05,
+                    "tottime_per": 4.3725555555555555e-06,
+                    "cumtime": 0.00018864600000000002,
+                    "cumtime_per": 1.0480333333333335e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2972(__array_finalize__)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 5.095e-06,
+                    "tottime_per": 2.5475e-06,
+                    "cumtime": 0.00018855,
+                    "cumtime_per": 9.4275e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:5622(sort)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 2.358e-06,
+                    "tottime_per": 1.179e-06,
+                    "cumtime": 0.000185748,
+                    "cumtime_per": 9.2874e-05,
+                    "function_name": "<__array_function__ internals>:177(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 4.0466e-05,
+                    "tottime_per": 2.0233e-05,
+                    "cumtime": 0.00018104900000000002,
+                    "cumtime_per": 9.052450000000001e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1616(nanvar)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 7.4715e-05,
+                    "tottime_per": 1.2452500000000001e-05,
+                    "cumtime": 0.000169273,
+                    "cumtime_per": 2.8212166666666667e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:3211(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "48/46",
+                    "ncalls": 48,
+                    "tottime": 1.5004e-05,
+                    "tottime_per": 3.261739130434783e-07,
+                    "cumtime": 0.000139511,
+                    "cumtime_per": 3.032847826086957e-06,
+                    "function_name": "~:0(<method 'view' of 'numpy.ndarray' objects>)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 8.492000000000001e-06,
+                    "tottime_per": 2.1230000000000003e-06,
+                    "cumtime": 0.000106904,
+                    "cumtime_per": 2.6726e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:6816(__call__)"
+                },
+                {
+                    "ncalls_recursion": "14",
+                    "ncalls": 14,
+                    "tottime": 1.2419000000000001e-05,
+                    "tottime_per": 8.870714285714286e-07,
+                    "cumtime": 0.000106514,
+                    "cumtime_per": 7.608142857142857e-06,
+                    "function_name": "<__array_function__ internals>:177(sum)"
+                },
+                {
+                    "ncalls_recursion": "26",
+                    "ncalls": 26,
+                    "tottime": 7.3744e-05,
+                    "tottime_per": 2.8363076923076926e-06,
+                    "cumtime": 0.00010347700000000001,
+                    "cumtime_per": 3.979884615384616e-06,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/ma/core.py:2946(_update_from)"
+                }
+            ],
+            "stats": {
+                "min": 0.0006000069988658652,
+                "max": 0.0007627340019098483,
+                "mean": 0.0006523256537874636,
+                "stddev": 3.601154857991907e-05,
+                "rounds": 78,
+                "median": 0.0006480654992628843,
+                "iqr": 4.733400055556558e-05,
+                "q1": 0.0006219449969648849,
+                "q3": 0.0006692789975204505,
+                "iqr_outliers": 2,
+                "stddev_outliers": 23,
+                "outliers": "23;2",
+                "ld15iqr": 0.0006000069988658652,
+                "hd15iqr": 0.0007414380015688948,
+                "ops": 1532.976656971724,
+                "total": 0.050881400995422155,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy0-pols0-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy0-pols0-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy0-pols0-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.00013411100000000002,
+                    "tottime_per": 0.00013411100000000002,
+                    "cumtime": 1.522021945,
+                    "cumtime_per": 1.522021945,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000936114,
+                    "tottime_per": 0.000468057,
+                    "cumtime": 1.513447039,
+                    "cumtime_per": 0.7567235195,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.00252922,
+                    "tottime_per": 0.00042153666666666667,
+                    "cumtime": 1.2679090510000002,
+                    "cumtime_per": 0.2113181751666667,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0008919980000000001,
+                    "tottime_per": 2.4777722222222223e-05,
+                    "cumtime": 1.215357092,
+                    "cumtime_per": 0.033759919222222226,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.001004448,
+                    "tottime_per": 2.7901333333333333e-05,
+                    "cumtime": 1.142403405,
+                    "cumtime_per": 0.03173342791666667,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0009435540000000001,
+                    "tottime_per": 2.6209833333333334e-05,
+                    "cumtime": 1.1395801840000002,
+                    "cumtime_per": 0.03165500511111111,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002730101,
+                    "tottime_per": 6.8252525e-05,
+                    "cumtime": 1.0900357790000001,
+                    "cumtime_per": 0.027250894475000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 9.709700000000001e-05,
+                    "tottime_per": 2.4274250000000003e-06,
+                    "cumtime": 0.676828262,
+                    "cumtime_per": 0.01692070655,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0035750250000000003,
+                    "tottime_per": 8.937562500000001e-05,
+                    "cumtime": 0.6767094800000001,
+                    "cumtime_per": 0.016917737000000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000432495,
+                    "tottime_per": 2.40275e-05,
+                    "cumtime": 0.588090502,
+                    "cumtime_per": 0.032671694555555554,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "220253/172121",
+                    "ncalls": 220253,
+                    "tottime": 0.053492425,
+                    "tottime_per": 3.1078383811388504e-07,
+                    "cumtime": 0.48273138800000004,
+                    "cumtime_per": 2.8046048303228544e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.0035277760000000003,
+                    "tottime_per": 8.017672727272728e-05,
+                    "cumtime": 0.367056361,
+                    "cumtime_per": 0.008342190022727273,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.007087553000000001,
+                    "tottime_per": 0.000177188825,
+                    "cumtime": 0.239357075,
+                    "cumtime_per": 0.005983926875,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.025905107,
+                    "tottime_per": 1.6627154685494223e-05,
+                    "cumtime": 0.222420004,
+                    "cumtime_per": 0.0001427599512195122,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00024121500000000003,
+                    "tottime_per": 6.030375000000001e-05,
+                    "cumtime": 0.202593618,
+                    "cumtime_per": 0.0506484045,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.013301058000000001,
+                    "tottime_per": 5.720885161290323e-06,
+                    "cumtime": 0.197528272,
+                    "cumtime_per": 8.495839655913978e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.08347484100000001,
+                    "tottime_per": 2.8944119625520115e-05,
+                    "cumtime": 0.194611269,
+                    "cumtime_per": 6.747963557558945e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001050074,
+                    "tottime_per": 2.6251850000000002e-05,
+                    "cumtime": 0.180237798,
+                    "cumtime_per": 0.00450594495,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001191103,
+                    "tottime_per": 2.9777575e-05,
+                    "cumtime": 0.17374608500000002,
+                    "cumtime_per": 0.004343652125000001,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "15894",
+                    "ncalls": 15894,
+                    "tottime": 0.013748967,
+                    "tottime_per": 8.65041336353341e-07,
+                    "cumtime": 0.17343336,
+                    "cumtime_per": 1.091187617969045e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "223402/166698",
+                    "ncalls": 223402,
+                    "tottime": 0.12377887600000001,
+                    "tottime_per": 7.425336596719817e-07,
+                    "cumtime": 0.172352172,
+                    "cumtime_per": 1.0339186552928049e-06,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.083736896,
+                    "tottime_per": 1.9509994408201306e-05,
+                    "cumtime": 0.16965456,
+                    "cumtime_per": 3.9528089468779124e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.007434371,
+                    "tottime_per": 7.586092857142858e-05,
+                    "cumtime": 0.152929318,
+                    "cumtime_per": 0.0015605032448979593,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0017659280000000002,
+                    "tottime_per": 4.4148200000000005e-05,
+                    "cumtime": 0.148509245,
+                    "cumtime_per": 0.0037127311250000003,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.019296949,
+                    "tottime_per": 0.00048242372500000003,
+                    "cumtime": 0.143224067,
+                    "cumtime_per": 0.0035806016750000004,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/npyio.py:1720(genfromtxt)"
+                }
+            ],
+            "stats": {
+                "min": 0.8652414899988798,
+                "max": 0.8652414899988798,
+                "mean": 0.8652414899988798,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.8652414899988798,
+                "iqr": 0.0,
+                "q1": 0.8652414899988798,
+                "q3": 0.8652414899988798,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.8652414899988798,
+                "hd15iqr": 0.8652414899988798,
+                "ops": 1.1557467037338842,
+                "total": 0.8652414899988798,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy1-pols1-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy1-pols1-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy",
+                    "xy",
+                    "yx"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy1-pols1-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.00012219000000000002,
+                    "tottime_per": 0.00012219000000000002,
+                    "cumtime": 1.6467096250000002,
+                    "cumtime_per": 1.6467096250000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000892208,
+                    "tottime_per": 0.000446104,
+                    "cumtime": 1.638185357,
+                    "cumtime_per": 0.8190926785,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.003977709,
+                    "tottime_per": 0.0006629515,
+                    "cumtime": 1.400580906,
+                    "cumtime_per": 0.233430151,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001010031,
+                    "tottime_per": 2.8056416666666668e-05,
+                    "cumtime": 1.339118551,
+                    "cumtime_per": 0.03719773752777778,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.001250842,
+                    "tottime_per": 3.474561111111111e-05,
+                    "cumtime": 1.2459924150000001,
+                    "cumtime_per": 0.03461090041666667,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001228502,
+                    "tottime_per": 3.4125055555555554e-05,
+                    "cumtime": 1.2427572770000002,
+                    "cumtime_per": 0.034521035472222225,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0031096130000000002,
+                    "tottime_per": 7.7740325e-05,
+                    "cumtime": 1.181414392,
+                    "cumtime_per": 0.0295353598,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.000104988,
+                    "tottime_per": 2.6247e-06,
+                    "cumtime": 0.7342058340000001,
+                    "cumtime_per": 0.01835514585,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.004053955000000001,
+                    "tottime_per": 0.00010134887500000002,
+                    "cumtime": 0.734075495,
+                    "cumtime_per": 0.018351887375,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000488242,
+                    "tottime_per": 2.7124555555555555e-05,
+                    "cumtime": 0.640930073,
+                    "cumtime_per": 0.03560722627777778,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "222509/174377",
+                    "ncalls": 222509,
+                    "tottime": 0.056553014000000006,
+                    "tottime_per": 3.24314640118823e-07,
+                    "cumtime": 0.5187568290000001,
+                    "cumtime_per": 2.974915436095357e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.004160643,
+                    "tottime_per": 9.456006818181819e-05,
+                    "cumtime": 0.386336542,
+                    "cumtime_per": 0.008780375954545455,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.007242173,
+                    "tottime_per": 0.000181054325,
+                    "cumtime": 0.251309891,
+                    "cumtime_per": 0.006282747275,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.027941027,
+                    "tottime_per": 1.7933906931964058e-05,
+                    "cumtime": 0.24248675600000003,
+                    "cumtime_per": 0.00015563976636713737,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.014830803000000002,
+                    "tottime_per": 6.378840000000001e-06,
+                    "cumtime": 0.212411709,
+                    "cumtime_per": 9.135987483870968e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.090457169,
+                    "tottime_per": 3.1365176490984745e-05,
+                    "cumtime": 0.210328186,
+                    "cumtime_per": 7.29293294036061e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0013181830000000001,
+                    "tottime_per": 3.2954575e-05,
+                    "cumtime": 0.19150718700000002,
+                    "cumtime_per": 0.004787679675000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00021044500000000002,
+                    "tottime_per": 5.2611250000000006e-05,
+                    "cumtime": 0.190747582,
+                    "cumtime_per": 0.0476868955,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "231946/172986",
+                    "ncalls": 231946,
+                    "tottime": 0.137201813,
+                    "tottime_per": 7.931382481819338e-07,
+                    "cumtime": 0.18971369700000001,
+                    "cumtime_per": 1.09669971558392e-06,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "15894",
+                    "ncalls": 15894,
+                    "tottime": 0.014606549000000002,
+                    "tottime_per": 9.189976720775136e-07,
+                    "cumtime": 0.18428522400000003,
+                    "cumtime_per": 1.1594640996602493e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0013744830000000001,
+                    "tottime_per": 3.4362075000000006e-05,
+                    "cumtime": 0.184163611,
+                    "cumtime_per": 0.004604090275,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.088330025,
+                    "tottime_per": 2.0580154939422182e-05,
+                    "cumtime": 0.180722391,
+                    "cumtime_per": 4.210680125815471e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.008066234,
+                    "tottime_per": 8.230851020408163e-05,
+                    "cumtime": 0.165456651,
+                    "cumtime_per": 0.001688333173469388,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0017808840000000002,
+                    "tottime_per": 4.4522100000000005e-05,
+                    "cumtime": 0.156800973,
+                    "cumtime_per": 0.003920024325,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.020196969000000002,
+                    "tottime_per": 0.0005049242250000001,
+                    "cumtime": 0.151160226,
+                    "cumtime_per": 0.00377900565,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/npyio.py:1720(genfromtxt)"
+                }
+            ],
+            "stats": {
+                "min": 0.8134273210016545,
+                "max": 0.8134273210016545,
+                "mean": 0.8134273210016545,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.8134273210016545,
+                "iqr": 0.0,
+                "q1": 0.8134273210016545,
+                "q3": 0.8134273210016545,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.8134273210016545,
+                "hd15iqr": 0.8134273210016545,
+                "ops": 1.2293661328815462,
+                "total": 0.8134273210016545,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy2-pols2-freq_range2]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy2-pols2-freq_range2]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": [
+                    150000000.0,
+                    180000000.0
+                ]
+            },
+            "param": "0-True-0.0-flag_strategy2-pols2-freq_range2",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000156329,
+                    "tottime_per": 0.000156329,
+                    "cumtime": 1.686947648,
+                    "cumtime_per": 1.686947648,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0010547830000000001,
+                    "tottime_per": 0.0005273915000000001,
+                    "cumtime": 1.6783809680000001,
+                    "cumtime_per": 0.8391904840000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.002913843,
+                    "tottime_per": 0.0004856405,
+                    "cumtime": 1.419856389,
+                    "cumtime_per": 0.2366427315,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001036994,
+                    "tottime_per": 2.880538888888889e-05,
+                    "cumtime": 1.362884956,
+                    "cumtime_per": 0.037857915444444445,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.0011517880000000002,
+                    "tottime_per": 3.1994111111111115e-05,
+                    "cumtime": 1.285306309,
+                    "cumtime_per": 0.03570295302777778,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001093716,
+                    "tottime_per": 3.0381e-05,
+                    "cumtime": 1.28234168,
+                    "cumtime_per": 0.03562060222222222,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.00298964,
+                    "tottime_per": 7.4741e-05,
+                    "cumtime": 1.233218197,
+                    "cumtime_per": 0.030830454925,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 9.6205e-05,
+                    "tottime_per": 2.405125e-06,
+                    "cumtime": 0.743292075,
+                    "cumtime_per": 0.018582301875000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.004040976,
+                    "tottime_per": 0.0001010244,
+                    "cumtime": 0.7431718610000001,
+                    "cumtime_per": 0.018579296525000004,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000448524,
+                    "tottime_per": 2.4918e-05,
+                    "cumtime": 0.644613976,
+                    "cumtime_per": 0.03581188755555556,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "240863/187475",
+                    "ncalls": 240863,
+                    "tottime": 0.061210098000000004,
+                    "tottime_per": 3.2649738898519807e-07,
+                    "cumtime": 0.5500642490000001,
+                    "cumtime_per": 2.9340672036271505e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.004231964,
+                    "tottime_per": 9.6181e-05,
+                    "cumtime": 0.393940026,
+                    "cumtime_per": 0.00895318240909091,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.007232105000000001,
+                    "tottime_per": 0.00018080262500000003,
+                    "cumtime": 0.255019779,
+                    "cumtime_per": 0.006375494475,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.028551172000000003,
+                    "tottime_per": 1.8325527599486525e-05,
+                    "cumtime": 0.245264278,
+                    "cumtime_per": 0.00015742251476251606,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.014918295000000002,
+                    "tottime_per": 6.416470967741936e-06,
+                    "cumtime": 0.21919954700000002,
+                    "cumtime_per": 9.427937505376345e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.093733648,
+                    "tottime_per": 3.2501264909847435e-05,
+                    "cumtime": 0.21747285200000002,
+                    "cumtime_per": 7.540667545076284e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "17946",
+                    "ncalls": 17946,
+                    "tottime": 0.016891433,
+                    "tottime_per": 9.412366544076675e-07,
+                    "cumtime": 0.213100752,
+                    "cumtime_per": 1.1874554329655634e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.000297476,
+                    "tottime_per": 7.4369e-05,
+                    "cumtime": 0.20677394200000002,
+                    "cumtime_per": 0.051693485500000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "244714/182124",
+                    "ncalls": 244714,
+                    "tottime": 0.145261991,
+                    "tottime_per": 7.975993883288309e-07,
+                    "cumtime": 0.20306879500000002,
+                    "cumtime_per": 1.115002937559026e-06,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001229545,
+                    "tottime_per": 3.0738625e-05,
+                    "cumtime": 0.19497145600000002,
+                    "cumtime_per": 0.0048742864,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001324307,
+                    "tottime_per": 3.3107675e-05,
+                    "cumtime": 0.187499347,
+                    "cumtime_per": 0.0046874836750000004,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.088892936,
+                    "tottime_per": 2.071130848089469e-05,
+                    "cumtime": 0.181707199,
+                    "cumtime_per": 4.233625326188258e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.008010107,
+                    "tottime_per": 8.173578571428572e-05,
+                    "cumtime": 0.16251677,
+                    "cumtime_per": 0.0016583343877551021,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0018059010000000002,
+                    "tottime_per": 4.5147525e-05,
+                    "cumtime": 0.16023461800000002,
+                    "cumtime_per": 0.004005865450000001,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.020527842,
+                    "tottime_per": 0.0005131960500000001,
+                    "cumtime": 0.154686024,
+                    "cumtime_per": 0.0038671506,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/npyio.py:1720(genfromtxt)"
+                }
+            ],
+            "stats": {
+                "min": 0.9878508180008794,
+                "max": 0.9878508180008794,
+                "mean": 0.9878508180008794,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.9878508180008794,
+                "iqr": 0.0,
+                "q1": 0.9878508180008794,
+                "q3": 0.9878508180008794,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.9878508180008794,
+                "hd15iqr": 0.9878508180008794,
+                "ops": 1.01229859992798,
+                "total": 0.9878508180008794,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-0.0-flag_strategy3-pols3-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-0.0-flag_strategy3-pols3-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    2,
+                    1,
+                    3
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-0.0-flag_strategy3-pols3-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.00013352,
+                    "tottime_per": 0.00013352,
+                    "cumtime": 1.5850109510000001,
+                    "cumtime_per": 1.5850109510000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0009512190000000001,
+                    "tottime_per": 0.00047560950000000005,
+                    "cumtime": 1.5763776820000002,
+                    "cumtime_per": 0.7881888410000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.002743095,
+                    "tottime_per": 0.0004571825,
+                    "cumtime": 1.3347361610000001,
+                    "cumtime_per": 0.22245602683333335,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.000915924,
+                    "tottime_per": 2.5442333333333335e-05,
+                    "cumtime": 1.2793194970000001,
+                    "cumtime_per": 0.03553665269444445,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.001059519,
+                    "tottime_per": 2.9431083333333337e-05,
+                    "cumtime": 1.202001734,
+                    "cumtime_per": 0.033388937055555554,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0010257180000000001,
+                    "tottime_per": 2.849216666666667e-05,
+                    "cumtime": 1.199091012,
+                    "cumtime_per": 0.03330808366666667,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002852901,
+                    "tottime_per": 7.132252500000001e-05,
+                    "cumtime": 1.1461184960000002,
+                    "cumtime_per": 0.028652962400000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 9.592e-05,
+                    "tottime_per": 2.398e-06,
+                    "cumtime": 0.709348219,
+                    "cumtime_per": 0.017733705475,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0038788580000000002,
+                    "tottime_per": 9.697145000000001e-05,
+                    "cumtime": 0.7092292,
+                    "cumtime_per": 0.01773073,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000415128,
+                    "tottime_per": 2.306266666666667e-05,
+                    "cumtime": 0.6207368710000001,
+                    "cumtime_per": 0.03448538172222223,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "220253/172121",
+                    "ncalls": 220253,
+                    "tottime": 0.054970200000000004,
+                    "tottime_per": 3.193695133074988e-07,
+                    "cumtime": 0.506938766,
+                    "cumtime_per": 2.9452464603389476e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.0037360260000000004,
+                    "tottime_per": 8.490968181818183e-05,
+                    "cumtime": 0.381813663,
+                    "cumtime_per": 0.00867758325,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.007182766,
+                    "tottime_per": 0.00017956915,
+                    "cumtime": 0.24890101900000003,
+                    "cumtime_per": 0.006222525475000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.026978896000000002,
+                    "tottime_per": 1.731636456996149e-05,
+                    "cumtime": 0.235236036,
+                    "cumtime_per": 0.0001509859024390244,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.014506791000000002,
+                    "tottime_per": 6.2394800000000004e-06,
+                    "cumtime": 0.20750494700000002,
+                    "cumtime_per": 8.924943956989249e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.087715947,
+                    "tottime_per": 3.0414683425797505e-05,
+                    "cumtime": 0.20603336400000002,
+                    "cumtime_per": 7.144014008321776e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00020348800000000001,
+                    "tottime_per": 5.0872000000000004e-05,
+                    "cumtime": 0.19505666600000002,
+                    "cumtime_per": 0.048764166500000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.00111971,
+                    "tottime_per": 2.7992750000000004e-05,
+                    "cumtime": 0.18781128200000002,
+                    "cumtime_per": 0.004695282050000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0012272230000000002,
+                    "tottime_per": 3.0680575000000004e-05,
+                    "cumtime": 0.18076882100000002,
+                    "cumtime_per": 0.004519220525000001,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "223402/166698",
+                    "ncalls": 223402,
+                    "tottime": 0.13042757200000002,
+                    "tottime_per": 7.824183373525778e-07,
+                    "cumtime": 0.180439081,
+                    "cumtime_per": 1.0824309889740728e-06,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.086736353,
+                    "tottime_per": 2.0208842730661696e-05,
+                    "cumtime": 0.179780242,
+                    "cumtime_per": 4.188728844361603e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "15894",
+                    "ncalls": 15894,
+                    "tottime": 0.014298143000000001,
+                    "tottime_per": 8.995937460676986e-07,
+                    "cumtime": 0.17929730700000002,
+                    "cumtime_per": 1.1280817100792754e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.007818483000000001,
+                    "tottime_per": 7.978043877551021e-05,
+                    "cumtime": 0.15887489700000001,
+                    "cumtime_per": 0.001621172418367347,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001693749,
+                    "tottime_per": 4.2343725e-05,
+                    "cumtime": 0.154573849,
+                    "cumtime_per": 0.0038643462250000002,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.020043624000000003,
+                    "tottime_per": 0.0005010906,
+                    "cumtime": 0.149334974,
+                    "cumtime_per": 0.00373337435,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/npyio.py:1720(genfromtxt)"
+                }
+            ],
+            "stats": {
+                "min": 0.8208348049993219,
+                "max": 0.8208348049993219,
+                "mean": 0.8208348049993219,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.8208348049993219,
+                "iqr": 0.0,
+                "q1": 0.8208348049993219,
+                "q3": 0.8208348049993219,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.8208348049993219,
+                "hd15iqr": 0.8208348049993219,
+                "ops": 1.218271927444434,
+                "total": 0.8208348049993219,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-True-3.0-flag_strategy4-pols4-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-True-3.0-flag_strategy4-pols4-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": true,
+                "sigma_clip_thresh": 3.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-True-3.0-flag_strategy4-pols4-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000181296,
+                    "tottime_per": 0.000181296,
+                    "cumtime": 2.010415143,
+                    "cumtime_per": 2.010415143,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.001229417,
+                    "tottime_per": 0.0006147085,
+                    "cumtime": 2.002205425,
+                    "cumtime_per": 1.0011027125,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.0033986420000000003,
+                    "tottime_per": 0.0005664403333333334,
+                    "cumtime": 1.702014396,
+                    "cumtime_per": 0.283669066,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001266573,
+                    "tottime_per": 3.5182583333333334e-05,
+                    "cumtime": 1.632161862,
+                    "cumtime_per": 0.0453378295,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.001550437,
+                    "tottime_per": 4.3067694444444447e-05,
+                    "cumtime": 1.5395966120000002,
+                    "cumtime_per": 0.04276657255555556,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001933503,
+                    "tottime_per": 5.3708416666666666e-05,
+                    "cumtime": 1.535330792,
+                    "cumtime_per": 0.04264807755555556,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0041666540000000005,
+                    "tottime_per": 0.00010416635000000002,
+                    "cumtime": 1.4619712740000002,
+                    "cumtime_per": 0.036549281850000004,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.000159039,
+                    "tottime_per": 3.9759750000000005e-06,
+                    "cumtime": 0.914315246,
+                    "cumtime_per": 0.022857881150000002,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0050810410000000006,
+                    "tottime_per": 0.000127026025,
+                    "cumtime": 0.914128453,
+                    "cumtime_per": 0.022853211325,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000616764,
+                    "tottime_per": 3.4264666666666664e-05,
+                    "cumtime": 0.7935850980000001,
+                    "cumtime_per": 0.044088061000000005,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "223109/174977",
+                    "ncalls": 223109,
+                    "tottime": 0.066770259,
+                    "tottime_per": 3.815944895614852e-07,
+                    "cumtime": 0.624895992,
+                    "cumtime_per": 3.5713036113317753e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.005200878,
+                    "tottime_per": 0.00011820177272727273,
+                    "cumtime": 0.468828348,
+                    "cumtime_per": 0.010655189727272727,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.008776357,
+                    "tottime_per": 0.000219408925,
+                    "cumtime": 0.303203693,
+                    "cumtime_per": 0.007580092325,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.033373507000000004,
+                    "tottime_per": 2.142073620025674e-05,
+                    "cumtime": 0.295103771,
+                    "cumtime_per": 0.00018941191976893455,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.017997832000000002,
+                    "tottime_per": 7.74100301075269e-06,
+                    "cumtime": 0.270671859,
+                    "cumtime_per": 0.00011641800387096775,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.11336431200000001,
+                    "tottime_per": 3.9308013869625524e-05,
+                    "cumtime": 0.26144045800000004,
+                    "cumtime_per": 9.065203120665743e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0017323820000000002,
+                    "tottime_per": 4.3309550000000006e-05,
+                    "cumtime": 0.236854581,
+                    "cumtime_per": 0.005921364525,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001889868,
+                    "tottime_per": 4.72467e-05,
+                    "cumtime": 0.227391367,
+                    "cumtime_per": 0.005684784175000001,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00027519,
+                    "tottime_per": 6.87975e-05,
+                    "cumtime": 0.22560162500000003,
+                    "cumtime_per": 0.05640040625000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "223402/166698",
+                    "ncalls": 223402,
+                    "tottime": 0.156868781,
+                    "tottime_per": 9.410357712750004e-07,
+                    "cumtime": 0.220316313,
+                    "cumtime_per": 1.3216494079113127e-06,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "15894",
+                    "ncalls": 15894,
+                    "tottime": 0.017267078,
+                    "tottime_per": 1.0863897068076004e-06,
+                    "cumtime": 0.219517807,
+                    "cumtime_per": 1.3811363218824714e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.106007368,
+                    "tottime_per": 2.4698827586206897e-05,
+                    "cumtime": 0.215158638,
+                    "cumtime_per": 5.013015796831314e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.009861636,
+                    "tottime_per": 0.00010062893877551021,
+                    "cumtime": 0.19300708000000003,
+                    "cumtime_per": 0.00196946,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002435749,
+                    "tottime_per": 6.0893725000000005e-05,
+                    "cumtime": 0.19154244,
+                    "cumtime_per": 0.004788561,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.001020155,
+                    "tottime_per": 2.833763888888889e-05,
+                    "cumtime": 0.187677649,
+                    "cumtime_per": 0.0052132680277777775,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:692(check_lsts_against_times)"
+                }
+            ],
+            "stats": {
+                "min": 0.8421060729997407,
+                "max": 0.8421060729997407,
+                "mean": 0.8421060729997407,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.8421060729997407,
+                "iqr": 0.0,
+                "q1": 0.8421060729997407,
+                "q3": 0.8421060729997407,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.8421060729997407,
+                "hd15iqr": 0.8421060729997407,
+                "ops": 1.1874988579975576,
+                "total": 0.8421060729997407,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[0-False-0.0-flag_strategy5-pols5-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[0-False-0.0-flag_strategy5-pols5-None]",
+            "params": {
+                "random_ants_to_drop": 0,
+                "rephase": false,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "0-False-0.0-flag_strategy5-pols5-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.000128336,
+                    "tottime_per": 0.000128336,
+                    "cumtime": 1.3923888070000001,
+                    "cumtime_per": 1.3923888070000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.0007943490000000001,
+                    "tottime_per": 0.00039717450000000004,
+                    "cumtime": 1.3845807490000002,
+                    "cumtime_per": 0.6922903745000001,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "6",
+                    "ncalls": 6,
+                    "tottime": 0.002185288,
+                    "tottime_per": 0.00036421466666666666,
+                    "cumtime": 1.168102615,
+                    "cumtime_per": 0.19468376916666666,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0007916030000000001,
+                    "tottime_per": 2.1988972222222223e-05,
+                    "cumtime": 1.1219330170000001,
+                    "cumtime_per": 0.031164806027777783,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "54/36",
+                    "ncalls": 54,
+                    "tottime": 0.0009380930000000001,
+                    "tottime_per": 2.605813888888889e-05,
+                    "cumtime": 1.053651252,
+                    "cumtime_per": 0.029268090333333337,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "36",
+                    "ncalls": 36,
+                    "tottime": 0.0008031830000000001,
+                    "tottime_per": 2.231063888888889e-05,
+                    "cumtime": 1.051226958,
+                    "cumtime_per": 0.02920074883333333,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.002287412,
+                    "tottime_per": 5.7185299999999996e-05,
+                    "cumtime": 1.005658009,
+                    "cumtime_per": 0.025141450225,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 8.282000000000001e-05,
+                    "tottime_per": 2.0705000000000003e-06,
+                    "cumtime": 0.616641356,
+                    "cumtime_per": 0.0154160339,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.00326003,
+                    "tottime_per": 8.150075e-05,
+                    "cumtime": 0.6165374720000001,
+                    "cumtime_per": 0.015413436800000003,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "18",
+                    "ncalls": 18,
+                    "tottime": 0.000369792,
+                    "tottime_per": 2.0544000000000002e-05,
+                    "cumtime": 0.542580198,
+                    "cumtime_per": 0.030143344333333336,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "220253/172121",
+                    "ncalls": 220253,
+                    "tottime": 0.050219152,
+                    "tottime_per": 2.9176655957146426e-07,
+                    "cumtime": 0.446805043,
+                    "cumtime_per": 2.5958775686871444e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "44",
+                    "ncalls": 44,
+                    "tottime": 0.00307703,
+                    "tottime_per": 6.99325e-05,
+                    "cumtime": 0.34189769200000003,
+                    "cumtime_per": 0.007770402090909092,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.0065320510000000005,
+                    "tottime_per": 0.000163301275,
+                    "cumtime": 0.222827785,
+                    "cumtime_per": 0.005570694625,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1558",
+                    "ncalls": 1558,
+                    "tottime": 0.023672689,
+                    "tottime_per": 1.5194280487804878e-05,
+                    "cumtime": 0.20250319900000002,
+                    "cumtime_per": 0.00012997637933247756,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "2884",
+                    "ncalls": 2884,
+                    "tottime": 0.07523843200000001,
+                    "tottime_per": 2.6088221914008323e-05,
+                    "cumtime": 0.178336251,
+                    "cumtime_per": 6.183642545076283e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "5237/2325",
+                    "ncalls": 5237,
+                    "tottime": 0.012310270000000002,
+                    "tottime_per": 5.294739784946237e-06,
+                    "cumtime": 0.177934994,
+                    "cumtime_per": 7.653118021505377e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00015808600000000002,
+                    "tottime_per": 3.9521500000000004e-05,
+                    "cumtime": 0.17710461000000002,
+                    "cumtime_per": 0.044276152500000006,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.000900382,
+                    "tottime_per": 2.2509550000000002e-05,
+                    "cumtime": 0.16672471700000002,
+                    "cumtime_per": 0.004168117925000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "223402/166698",
+                    "ncalls": 223402,
+                    "tottime": 0.115985184,
+                    "tottime_per": 6.957802973041068e-07,
+                    "cumtime": 0.16111008400000001,
+                    "cumtime_per": 9.66478805984475e-07,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "15894",
+                    "ncalls": 15894,
+                    "tottime": 0.01299603,
+                    "tottime_per": 8.176689316723292e-07,
+                    "cumtime": 0.160724904,
+                    "cumtime_per": 1.0112300490751226e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001008393,
+                    "tottime_per": 2.5209825e-05,
+                    "cumtime": 0.160680122,
+                    "cumtime_per": 0.0040170030500000006,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "76740/4292",
+                    "ncalls": 76740,
+                    "tottime": 0.080023966,
+                    "tottime_per": 1.8644912861137e-05,
+                    "cumtime": 0.160429972,
+                    "cumtime_per": 3.737883783783784e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "98",
+                    "ncalls": 98,
+                    "tottime": 0.006679272,
+                    "tottime_per": 6.815583673469388e-05,
+                    "cumtime": 0.14027339700000002,
+                    "cumtime_per": 0.0014313611938775513,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.001459481,
+                    "tottime_per": 3.6487025e-05,
+                    "cumtime": 0.13795679400000002,
+                    "cumtime_per": 0.0034489198500000004,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                },
+                {
+                    "ncalls_recursion": "40",
+                    "ncalls": 40,
+                    "tottime": 0.017495973,
+                    "tottime_per": 0.00043739932500000005,
+                    "cumtime": 0.13342595000000002,
+                    "cumtime_per": 0.0033356487500000006,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/numpy/lib/npyio.py:1720(genfromtxt)"
+                }
+            ],
+            "stats": {
+                "min": 0.8071211950009456,
+                "max": 0.8071211950009456,
+                "mean": 0.8071211950009456,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.8071211950009456,
+                "iqr": 0.0,
+                "q1": 0.8071211950009456,
+                "q3": 0.8071211950009456,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.8071211950009456,
+                "hd15iqr": 0.8071211950009456,
+                "ops": 1.2389713046735547,
+                "total": 0.8071211950009456,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_nontrivial_cal[3-True-0.0-flag_strategy6-pols6-None]",
+            "fullname": "hera_cal/tests/test_lstbin_simple.py::Test_LSTBinFiles::test_nontrivial_cal[3-True-0.0-flag_strategy6-pols6-None]",
+            "params": {
+                "random_ants_to_drop": 3,
+                "rephase": true,
+                "sigma_clip_thresh": 0.0,
+                "flag_strategy": [
+                    0,
+                    0,
+                    0
+                ],
+                "pols": [
+                    "xx",
+                    "yy"
+                ],
+                "freq_range": null
+            },
+            "param": "3-True-0.0-flag_strategy6-pols6-None",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 1,
+                "max_time": 0.1,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "cprofile": [
+                {
+                    "ncalls_recursion": "1",
+                    "ncalls": 1,
+                    "tottime": 0.00010204,
+                    "tottime_per": 0.00010204,
+                    "cumtime": 0.999450457,
+                    "cumtime_per": 0.999450457,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1056(lst_bin_files)"
+                },
+                {
+                    "ncalls_recursion": "2",
+                    "ncalls": 2,
+                    "tottime": 0.000626171,
+                    "tottime_per": 0.0003130855,
+                    "cumtime": 0.9917842210000001,
+                    "cumtime_per": 0.49589211050000004,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:784(lst_bin_files_single_outfile)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.001523519,
+                    "tottime_per": 0.00038087975,
+                    "cumtime": 0.7849457670000001,
+                    "cumtime_per": 0.19623644175000002,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:401(lst_bin_files_for_baselines)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 0.000542962,
+                    "tottime_per": 2.2623416666666668e-05,
+                    "cumtime": 0.752038194,
+                    "cumtime_per": 0.03133492475,
+                    "function_name": "hera_cal/hera_cal/io.py:737(read)"
+                },
+                {
+                    "ncalls_recursion": "36/24",
+                    "ncalls": 36,
+                    "tottime": 0.000654591,
+                    "tottime_per": 2.7274625000000003e-05,
+                    "cumtime": 0.720999614,
+                    "cumtime_per": 0.030041650583333333,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12281(read)"
+                },
+                {
+                    "ncalls_recursion": "24",
+                    "ncalls": 24,
+                    "tottime": 0.00066467,
+                    "tottime_per": 2.7694583333333334e-05,
+                    "cumtime": 0.719255022,
+                    "cumtime_per": 0.02996895925,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:12022(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.001621604,
+                    "tottime_per": 5.791442857142857e-05,
+                    "cumtime": 0.7003339970000001,
+                    "cumtime_per": 0.025011928464285717,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1354(read_uvh5)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 7.095300000000001e-05,
+                    "tottime_per": 2.5340357142857148e-06,
+                    "cumtime": 0.43562959500000004,
+                    "cumtime_per": 0.015558199821428573,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:1015(_read_header)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.002295746,
+                    "tottime_per": 8.199092857142858e-05,
+                    "cumtime": 0.43554350700000005,
+                    "cumtime_per": 0.015555125250000001,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:854(_read_header_with_fast_meta)"
+                },
+                {
+                    "ncalls_recursion": "12",
+                    "ncalls": 12,
+                    "tottime": 0.000246939,
+                    "tottime_per": 2.057825e-05,
+                    "cumtime": 0.367022862,
+                    "cumtime_per": 0.0305852385,
+                    "function_name": "hera_cal/hera_cal/io.py:518(__init__)"
+                },
+                {
+                    "ncalls_recursion": "152979/118845",
+                    "ncalls": 152979,
+                    "tottime": 0.034845574000000004,
+                    "tottime_per": 2.9320185115065846e-07,
+                    "cumtime": 0.314749806,
+                    "cumtime_per": 2.648405957339392e-06,
+                    "function_name": "~:0(<built-in method builtins.getattr>)"
+                },
+                {
+                    "ncalls_recursion": "32",
+                    "ncalls": 32,
+                    "tottime": 0.002297326,
+                    "tottime_per": 7.17914375e-05,
+                    "cumtime": 0.245494025,
+                    "cumtime_per": 0.00767168828125,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3214(check)"
+                },
+                {
+                    "ncalls_recursion": "4",
+                    "ncalls": 4,
+                    "tottime": 0.00015837500000000001,
+                    "tottime_per": 3.9593750000000004e-05,
+                    "cumtime": 0.176144724,
+                    "cumtime_per": 0.044036181,
+                    "function_name": "hera_cal/hera_cal/lstbin_simple.py:1354(create_lstbin_output_file)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.004653148,
+                    "tottime_per": 0.00016618385714285716,
+                    "cumtime": 0.159593578,
+                    "cumtime_per": 0.005699770642857143,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:3541(copy)"
+                },
+                {
+                    "ncalls_recursion": "1078",
+                    "ncalls": 1078,
+                    "tottime": 0.016813420000000003,
+                    "tottime_per": 1.5596864564007423e-05,
+                    "cumtime": 0.14315742,
+                    "cumtime_per": 0.00013279909090909092,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvh5.py:438(__getattr__)"
+                },
+                {
+                    "ncalls_recursion": "3635/1601",
+                    "ncalls": 3635,
+                    "tottime": 0.008781451000000001,
+                    "tottime_per": 5.484978763272955e-06,
+                    "cumtime": 0.129143118,
+                    "cumtime_per": 8.066403372891942e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/functools.py:961(__get__)"
+                },
+                {
+                    "ncalls_recursion": "2004",
+                    "ncalls": 2004,
+                    "tottime": 0.05367347,
+                    "tottime_per": 2.678316866267465e-05,
+                    "cumtime": 0.127749684,
+                    "cumtime_per": 6.374734730538923e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/site-packages/h5py/_hl/group.py:296(__getitem__)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.0006567280000000001,
+                    "tottime_per": 2.3454571428571432e-05,
+                    "cumtime": 0.11765741,
+                    "cumtime_per": 0.0042020503571428575,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2375(set_telescope_params)"
+                },
+                {
+                    "ncalls_recursion": "11160",
+                    "ncalls": 11160,
+                    "tottime": 0.009335136,
+                    "tottime_per": 8.364817204301076e-07,
+                    "cumtime": 0.115162281,
+                    "cumtime_per": 1.0319200806451613e-05,
+                    "function_name": "pyuvdata/pyuvdata/uvbase.py:315(__iter__)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.000755635,
+                    "tottime_per": 2.698696428571429e-05,
+                    "cumtime": 0.11337644100000001,
+                    "cumtime_per": 0.0040491586071428574,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:222(get_telescope)"
+                },
+                {
+                    "ncalls_recursion": "151984/113652",
+                    "ncalls": 151984,
+                    "tottime": 0.08022195700000001,
+                    "tottime_per": 7.058560958012179e-07,
+                    "cumtime": 0.111560591,
+                    "cumtime_per": 9.815981328969133e-07,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:2227(__getattribute__)"
+                },
+                {
+                    "ncalls_recursion": "50916/3032",
+                    "ncalls": 50916,
+                    "tottime": 0.053393638,
+                    "tottime_per": 1.7610038918205805e-05,
+                    "cumtime": 0.107684624,
+                    "cumtime_per": 3.5516036939313984e-05,
+                    "function_name": "/home/steven/miniconda3/envs/hera/lib/python3.10/copy.py:128(deepcopy)"
+                },
+                {
+                    "ncalls_recursion": "68",
+                    "ncalls": 68,
+                    "tottime": 0.004978846,
+                    "tottime_per": 7.321832352941177e-05,
+                    "cumtime": 0.101122107,
+                    "cumtime_per": 0.0014870898088235295,
+                    "function_name": "pyuvdata/pyuvdata/uvdata/uvdata.py:126(__init__)"
+                },
+                {
+                    "ncalls_recursion": "32",
+                    "ncalls": 32,
+                    "tottime": 0.0009990090000000001,
+                    "tottime_per": 3.1219031250000004e-05,
+                    "cumtime": 0.099164506,
+                    "cumtime_per": 0.0030988908125,
+                    "function_name": "pyuvdata/pyuvdata/utils.py:3777(get_lst_for_time)"
+                },
+                {
+                    "ncalls_recursion": "28",
+                    "ncalls": 28,
+                    "tottime": 0.001045778,
+                    "tottime_per": 3.7349214285714286e-05,
+                    "cumtime": 0.097144719,
+                    "cumtime_per": 0.00346945425,
+                    "function_name": "pyuvdata/pyuvdata/telescopes.py:183(_parse_antpos_file)"
+                }
+            ],
+            "stats": {
+                "min": 0.517690650998702,
+                "max": 0.517690650998702,
+                "mean": 0.517690650998702,
+                "stddev": 0,
+                "rounds": 1,
+                "median": 0.517690650998702,
+                "iqr": 0.0,
+                "q1": 0.517690650998702,
+                "q3": 0.517690650998702,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.517690650998702,
+                "hd15iqr": 0.517690650998702,
+                "ops": 1.9316555129416606,
+                "total": 0.517690650998702,
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2023-05-10T22:20:18.602451",
+    "version": "4.0.0"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,10 @@ jobs:
       - name: Install
         run: |
           pip install .[dev]
-          pip install git+https://github.com/hera-team/hera_filters  # temporary until hera-filters is released
 
       - name: Run Tests
         run: |
-          pytest -s -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15 hera_cal/tests/test_chunker.py::test_chunk_data_files
+          pytest -s hera_cal/tests/test_chunker.py::test_chunk_data_files
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest -s hera_cal/tests/test_chunker.py::test_chunk_data_files
+          pytest -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15
+          pytest -s -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15 hera_cal/tests/test_chunker::test_chunk_data_files
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          pytest -s -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15 hera_cal/tests/test_chunker::test_chunk_data_files
+          pytest -s -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15 hera_cal/tests/test_chunker.py::test_chunk_data_files
 
       - name: Upload Coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && success()

--- a/hera_cal/chunker.py
+++ b/hera_cal/chunker.py
@@ -69,8 +69,12 @@ def chunk_files(filenames, inputfile, outputfile, chunk_size, type="data",
                 polarizations = chunked_files.pols
         if spw_range is None:
             spw_range = (0, chunked_files.Nfreqs)
-        data, flags, nsamples = chunked_files.read(polarizations=polarizations,
-                                                   freq_chans=range(spw_range[0], spw_range[1]), **read_kwargs)
+        chunked_files.read(
+            polarizations=polarizations,
+            freq_chans=range(spw_range[0], spw_range[1]), 
+            **read_kwargs
+        )
+        print(chunked_files.data_array.shape, chunked_files.future_array_shapes)
     elif type == 'gains':
         chunked_files.read()
         if polarizations is None:

--- a/hera_cal/chunker.py
+++ b/hera_cal/chunker.py
@@ -60,7 +60,7 @@ def chunk_files(filenames, inputfile, outputfile, chunk_size, type="data",
         chunked_files = io.HERACal(filenames[start:end])
     else:
         raise ValueError("Invalid type provided. Must be in ['data', 'gains']")
-    read_args = {}
+    
     if type == 'data':
         if polarizations is None:
             if len(chunked_files.filepaths) > 1:
@@ -74,7 +74,6 @@ def chunk_files(filenames, inputfile, outputfile, chunk_size, type="data",
             freq_chans=range(spw_range[0], spw_range[1]), 
             **read_kwargs
         )
-        print(chunked_files.data_array.shape, chunked_files.future_array_shapes)
     elif type == 'gains':
         chunked_files.read()
         if polarizations is None:

--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -888,17 +888,20 @@ class CalibrationSmoother():
         '''
         all_time_indices = np.array([i for indices in self.time_indices.values() for i in indices])
         assert len(all_time_indices) == len(np.unique(all_time_indices)), \
-            'Multiple calibration integrations map to the same time index.'
+                'Multiple calibration integrations map to the same time index.'
         for cal in self.cals:
-            assert np.all(np.abs(self.cal_freqs[cal] - self.freqs) < 1e-4), \
-                '{} and {} have different frequencies.'.format(cal, self.cals[0])
+            assert np.all(
+                np.abs(self.cal_freqs[cal] - self.freqs) < 1e-4
+            ), f'{cal} and {self.cals[0]} have different frequencies.'
         if len(self.flag_files) > 0:
             all_flag_time_indices = np.array([i for indices in self.flag_time_indices.values() for i in indices])
-            assert np.all(np.unique(all_flag_time_indices) == np.unique(all_time_indices)), \
-                'The number of unique indices for the flag files does not match the calibration files.'
+            unq_flag = np.unique(all_flag_time_indices)
+            unq_time = np.unique(all_time_indices)
+            assert len(unq_flag) == len(unq_time) and np.all(unq_flag == unq_time), \
+                    'The number of unique indices for the flag files does not match the calibration files.'
             for ff in self.flag_files:
                 assert np.all(np.abs(self.flag_freqs[ff] - self.freqs) < 1e-4), \
-                    '{} and {} have different frequencies.'.format(ff, self.cals[0])
+                        '{} and {} have different frequencies.'.format(ff, self.cals[0])
 
     def rephase_to_refant(self, warn=True, propagate_refant_flags=False):
         '''If the CalibrationSmoother object has a refant attribute, this function rephases the

--- a/hera_cal/tests/test_chunker.py
+++ b/hera_cal/tests/test_chunker.py
@@ -56,10 +56,10 @@ def test_chunk_data_files(tmpdir):
     # load in chunks
     chunks = sorted(glob.glob(tmp_path + '/chunk.*.uvh5'))
     uvd = UVData()
-    uvd.read(chunks)
+    uvd.read(chunks, use_future_array_shapes=True)
     # load in original file
     uvdo = UVData()
-    uvdo.read(data_files)
+    uvdo.read(data_files, use_future_array_shapes=True)
     apply_yaml_flags(uvdo, DATA_PATH + '/test_input/a_priori_flags_sample_noflags.yaml', throw_away_flagged_ants=True,
                      flag_freqs=False, flag_times=False, ant_indices_only=True)
     assert np.all(np.isclose(uvdo.data_array, uvd.data_array))

--- a/hera_cal/tests/test_chunker.py
+++ b/hera_cal/tests/test_chunker.py
@@ -36,6 +36,7 @@ def test_chunk_data_files(tmpdir):
     uvdo.read(data_files, freq_chans=range(32))
     apply_yaml_flags(uvdo, DATA_PATH + '/test_input/a_priori_flags_sample_noflags.yaml', throw_away_flagged_ants=True,
                      flag_freqs=False, flag_times=False, ant_indices_only=True)
+    print(uvdo.data_array.shape, uvd.data_array.shape)
     assert np.all(np.isclose(uvdo.data_array, uvd.data_array))
     assert np.all(np.isclose(uvdo.flag_array, uvd.flag_array))
     assert np.all(np.isclose(uvdo.nsample_array, uvd.nsample_array))

--- a/hera_cal/tests/test_chunker.py
+++ b/hera_cal/tests/test_chunker.py
@@ -31,22 +31,15 @@ def test_chunk_data_files(tmpdir):
     # to original combined list of files.
     # load in chunks
     chunks = sorted(glob.glob(f'{tmp_path}/chunk.*.uvh5'))
-    meta = FastUVH5Meta(chunks[0])
-    print(meta.datagrp['visdata'].shape)
-    meta.close()
     uvd = UVData()
-    uvd.read(chunks)
+    uvd.read(chunks, use_future_array_shapes=True)
     # load in original file
-    uvdx = UVData()
-    uvdx.read(data_files)
-    print("WITHOUTH FREQ CHAN SELECT: ", uvdx.data_array.shape)
     uvdo = UVData()
-    uvdo.read(data_files, freq_chans=range(32))
-    print("BEFORE APPLYING YAML FLAGS: ", uvdo.data_array.shape, uvd.data_array.shape)
+    uvdo.read(data_files, freq_chans=range(32), use_future_array_shapes=True)
+    # apply_yaml_flags always makes the uvdo object use future_array_shapes!
     apply_yaml_flags(uvdo, f'{DATA_PATH}/test_input/a_priori_flags_sample_noflags.yaml', 
                      throw_away_flagged_ants=True,
                      flag_freqs=False, flag_times=False, ant_indices_only=True)
-    print("AFTER YAML FLAGS: ", uvdo.data_array.shape, uvd.data_array.shape)
     assert np.all(np.isclose(uvdo.data_array, uvd.data_array))
     assert np.all(np.isclose(uvdo.flag_array, uvd.flag_array))
     assert np.all(np.isclose(uvdo.nsample_array, uvd.nsample_array))

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_args = {
         'linsolve',
         'hera_qm',
         'scikit-learn',
-        'hera_filters',
+        'hera-filters',
         "line_profiler",
         'aipy',
         "rich",


### PR DESCRIPTION
Attempt to fix the problem with a huge memory allocation in the dta chunker