### PR TITLE
feat: add inpaint-mode for lst binner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -40,7 +40,12 @@ jobs:
         run: |
           pytest -n auto --pyargs hera_cal --cov=hera_cal --cov-config=./.coveragerc --cov-report xml:./coverage.xml --durations=15
 
-      - name: Upload Coverage (Ubuntu)
+      - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && success()
-        run: |
-          bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3.1.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -12,6 +12,7 @@ from typing import Sequence
 from .utils import conj_pol, comply_pol, make_bl, comply_bl, reverse_bl
 from .red_groups import RedundantGroups, Baseline, AntPair
 
+
 class DataContainer:
     """Dictionary-like object that abstracts away the pol/ant pair ordering of data
     dictionaries and the the polarization case (i.e. 'nn' vs. 'NN'). Keys are in
@@ -70,8 +71,7 @@ class DataContainer:
                     setattr(self, attr, getattr(data, attr))
                 else:
                     setattr(self, attr, None)
-        
-        
+
     @property
     def dtype(self):
         """The dtype of the underlying data."""
@@ -82,7 +82,6 @@ class DataContainer:
                 return None
         else:
             return None
-
 
     def antpairs(self, pol=None):
         '''Return a set of antenna pairs (with a specific pol or more generally).'''
@@ -187,7 +186,7 @@ class DataContainer:
     @property
     def shape(self) -> tuple[int]:
         return self[next(iter(self.keys()))].shape
-        
+
     def concatenate(self, D, axis=0):
         '''Concatenates D, a DataContainer or a list of DCs, with self along an axis'''
         # check type of D
@@ -517,14 +516,14 @@ class DataContainer:
             return dc
 
     def select_freqs(
-        self, 
-        freqs: np.ndarray | None = None, 
-        channels: np.ndarray | slice | None = None, 
-        in_place: bool=True
+        self,
+        freqs: np.ndarray | None = None,
+        channels: np.ndarray | slice | None = None,
+        in_place: bool = True
     ):
         """Update the object with a subset of frequencies (which may be repeated).
-        
-        While typically this will be used to down-select frequencies, one can 
+
+        While typically this will be used to down-select frequencies, one can
         'expand' the frequencies by duplicating channels.
 
         Parameters
@@ -532,7 +531,7 @@ class DataContainer:
         freqs : np.ndarray, optional
             Frequencies to select. If given, all frequencies must be in the datacontainer.
         channels : np.ndarray, slice, optional
-            Channels to select. If given, all channels must be in the datacontainer. 
+            Channels to select. If given, all channels must be in the datacontainer.
             Only one of freqs or channels can be given.
         in_place : bool, optional
             If True, modify the object in place. Otherwise, return a modified copy.
@@ -548,12 +547,15 @@ class DataContainer:
             return obj
         elif freqs is not None and channels is not None:
             raise ValueError('Cannot specify both freqs and channels.')
-        
+
         if freqs is not None:
+            if obj.freqs is None:
+                raise ValueError('Cannot select frequencies if self.freqs is None.')
+
             if not np.all([fq in obj.freqs for fq in freqs]):
                 raise ValueError('All freqs must be in self.freqs.')
             channels = np.searchsorted(obj.freqs, freqs)
-        
+
         if obj.freqs is None:
             warnings.warn("It is impossible to automatically detect which axis is frequency. Trying last axis.")
             axis = -1
@@ -563,21 +565,23 @@ class DataContainer:
             obj[bl] = obj[bl].take(channels, axis=axis)
 
         # update metadata
-        obj.freqs = obj.freqs[channels]
+        if obj.freqs is not None:
+            obj.freqs = obj.freqs[channels]
 
         return obj
+
 
 class RedDataContainer(DataContainer):
     '''Structure for containing redundant visibilities that can be accessed by any
         one of the redundant baseline keys (or their conjugate).'''
 
     def __init__(
-            self, 
-            data: DataContainer | dict[Baseline, np.ndarray], 
-            reds: RedundantGroups | Sequence[Sequence[Baseline | AntPair]] | None=None, 
-            antpos: dict[int, np.ndarray] | None=None, 
-            bl_error_tol: float=1.0
-        ):
+        self,
+        data: DataContainer | dict[Baseline, np.ndarray],
+        reds: RedundantGroups | Sequence[Sequence[Baseline | AntPair]] | None = None,
+        antpos: dict[int, np.ndarray] | None = None,
+        bl_error_tol: float = 1.0
+    ):
         '''Creates a RedDataContainer.
 
         Parameters
@@ -585,7 +589,7 @@ class RedDataContainer(DataContainer):
         data : DataContainer or dictionary of visibilities, just as one would pass into DataContainer().
             Will error if multiple baselines are part of the same redundant group.
         reds : :class:`RedundantGroups` object, or list of lists of redundant baseline tuples, e.g. (ind1, ind2, pol).
-            These are the redundant groups of baselines. If not provided, will try to 
+            These are the redundant groups of baselines. If not provided, will try to
             infer them from antpos.
         antpos: dictionary of antenna positions in the form {ant_index: np.array([x, y, z])}.
             Will error if one tries to provide both reds and antpos. If neither is provided,
@@ -597,10 +601,10 @@ class RedDataContainer(DataContainer):
 
         Attributes
         ----------
-        reds 
-            A :class:`RedundantGroups` object that contains the redundant groups for 
-            the entire array, and methods to manipulate them. 
-            
+        reds
+            A :class:`RedundantGroups` object that contains the redundant groups for
+            the entire array, and methods to manipulate them.
+
         '''
         if reds is not None and antpos is not None:
             raise ValueError('Can only provide reds or antpos, not both.')
@@ -620,12 +624,11 @@ class RedDataContainer(DataContainer):
                 )
             else:
                 raise ValueError('Must provide reds, antpos, or have antpos available at data.antpos')
-        
+
         if not isinstance(reds, RedundantGroups):
             reds = RedundantGroups(red_list=reds, antpos=self.antpos)
 
         self.build_red_keys(reds)
-
 
     def build_red_keys(self, reds: RedundantGroups | list[list[Baseline]]):
         '''Build the dictionaries that map baselines to redundant keys.
@@ -633,12 +636,12 @@ class RedDataContainer(DataContainer):
         Arguments:
             reds: list of lists of redundant baseline tuples, e.g. (ind1, ind2, pol).
         '''
-        
+
         if isinstance(reds, RedundantGroups):
             self.reds = reds
         else:
             self.reds = RedundantGroups(red_list=reds, antpos=getattr(self, 'antpos', None))
-                
+
         self._reds_keyed_on_data = self.reds.keyed_on_bls(bls=self.bls())
 
         # delete unused data to avoid leaking memory
@@ -652,24 +655,23 @@ class RedDataContainer(DataContainer):
                 raise ValueError(
                     'RedDataContainer can only be constructed with (at most) one baseline per group, '
                     f'but {bl} is redundant with {redkeys[ubl]}.'
-                ) 
+                )
             else:
                 redkeys[ubl] = bl
 
-
     def get_ubl_key(self, bl):
         '''Returns the blkey used to internally denote the data stored.
-        
+
         If this bl is in a redundant group present in the data, this will return the
         blkey that exists in the data. Otherwise, it will return the array-wide blkey
         representing this group.
         '''
         return self._reds_keyed_on_data.get_ubl_key(bl)
-        
+
     def get_red(self, key):
         '''Returns the list of baselines in the array redundant with this key.
-        
-        Note: this is not just baselines existing in the data itself, but in the 
+
+        Note: this is not just baselines existing in the data itself, but in the
               entire array.
         '''
         return self.reds[key]
@@ -694,8 +696,6 @@ class RedDataContainer(DataContainer):
 
         super().__setitem__(ubl_key, value)
 
-
     def __contains__(self, key):
         '''Returns true if the baseline redundant with the key is in the data.'''
         return (key in self.reds) and (super().__contains__(self.get_ubl_key(key)))
-        

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -108,21 +108,31 @@ class HERACal(UVCal):
             total_qual: dict mapping polarization to (Nint, Nfreq) float total quality array
         '''
         self._extract_metadata()
-        gains, flags, quals, total_qual = odict(), odict(), odict(), odict()
+        gains, flags = odict(), odict()
+
+        if self.total_quality_array is not None:
+            total_qual = odict()
+        else:
+            total_qual = None
+
+        if self.quality_array is not None:
+            quals = odict()
+        else:
+            quals = None
 
         # build dict of gains, flags, and quals
         for (ant, pol) in self.ants:
             i, ip = self._antnum_indices[ant], self._jnum_indices[jstr2num(pol, x_orientation=self.x_orientation)]
             gains[(ant, pol)] = np.array(self.gain_array[i, :, :, ip].T)
             flags[(ant, pol)] = np.array(self.flag_array[i, :, :, ip].T)
-            quals[(ant, pol)] = np.array(self.quality_array[i, :, :, ip].T)
+            if quals is not None:
+                quals[(ant, pol)] = np.array(self.quality_array[i, :, :, ip].T)
+
         # build dict of total_qual if available
-        for pol in self.pols:
-            ip = self._jnum_indices[jstr2num(pol, x_orientation=self.x_orientation)]
-            if self.total_quality_array is not None:
+        if total_qual is not None:
+            for pol in self.pols:
+                ip = self._jnum_indices[jstr2num(pol, x_orientation=self.x_orientation)]
                 total_qual[pol] = np.array(self.total_quality_array[:, :, ip].T)
-            else:
-                total_qual = None
 
         return gains, flags, quals, total_qual
 

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -460,7 +460,7 @@ def get_blt_slices(uvo, tried_to_reorder=False):
     if getattr(uvo, 'blts_are_rectangular', False):
         if uvo.time_axis_faster_than_bls:
             for i in range(uvo.Nbls):
-                start = i*uvo.Ntimes
+                start = i * uvo.Ntimes
                 antp = (uvo.ant_1_array[start], uvo.ant_2_array[start])
                 blt_slices[antp] = slice(start, start + uvo.Ntimes, 1)
             assert uvo.Nbls == len(blt_slices)
@@ -479,8 +479,10 @@ def get_blt_slices(uvo, tried_to_reorder=False):
                     uvo.reorder_blts(order='time')
                     return get_blt_slices(uvo, tried_to_reorder=True)
                 else:
-                    raise NotImplementedError('UVData objects with non-regular spacing of '
-                                            'baselines in its baseline-times are not supported.')
+                    raise NotImplementedError(
+                        'UVData objects with non-regular spacing of '
+                        'baselines in its baseline-times are not supported.'
+                    )
             else:
                 blt_slices[(ant1, ant2)] = slice(indices[0], indices[-1] + 1, indices[1] - indices[0])
     return blt_slices
@@ -797,7 +799,7 @@ class HERAData(UVData):
         locs = locals()
         partials = ['bls', 'polarizations', 'times', 'time_range', 'lsts', 'lst_range', 'frequencies', 'freq_chans']
         self.last_read_kwargs = {p: locs[p] for p in partials}
-        
+
         # if filepaths is None, this was converted to HERAData
         # from a different pre-loaded object with no history of filepath
         if self.filepaths is not None:
@@ -1618,6 +1620,8 @@ def load_flags(flagfile, filetype='h5', return_meta=False):
             # data container only supports standard polarizations strings
             if np.issubdtype(uvf.polarization_array.dtype, np.signedinteger):
                 flags = DataContainer(flags)
+                flags.times = times
+                flags.freqs = freqs
 
         elif uvf.type == 'antenna':  # one time x freq waterfall per antenna
             for i, ant in enumerate(uvf.ant_array):
@@ -2234,9 +2238,6 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
         return uvd
 
 
-
-
-
 def update_uvdata(uvd, data=None, flags=None, nsamples=None, add_to_history='', **kwargs):
     '''Updates a UVData/HERAData object with data or parameters. Cannot modify the shape of
     data arrays. More than one spectral window is not supported. Assumes every baseline
@@ -2719,6 +2720,7 @@ def throw_away_flagged_ants_parser():
     ap.add_argument("--clobber", default=False, action="store_true", help='overwrites existing file at outfile')
     return ap
 
+
 def uvdata_from_fastuvh5(
     meta: FastUVH5Meta,
     antpairs: list[tuple[int, int]] | None = None,
@@ -2726,7 +2728,8 @@ def uvdata_from_fastuvh5(
     lsts: np.ndarray | None = None,
     start_jd: float | None = None,
     lst_branch_cut: float = 0.0,
-    **kwargs) -> UVData:
+    **kwargs
+) -> UVData:
     """Convert a FastUVH5Meta object to a UVData object.
 
     This is a convenience function to convert a FastUVH5Meta object to a UVData

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1600,7 +1600,7 @@ def load_flags(flagfile, filetype='h5', return_meta=False):
     elif filetype == 'h5':
         from pyuvdata import UVFlag
         uvf = UVFlag(flagfile)
-        assert uvf.mode == 'flag', 'The input h5-based UVFlag object must be in flag mode.'
+        assert uvf.mode == 'flag', f'The input h5-based UVFlag object must be in flag mode, got {uvf.mode}'
         assert (np.issubsctype(uvf.polarization_array.dtype, np.signedinteger)
                 or np.issubsctype(uvf.polarization_array.dtype, np.str_)), \
             "The input h5-based UVFlag object's polarization_array must be integers or byte strings."

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -1076,8 +1076,8 @@ def sigma_clip(array: np.ndarray | np.ma.MaskedArray, sigma: float=4.0, min_N: i
         return np.zeros_like(array, dtype=bool)
 
     if isinstance(array, np.ma.MaskedArray):
-        location = np.expand_dims(np.median(array, axis=axis), axis=axis)
-        scale = np.expand_dims(np.median(np.abs(array - location), axis=axis) * 1.482579, axis=axis)
+        location = np.expand_dims(np.ma.median(array, axis=axis), axis=axis)
+        scale = np.expand_dims(np.ma.median(np.abs(array - location), axis=axis) * 1.482579, axis=axis)
     else:
         # get robust location
         location = np.expand_dims(np.nanmedian(array, axis=axis), axis=axis)

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -1045,7 +1045,7 @@ def make_lst_grid(
     return lst_grid
 
 
-def sigma_clip(array: np.ndarray, sigma: float=4.0, min_N: int=4, axis: int = 0):
+def sigma_clip(array: np.ndarray | np.ma.MaskedArray, sigma: float=4.0, min_N: int=4, axis: int = 0):
     """
     One-iteration robust sigma clipping algorithm.
 
@@ -1075,11 +1075,15 @@ def sigma_clip(array: np.ndarray, sigma: float=4.0, min_N: int=4, axis: int = 0)
     if array.shape[axis] < min_N:
         return np.zeros_like(array, dtype=bool)
 
-    # get robust location
-    location = np.expand_dims(np.nanmedian(array, axis=axis), axis=axis)
+    if isinstance(array, np.ma.MaskedArray):
+        location = np.expand_dims(np.median(array, axis=axis), axis=axis)
+        scale = np.expand_dims(np.median(np.abs(array - location), axis=axis) * 1.482579, axis=axis)
+    else:
+        # get robust location
+        location = np.expand_dims(np.nanmedian(array, axis=axis), axis=axis)
 
-    # get MAD * 1.482579 for consistency with Gaussian white noise
-    scale = np.expand_dims(np.nanmedian(np.abs(array - location), axis=axis) * 1.482579, axis=axis)
+        # get MAD * 1.482579 for consistency with Gaussian white noise
+        scale = np.expand_dims(np.nanmedian(np.abs(array - location), axis=axis) * 1.482579, axis=axis)
 
     # get clipped data
     clip_flags = np.abs(array - location) / scale > sigma

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1757,7 +1757,7 @@ def create_lstbin_output_file(
     times: np.ndarray | None = None,
     lsts: np.ndarray | None = None,
     history: str  = "",
-    fname_format: str="zen.{kind}.{lst:7.5f}{inpaint_mode}.uvh5",
+    fname_format: str="zen.{kind}.{lst:7.5f}.{inpaint_mode}.uvh5",
     overwrite: bool = False,
     antpairs: list[tuple[int, int]] | None = None,
     freq_min: float | None = None,
@@ -1779,7 +1779,7 @@ def create_lstbin_output_file(
 
     fname = outdir / fname_format.format(
         kind=kind, lst=lst, pol=''.join(pols),
-        inpaint_mode='.inpaint' if inpaint_mode else ('.flagged' if inpaint_mode is False else "")
+        inpaint_mode='inpaint' if inpaint_mode else ('flagged' if inpaint_mode is False else "")
     )
 
     logger.info(f"Initializing {fname}")

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -2041,7 +2041,7 @@ def make_lst_bin_config_file(
     # Get the best lst_branch_cut by finding the largest gap in LSTs and starting 
     # AFTER it
     if lst_branch_cut is None:
-        lst_branch_cut = utils.get_best_lst_branch_cut(np.concatenate(lst_grid))
+        lst_branch_cut = float(utils.get_best_lst_branch_cut(np.concatenate(lst_grid)))
     
     dlst = lst_grid[0][1] - lst_grid[0][0]
     # Make it a real list of floats to make the YAML easier to read

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -181,8 +181,6 @@ def lst_align(
         nsamples = nsamples[lst_mask]
         data_lsts = data_lsts[lst_mask]
         grid_indices = grid_indices[lst_mask]
-        if where_inpainted is not None:
-            where_inpainted = where_inpainted[lst_mask]
 
         if freq_array is None or antpos is None:
             raise ValueError("freq_array and antpos is needed for rephase")

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -311,13 +311,13 @@ def reduce_lst_bins(
         within an LST-bin that can be flagged before that combination is flagged
         in the LST-average.
     get_mad
-        Whether to compute the median and median absolute deviation of the data in each 
+        Whether to compute the median and median absolute deviation of the data in each
         LST bin, in addition to the mean and standard deviation.
 
     Returns
     -------
     dict
-        The reduced data in a dictionary. Keys are 'data' (the lst-binned mean), 
+        The reduced data in a dictionary. Keys are 'data' (the lst-binned mean),
         'nsamples', 'flags', 'days_binned' (the number of days that went into each bin),
         'std' (standard deviation) and *otionally* 'median' and 'mad' (if `get_mad` is
         True). All values are arrays of the same shape: ``(nbl, nlst_bins, nfreq, npol)``.
@@ -349,7 +349,7 @@ def reduce_lst_bins(
 
         # TODO: check that this doesn't make yet another copy...
         # This is just the data in this particular lst-bin.
-        
+
         if d.size:
             d, f = get_masked_data(d, n, f, inpainted=inpf, inpainted_mode=inpainted_mode)
             f = threshold_flags(f, inplace=True, flag_thresh=flag_thresh)
@@ -362,7 +362,7 @@ def reduce_lst_bins(
                 out_nsamples[:, lstbin],
                 days_binned[:, lstbin]
             ) = lst_average(
-                d, n, f, 
+                d, n, f,
                 inpainted_mode=inpainted_mode,
                 sigma_clip_thresh=sigma_clip_thresh,
                 sigma_clip_min_N=sigma_clip_min_N,
@@ -411,23 +411,23 @@ def get_masked_data(
     elif inpainted is None:
         # Flag if a whole blt is flagged:
         allf = np.all(flags, axis=2)[:,:, None, :]
-        
+
         # Assume everything else that's flagged is inpainted.
         inpainted = flags.copy() * (~allf)
 
     flags = flags | np.isnan(data) | np.isinf(data) | (nsamples == 0)
     data = np.ma.masked_array(
-        data, 
+        data,
         mask=(flags & ~inpainted)
     )
     return data, flags
 
 
 def get_lst_median_and_mad(
-    data: np.ndarray | np.ma.MaskedArray, 
+    data: np.ndarray | np.ma.MaskedArray,
 ):
     """Compute the median absolute deviation of a set of data over its zeroth axis.
-    
+
     Flagged data will be ignored in flagged mode, but included in inpainted mode.
     Nsamples is not taken into account at all, unless Nsamples=0.
     """
@@ -568,12 +568,12 @@ def lst_average(
 
     std[~normalizable] = np.inf
 
-    
-    # While the previous norm is correct for normalizing the mean, we now 
+
+    # While the previous norm is correct for normalizing the mean, we now
     # calculate nsamples as the unflagged samples in each LST bin.
     nsamples.mask = flags
     nsamples  = np.sum(nsamples, axis=0)
-    
+
     return meandata.data, lstbin_flagged, std.data, nsamples.data, ndays_binned
 
 def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
@@ -671,7 +671,7 @@ def lst_bin_files_for_baselines(
         all frequencies will be included.
     where_inpainted_files
         A list of lists of strings, one for each file, where each file is a UVFlag file
-        specifying which data are in-painted. If not provided, no inpainting will be 
+        specifying which data are in-painted. If not provided, no inpainting will be
         assumed.
 
     Returns
@@ -797,7 +797,7 @@ def lst_bin_files_for_baselines(
             inpainted = io.load_flags(inpfile)
             if not isinstance(inpainted, DataContainer):
                 raise ValueError(f"Expected {inpfile} to be a DataContainer")
-            
+
             # We need to down-selecton times/freqs (bls and pols will be sub-selected
             # based on those in the data through the next loop)
             inpainted.select_or_expand_times(times=tarr, skip_bda_check=True)
@@ -968,14 +968,14 @@ def filter_required_files_by_times(
     return tinds, time_arrays, all_lsts, file_list, cals, where_inpainted
 
 def _get_where_inpainted_files(
-    data_files: list[list[str | Path]], 
+    data_files: list[list[str | Path]],
     where_inpainted_file_rules: list[tuple[str, str]] | None
 ) -> list[list[str | Path]] | None:
     if where_inpainted_file_rules is None:
         return None
-    
+
     where_inpainted_files = []
-    for dflist in enumerate(data_files):
+    for dflist in data_files:
         this = []
         where_inpainted_files.append(this)
         for df in dflist:
@@ -992,7 +992,7 @@ def _configure_inpainted_mode(output_flagged, output_inpainted, where_inpainted_
     # Sort out defaults for inpaint/flagging mode
     if output_inpainted is None:
         output_inpainted = bool(where_inpainted_files)
-    
+
     if not output_inpainted and not output_flagged:
         raise ValueError("Both output_inpainted and output_flagged are False. One must be True.")
 
@@ -1052,7 +1052,7 @@ def lst_bin_files_single_outfile(
     use *both* modes by default.
 
     .. note:: Both "flagged" and "inpainted" mode as implemented in this function are
-        *not* spectrally smooth if the input Nsamples are not spectrally uniform. 
+        *not* spectrally smooth if the input Nsamples are not spectrally uniform.
 
     Parameters
     ----------
@@ -1157,24 +1157,24 @@ def lst_bin_files_single_outfile(
     output_inpainted
         If True, output data LST-binned in in-painted mode. This mode does *not* flag
         data for the averaging, assuming that data that has flags has been in-painted
-        to improve spectral smoothness. It does take the flags into account for the 
+        to improve spectral smoothness. It does take the flags into account for the
         LST-binned Nsamples, however.
     output_flagged
         If True, output data LST-binned in flagged mode. This mode *does* apply flags
         to the data before averaging. It will yield the same Nsamples as the in-painted
         mode, but simply ignores flagged data for the average, which can yield less
-        spectrally-smooth LST-binned results. 
+        spectrally-smooth LST-binned results.
     where_inpainted_file_rules
-        Rules to transform the input data file names into the corresponding "where 
+        Rules to transform the input data file names into the corresponding "where
         inpainted" files (which should be in UVFlag format). If provided, this indicates
-        that the data itself is in-painted, and the `output_inpainted` mode will be 
+        that the data itself is in-painted, and the `output_inpainted` mode will be
         switched on by default. These files should specify which data is in-painted
         in the associated data file (which may be different than the in-situ flags
         of the data object). If not provided, but `output_inpainted` is set to True,
         all data-flags will be considered in-painted except for baseline-times that are
         fully flagged, which will be completely ignored.
     sigma_clip_in_inpainted_mode
-        If True, sigma clip the data in inpainted mode (if sigma-clipping is turned on). 
+        If True, sigma clip the data in inpainted mode (if sigma-clipping is turned on).
         This is generally not a good idea, since the point of inpainting is to get
         smoother spectra, and sigma-clipping creates non-uniform Nsamples, which can
         lead to less smooth spectra. This option is only here to enable sigma-clipping
@@ -1196,42 +1196,42 @@ def lst_bin_files_single_outfile(
     the data in flagged bl-channel-pols is used for the averaging, as it is considered
     to be in-painted. This gives the most spectrally-smooth results. In order to ignore
     a particular bl-channel-pol while still using inpaint mode, supply a "where inpainted"
-    file, which should be a UVFlag object that specifies which bl-channel-pols are 
-    inpainted in the associated data file. Anything that's flagged but not inpainted is 
+    file, which should be a UVFlag object that specifies which bl-channel-pols are
+    inpainted in the associated data file. Anything that's flagged but not inpainted is
     ignored for the averaging. In this inpainted mode, the Nsamples are the number of
     un-flagged integrations (whether they were in-painted or not). The LST-binned flags
     are only set to True if ALL of the nights for a given bl-channel-pol are flagged
     (again, whether they were in-painted or not). In flagged mode, both the Nsamples
     and Flags are the same as inpainted mode. The averaged data, however, ignores any
-    flagged data. This can lead to less spectrally-smooth results. The "STD" files 
+    flagged data. This can lead to less spectrally-smooth results. The "STD" files
     contain LST-binned "data" that is the standard deviation of the data in each LST-bin.
     This differs between inpainted and flagged modes in the same way as the "LST" files:
     in inpainted mode, the flagged and inpainted data is used for calculating the sample
     variance, while in flagged mode, only the unflagged data is used. The final flags
-    in the "STD" files is equivalent to that in the "LST" files. The Nsamples in the 
+    in the "STD" files is equivalent to that in the "LST" files. The Nsamples in the
     "STD" files is actually the number of unflagged nights in the LST bin (so, not the
     sum of Nsamples), where "unflagged" really does mean unflagged -- whether inpainted
-    or not. 
+    or not.
 
     One note here about what is considered "flagged" vs. "flagged and inpainted" vs
     "flagged and not inpainted". In flagged mode, there are input flags that exist in the
     input files. These are potentially *augmented* by sigma clipping within the LST
     binner, and also by flagging whole LST bins if they have too few unflagged integrations.
-    In inpainted mode, input flags are considered as normal flags. However, only 
+    In inpainted mode, input flags are considered as normal flags. However, only
     "non-inpainted" flags are *ignored* for the averaging. By default, all flagged data
     is considered to to be in-painted UNLESS it is a blt-pol that is fully flagged (i.e.
     all channels are flagged for an integration for a single bl and pol). However, you
     can tell the routine that other data is NOT in-painted by supplying a "where inpainted"
-    file. Now, integrations in LST-bins that end up having "too few" unflagged 
+    file. Now, integrations in LST-bins that end up having "too few" unflagged
     integrations will be flagged inside the binner, however in inpainted mode, if these
     are considered "inpainted", they will still be used in averaging (this means they
-    will have "valid" data for the average, but their average will be flagged). 
-    On the other hand, flags that are applied by sigma-clipping will be considered 
-    NOT inpainted, i.e. those data will be ignored in the averaged, just like flagging 
+    will have "valid" data for the average, but their average will be flagged).
+    On the other hand, flags that are applied by sigma-clipping will be considered
+    NOT inpainted, i.e. those data will be ignored in the averaged, just like flagging
     mode. In this case, either choice is bad: to include them in the average is bad
     because even though they may have been actually in-painted, whatever value they have
     is clearly triggering the sigma-clipper and is therefore an outlier. On the other
-    hand, to ignore them is bad because the point of in-painting mode is to get 
+    hand, to ignore them is bad because the point of in-painting mode is to get
     smoother spectra, and this negates that. So, it's best just to not do sigma-clipping
     in inpainted mode.
     """
@@ -1252,7 +1252,7 @@ def lst_bin_files_single_outfile(
         output_inpainted, output_flagged, where_inpainted_files
     )
 
-    
+
     # Prune empty nights (some nights start with files, but have files removed because
     # they have no associated calibration)
     data_files = [df for df in data_files if df]
@@ -1768,7 +1768,7 @@ def create_lstbin_output_file(
     lst_branch_cut: float = 0.0,
 ) -> Path:
     outdir = Path(outdir)
-    
+
     # update history
     file_list_str = "-".join(ff.path.name for ff in file_list)
     file_history = f"{history} Input files: {file_list_str}"
@@ -1778,7 +1778,7 @@ def create_lstbin_output_file(
         lst += 2*np.pi
 
     fname = outdir / fname_format.format(
-        kind=kind, lst=lst, pol=''.join(pols), 
+        kind=kind, lst=lst, pol=''.join(pols),
         inpaint_mode='.inpaint' if inpaint_mode else ('.flagged' if inpaint_mode is False else "")
     )
 
@@ -2011,12 +2011,12 @@ def make_lst_bin_config_file(
         Regex to use to extract the JD from the file name. Set to None or empty
         to force the LST-matching to use the LSTs in the metadata within the file.
     lst_branch_cut
-        The LST at which to branch cut the LST grid for file writing. The JDs in the 
+        The LST at which to branch cut the LST grid for file writing. The JDs in the
         output LST-binned files will be *lowest* at the lst_branch_cut, and all file
         names will have LSTs that are higher than lst_branch_cut. If None, this will
         be determined automatically by finding the largest gap in LSTs and starting
         AFTER it.
-        
+
     Returns
     -------
     config : dict
@@ -2038,11 +2038,11 @@ def make_lst_bin_config_file(
         ntimes_per_file=ntimes_per_file,
     )
 
-    # Get the best lst_branch_cut by finding the largest gap in LSTs and starting 
+    # Get the best lst_branch_cut by finding the largest gap in LSTs and starting
     # AFTER it
     if lst_branch_cut is None:
         lst_branch_cut = float(utils.get_best_lst_branch_cut(np.concatenate(lst_grid)))
-    
+
     dlst = lst_grid[0][1] - lst_grid[0][0]
     # Make it a real list of floats to make the YAML easier to read
     lst_grid = [[float(l) for l in lsts] for lsts in lst_grid]

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -343,8 +343,8 @@ def reduce_lst_bins(
     days_binned = np.zeros(out_nsamples.shape, dtype=int)
 
     if get_mad:
-        mad = np.zeros(out_data.shape, dtype=complex)
-        med = np.zeros(out_data.shape, dtype=complex)
+        mad = np.ones(out_data.shape, dtype=complex)
+        med = np.ones(out_data.shape, dtype=complex)
 
     if where_inpainted is None:
         where_inpainted = [None] * nlst_bins
@@ -1039,12 +1039,12 @@ def _get_where_inpainted_files(
         for df in dflist:
             wif = str(df)
             for rule in where_inpainted_file_rules:
-                print(rule[0], "HA", rule[1])
                 wif = wif.replace(rule[0], rule[1])
             if os.path.exists(wif):
                 this.append(wif)
             else:
                 raise IOError(f"Where inpainted file {wif} does not exist")
+
     return where_inpainted_files
 
 
@@ -1311,8 +1311,8 @@ def lst_bin_files_single_outfile(
     where_inpainted_files = _get_where_inpainted_files(
         data_files, where_inpainted_file_rules
     )
-    output_inpainted, output_flagged = _configure_inpainted_mode(
-        output_inpainted, output_flagged, where_inpainted_files
+    output_flagged, output_inpainted = _configure_inpainted_mode(
+        output_flagged, output_inpainted, where_inpainted_files
     )
 
     # Prune empty nights (some nights start with files, but have files removed because

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -1,7 +1,7 @@
 """Functions for mocking UVdata objects for testing purposes."""
 from __future__ import annotations
 
-from pyuvdata import UVData, UVCal
+from pyuvdata import UVData, UVCal, UVFlag
 from pyuvdata.uvdata import FastUVH5Meta
 from pyuvdata.telescopes import get_telescope
 
@@ -25,16 +25,19 @@ with open(f"{DATA_PATH}/hera_antpos.yaml", "r") as fl:
     HERA_ANTPOS = yaml.safe_load(fl)
 
 start: 46920776.3671875
-end:   234298706.0546875
+end: 234298706.0546875
 delta: 122070.3125
+
 
 def create_mock_hera_obs(
     jdint: int = 2459855,
     integration_time=9.663677215576172,
     lst_start=0.1,
     jd_start: float | None = None,
-    ntimes: int=2,
-    freqs: np.ndarray = np.arange(46920776.3671875, 234298706.0546875 + 10.0, 122070.3125),
+    ntimes: int = 2,
+    freqs: np.ndarray = np.arange(
+        46920776.3671875, 234298706.0546875 + 10.0, 122070.3125
+    ),
     pols: list[str] = ["xx", "yy", "xy", "yx"],
     ants: list[int] | None = None,
     antpairs: list[tuple[int, int]] | None = None,
@@ -49,17 +52,17 @@ def create_mock_hera_obs(
     if jd_start is None:
         # We ensure that the LSTs align exactly with the LST-grid that would be LST-binned.
         lst_start = make_lst_grid(dlst, begin_lst=lst_start)[0]
-        lsts = np.arange(lst_start, ntimes*dlst + lst_start, dlst)[:ntimes]
+        lsts = np.arange(lst_start, ntimes * dlst + lst_start, dlst)[:ntimes]
         times = utils.LST2JD(lsts, start_jd=jdint, allow_other_jd=False)
     else:
         if jd_start < 2000000:
             jd_start += jdint
-        times = np.arange(jd_start, ntimes*tint + jd_start, tint)[:ntimes]
+        times = np.arange(jd_start, ntimes * tint + jd_start, tint)[:ntimes]
 
     if ants is None:
         ants = list(HERA_ANTPOS.keys())
 
-    antpos = {k: v for k,v in HERA_ANTPOS.items() if k in ants}
+    antpos = {k: v for k, v in HERA_ANTPOS.items() if k in ants}
 
     reds = RedundantGroups.from_antpos(antpos)
 
@@ -75,29 +78,27 @@ def create_mock_hera_obs(
 
     # build a UVData object
     uvd = UVData.new(
-        freq_array= freqs,
+        freq_array=freqs,
         polarization_array=pols,
-        antenna_positions= antpos,
+        antenna_positions=antpos,
         antpairs=np.array(antpairs),
-        telescope_location= HERA_LOC,
-        telescope_name= "HERA",
-        times= times,
+        telescope_location=HERA_LOC,
+        telescope_name="HERA",
+        times=times,
         x_orientation=x_orientation,
         empty=empty,
         time_axis_faster_than_bls=time_axis_faster_than_bls,
-        do_blt_outer=True
+        do_blt_outer=True,
     )
     uvd.polarization_array = np.array(uvd.polarization_array)
     return uvd
 
 
 def create_uvd_ones(**kwargs) -> UVData:
-    uvd = create_mock_hera_obs(
-        empty=True,
-        **kwargs
-    )
+    uvd = create_mock_hera_obs(empty=True, **kwargs)
     uvd.data_array += 1.0
     return uvd
+
 
 def identifiable_data_from_uvd(
     ones: UVData,
@@ -105,21 +106,26 @@ def identifiable_data_from_uvd(
 ) -> np.ndarray:
     lsts = np.unique(ones.lst_array)
 
-    normfreqs = 2*np.pi * (ones.freq_array - 100e6) / 100e6
+    normfreqs = 2 * np.pi * (ones.freq_array - 100e6) / 100e6
 
     data = np.zeros_like(ones.data_array)
 
     orig_shape = data.shape
     # in-place reshape of data to make it easier for us.
-    data.shape = (len(ones.get_antpairs()), ones.Ntimes, ones.Nfreqs, len(ones.polarization_array))
+    data.shape = (
+        len(ones.get_antpairs()),
+        ones.Ntimes,
+        ones.Nfreqs,
+        len(ones.polarization_array),
+    )
 
     for i, ap in enumerate(ones.get_antpairs()):
         for j, p in enumerate(ones.polarization_array):
             if ap[0] == ap[1] and p in (-5, -6):
-                d = np.outer(-p*lsts*1000, (ones.freq_array / 75e6)**-2)
+                d = np.outer(-p * lsts * 1000, (ones.freq_array / 75e6) ** -2)
             else:
                 d = np.outer(
-                    p*lsts, np.cos(normfreqs*ap[0]) + np.sin(normfreqs*ap[1])*1j
+                    p * lsts, np.cos(normfreqs * ap[0]) + np.sin(normfreqs * ap[1]) * 1j
                 )
 
             data[i, :, :, j] = d
@@ -127,11 +133,13 @@ def identifiable_data_from_uvd(
         data.shape = orig_shape
     return data
 
+
 def create_uvd_identifiable(
     with_noise: bool = False,
     autos_noise: bool = False,
     flag_frac: float = 0.0,
-    **kwargs) -> UVData:
+    **kwargs,
+) -> UVData:
     """Make a UVData object with identifiable data.
 
     Each baseline, pol, LST and freq channel should be identifiable in the data with the
@@ -143,18 +151,18 @@ def create_uvd_identifiable(
     uvd.data_array = identifiable_data_from_uvd(uvd)
 
     if with_noise:
-        add_noise_to_uvd(uvd, autos = autos_noise)
+        add_noise_to_uvd(uvd, autos=autos_noise)
 
     if flag_frac > 0:
         add_flags_to_uvd(uvd, flag_frac=flag_frac)
     return uvd
 
+
 def add_noise_to_uvd(uvd, autos: bool = False):
     hd = io.to_HERAData(uvd)
 
-
     data, flags, nsamples = hd.read()
-    dt = (data.times[1] - data.times[0])* units.si.day.in_units(units.si.s)
+    dt = (data.times[1] - data.times[0]) * units.si.day.in_units(units.si.s)
     df = data.freqs[1] - data.freqs[0]
 
     for bl in data.bls():
@@ -164,11 +172,11 @@ def add_noise_to_uvd(uvd, autos: bool = False):
         variance = noise.predict_noise_variance_from_autos(
             bl, data, dt=dt, df=df, nsamples=nsamples
         )
-        data[bl] += (
-            np.random.normal(scale=np.sqrt(variance/2))
-            + 1j * np.random.normal(scale=np.sqrt(variance/2))
-        )
+        data[bl] += np.random.normal(
+            scale=np.sqrt(variance / 2)
+        ) + 1j * np.random.normal(scale=np.sqrt(variance / 2))
     hd.update(data=data)
+
 
 def add_flags_to_uvd(uvd, flag_frac: float = 0.1):
     hd = io.to_HERAData(uvd)
@@ -180,13 +188,14 @@ def add_flags_to_uvd(uvd, flag_frac: float = 0.1):
         flags[bl] = np.random.uniform(size=flags[bl].shape) < flag_frac
     hd.update(flags=flags)
 
+
 def write_files_in_hera_format(
     uvds: list[UVData] | list[list[UVData]],
     tmpdir: Path,
     fmt: str = "zen.{jd:.5f}.sum.uvh5",
     in_jdint_dir: bool = True,
+    add_where_inpainted_files: bool = False,
 ) -> list[list[str]]:
-
     if not tmpdir.exists():
         tmpdir.mkdir()
 
@@ -199,7 +208,7 @@ def write_files_in_hera_format(
     for uvdlist in uvds:
         if in_jdint_dir:
             jdint = int(uvdlist[0].time_array.min())
-            daydir = (tmpdir / str(jdint))
+            daydir = tmpdir / str(jdint)
             if not daydir.exists():
                 daydir.mkdir()
         else:
@@ -212,6 +221,14 @@ def write_files_in_hera_format(
                 obj.initialize_uvh5_file(fl, clobber=True)
             else:
                 obj.write_uvh5(fl, clobber=True)
+
+            if add_where_inpainted_files:
+                flg = UVFlag()
+                flg.from_uvdata(obj, copy_flags=True, waterfall=False)
+                flg.flag_array[:] = True  # Everything inpainted.
+                flgfile = fl.with_suffix(".where_inpainted.h5")
+                flg.write(flgfile, clobber=True)
+
             _fls.append(str(fl))
         fls.append(_fls)
 
@@ -220,7 +237,10 @@ def write_files_in_hera_format(
     else:
         return fls
 
-def make_day(nfiles: int, creator: callable = create_mock_hera_obs, **kwargs) -> list[UVData]:
+
+def make_day(
+    nfiles: int, creator: callable = create_mock_hera_obs, **kwargs
+) -> list[UVData]:
     """Make a day of UVData objects."""
 
     uvds = []
@@ -228,17 +248,21 @@ def make_day(nfiles: int, creator: callable = create_mock_hera_obs, **kwargs) ->
 
     for i in range(nfiles):
         uvds.append(creator(lst_start=lst_start, **kwargs))
-        if i ==0:
+        if i == 0:
             lsts = np.unique(uvds[0].lst_array)
             dlst = lsts[1] - lsts[0]
         lst_start = uvds[-1].lst_array[-1] + dlst
-        kwargs['jd_start'] = None  # only use for first file, after, use lst_start
+        kwargs["jd_start"] = None  # only use for first file, after, use lst_start
     return uvds
 
+
 def make_dataset(
-    ndays: int, nfiles: int, start_jdint: int = 2459855, creator: callable = create_mock_hera_obs,
+    ndays: int,
+    nfiles: int,
+    start_jdint: int = 2459855,
+    creator: callable = create_mock_hera_obs,
     random_ants_to_drop: int = 0,
-    **kwargs
+    **kwargs,
 ) -> list[list[UVData]]:
     """Make a dataset of UVData objects."""
 
@@ -246,56 +270,79 @@ def make_dataset(
         default = creator(jdint=start_jdint, **kwargs)
         antpairs = default.get_antpairs()
         data_ants = list(set([ap[0] for ap in antpairs] + [ap[1] for ap in antpairs]))
-        if 'antpairs' in kwargs:
-            del kwargs['antpairs']
+        if "antpairs" in kwargs:
+            del kwargs["antpairs"]
 
     uvds = []
     for i in range(ndays):
         if random_ants_to_drop > 0:
             drop_ants = np.random.choice(data_ants, random_ants_to_drop, replace=False)
-            _antpairs = [ap for ap in antpairs if ap[0] not in drop_ants and ap[1] not in drop_ants]
-            kwargs['antpairs'] = _antpairs
+            _antpairs = [
+                ap
+                for ap in antpairs
+                if ap[0] not in drop_ants and ap[1] not in drop_ants
+            ]
+            kwargs["antpairs"] = _antpairs
         uvds.append(make_day(nfiles, jdint=start_jdint + i, creator=creator, **kwargs))
 
     return uvds
 
-def make_uvc_ones(uvd: UVData, flag_full_ant: int = 0, flag_ant_time: int = 0, flag_ant_freq: int = 0):
+
+def make_uvc_ones(
+    uvd: UVData, flag_full_ant: int = 0, flag_ant_time: int = 0, flag_ant_freq: int = 0
+):
     uvc = UVCal.initialize_from_uvdata(
         uvd,
-        cal_style = "redundant",
-        gain_convention = "multiply",
-        jones_array = "linear",
-        cal_type = "gain",
-        metadata_only=False
+        cal_style="redundant",
+        gain_convention="multiply",
+        jones_array="linear",
+        cal_type="gain",
+        metadata_only=False,
     )
 
     if flag_full_ant > 0:
-        badants = np.random.choice(np.arange(uvc.Nants_data), flag_full_ant, replace=False)
+        badants = np.random.choice(
+            np.arange(uvc.Nants_data), flag_full_ant, replace=False
+        )
         uvc.flag_array[badants] = True
     if flag_ant_time > 0:
-        badants = np.random.choice(np.arange(uvc.Nants_data), flag_ant_time, replace=False)
+        badants = np.random.choice(
+            np.arange(uvc.Nants_data), flag_ant_time, replace=False
+        )
         badtime = np.random.randint(0, uvc.Ntimes)
         uvc.flag_array[badants, :, badtime] = True
     if flag_ant_freq > 0:
-        badants = np.random.choice(np.arange(uvc.Nants_data), flag_ant_freq, replace=False)
+        badants = np.random.choice(
+            np.arange(uvc.Nants_data), flag_ant_freq, replace=False
+        )
         badfreq = np.random.randint(0, uvc.Nfreqs)
         uvc.flag_array[badants, badfreq, :] = True
     return uvc
+
 
 def identifiable_gains_from_uvc(uvc: UVCal):
     gains = np.zeros_like(uvc.gain_array)
     for i, ant in enumerate(uvc.ant_array):
         for j in range(uvc.Njones):
             gains[i, :, :, j] = np.outer(
-                np.exp(2j*np.pi*uvc.freq_array*(j+1)),
-                np.ones_like(uvc.time_array)*(ant+1)
+                np.exp(2j * np.pi * uvc.freq_array * (j + 1)),
+                np.ones_like(uvc.time_array) * (ant + 1),
             )
     return gains
 
-def make_uvc_identifiable(uvd: UVData,  flag_full_ant: int = 0, flag_ant_time: int = 0, flag_ant_freq: int = 0):
-    uvc = make_uvc_ones(uvd,  flag_full_ant=flag_full_ant, flag_ant_time=flag_ant_time, flag_ant_freq=flag_ant_freq)
+
+def make_uvc_identifiable(
+    uvd: UVData, flag_full_ant: int = 0, flag_ant_time: int = 0, flag_ant_freq: int = 0
+):
+    uvc = make_uvc_ones(
+        uvd,
+        flag_full_ant=flag_full_ant,
+        flag_ant_time=flag_ant_time,
+        flag_ant_freq=flag_ant_freq,
+    )
     uvc.gain_array = identifiable_gains_from_uvc(uvc)
     return uvc
+
 
 def write_cals_in_hera_format(
     uvds: list[UVCal] | list[list[UVCal]],
@@ -303,7 +350,6 @@ def write_cals_in_hera_format(
     fmt: str = "zen.{jd:.5f}.sum.calfits",
     in_jdint_dir: bool = True,
 ) -> list[list[str]]:
-
     if not tmpdir.exists():
         tmpdir.mkdir()
 
@@ -316,7 +362,7 @@ def write_cals_in_hera_format(
     for uvdlist in uvds:
         if in_jdint_dir:
             jdint = int(uvdlist[0].time_array.min())
-            daydir = (tmpdir / str(jdint))
+            daydir = tmpdir / str(jdint)
             if not daydir.exists():
                 daydir.mkdir()
         else:

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -130,6 +130,7 @@ def identifiable_data_from_uvd(
 def create_uvd_identifiable(
     with_noise: bool = False,
     autos_noise: bool = False,
+    flag_frac: float = 0.0,
     **kwargs) -> UVData:
     """Make a UVData object with identifiable data.
 
@@ -144,6 +145,8 @@ def create_uvd_identifiable(
     if with_noise:
         add_noise_to_uvd(uvd, autos = autos_noise)
 
+    if flag_frac > 0:
+        add_flags_to_uvd(uvd, flag_frac=flag_frac)
     return uvd
 
 def add_noise_to_uvd(uvd, autos: bool = False):
@@ -166,6 +169,16 @@ def add_noise_to_uvd(uvd, autos: bool = False):
             + 1j * np.random.normal(scale=np.sqrt(variance/2))
         )
     hd.update(data=data)
+
+def add_flags_to_uvd(uvd, flag_frac: float = 0.1):
+    hd = io.to_HERAData(uvd)
+    data, flags, nsamples = hd.read()
+
+    for bl in data.bls():
+        if bl[0] == bl[1] and bl[2][0] == bl[2][1]:
+            continue
+        flags[bl] = np.random.uniform(size=flags[bl].shape) < flag_frac
+    hd.update(flags=flags)
 
 def write_files_in_hera_format(
     uvds: list[UVData] | list[list[UVData]],

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -504,6 +504,9 @@ class TestDataContainerWithRealData:
         with pytest.raises(ValueError, match='Cannot specify both freqs and channels'):
             dc1.select_freqs(fq, channels=chans)
 
+        with pytest.raises(ValueError, match="All freqs must be in self.freqs"):
+            dc1.select_freqs(np.array([100.0]))
+
         # Ensure warning is raised without freqs
         dc1.freqs = None
         with pytest.warns(UserWarning, match='It is impossible'):

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -180,10 +180,10 @@ class TestDataContainer(object):
             del dc['bad_key']
 
         with pytest.raises(ValueError, match='Tuple keys to delete must be in the format'):
-            del dc[(1,2,3,4)]
-        
+            del dc[(1, 2, 3, 4)]
+
         with pytest.raises(ValueError, match='Tuple keys to delete must be in the format'):
-            del dc[[1,2,'xx']]
+            del dc[[1, 2, 'xx']]
 
     def test_getitem(self):
         dc = datacontainer.DataContainer(self.blpol)
@@ -314,7 +314,7 @@ class TestDataContainer(object):
         assert dc.dtype is None
         dc = datacontainer.DataContainer({(1, 2): {'xx': 2}})
         assert dc.dtype is None
-        
+
         dc = datacontainer.DataContainer(self.blpolarr)
         assert dc.dtype == complex
         dc = datacontainer.DataContainer(self.bools)
@@ -326,17 +326,18 @@ class TestDataContainer(object):
             def __init__(self, d: dict):
                 self._data = deepcopy(d)
                 self.ants = set(sum(self._data.keys(), ()))
-            
+
             def __getitem__(self, key):
                 return self._data[key]
-            
+
             def keys(self):
                 return self._data.keys()
-            
+
         blpol = SmallDataContainer(self.blpol)
-        
+
         dc = datacontainer.DataContainer(blpol)
         assert dc.ants == blpol.ants
+
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 class TestDataContainerWithRealData:
@@ -467,6 +468,52 @@ class TestDataContainerWithRealData:
                 assert np.all(dc.lsts == (np.arange(10) * 2 * np.pi / 10)[new_times])
                 assert np.all(dc.lsts_by_bl[0, 1] == (np.arange(10) * 2 * np.pi / 10)[new_times])
 
+    def test_select_freqs(self):
+        fq = np.linspace(0, 1, 10)
+        dc1 = datacontainer.DataContainer({(0, 1, 'ee'): np.arange(10)})
+        dc1.freqs = fq
+
+        # Both of the following should pick all the freqs
+        dc2 = dc1.select_freqs(fq, in_place=False)
+        dc1.select_freqs(fq, in_place=True)
+        dc1.select_freqs()
+
+        for dc in (dc1, dc2):
+            assert np.all(dc[(0, 1, 'ee')] == np.arange(10))
+            assert np.all(dc.freqs == fq)
+
+        # Now actually sub-select
+        fq2 = fq[:9]
+        dc2 = dc1.select_freqs(fq2, in_place=False)
+        dc1.select_freqs(fq2, in_place=True)
+
+        for dc in (dc1, dc2):
+            assert np.all(dc[(0, 1, 'ee')] == np.arange(9))
+            assert np.all(dc.freqs == fq2)
+
+        # Sub-select by channel
+        chans = np.arange(8)
+        dc2 = dc1.select_freqs(channels=chans, in_place=False)
+        dc1.select_freqs(channels=chans, in_place=True)
+
+        for dc in (dc1, dc2):
+            assert np.all(dc[(0, 1, 'ee')] == np.arange(8))
+            assert np.all(dc.freqs == fq[chans])
+
+        # Error if both freqs and chans given
+        with pytest.raises(ValueError, match='Cannot specify both freqs and channels'):
+            dc1.select_freqs(fq, channels=chans)
+
+        # Ensure warning is raised without freqs
+        dc1.freqs = None
+        with pytest.warns(UserWarning, match='It is impossible'):
+            dc1.select_freqs(channels=chans)
+
+        assert len(dc1[(0, 1, 'ee')]) == 8
+
+        with pytest.raises(ValueError, match='Cannot select frequencies'):
+            dc1.select_freqs(fq2)
+
 
 def test_RedDataContainer():
     # build hexagonal array and data which tells us which baseline it comes from
@@ -486,7 +533,7 @@ def test_RedDataContainer():
     # build an incomplete datacontainer, then finish it
     rdata6 = datacontainer.RedDataContainer(deepcopy(data), reds[:-1])
     rdata6[reds[-1][0]] = deepcopy(data[reds[-1][0]])
-    #rdata6.build_red_keys(reds)
+    # rdata6.build_red_keys(reds)
 
     # make sure that the data for a redundant group are being accessed from the same place in memory
     for i, rdata in enumerate([rdata1, rdata2, rdata3, rdata4, rdata5, rdata6]):
@@ -555,4 +602,3 @@ def test_RedDataContainerKeyManipulation():
     rdc[1, 3, 'ee'] = 21j
     with pytest.raises(ValueError):
         rdc.build_red_keys([[(0, 2, 'ee'), (1, 3, 'ee')]])
-

--- a/hera_cal/tests/test_lstbin_simple.py
+++ b/hera_cal/tests/test_lstbin_simple.py
@@ -20,11 +20,14 @@ from functools import partial
 try:
     benchmark
 except NameError:
-    @pytest.fixture(scope='module')
+
+    @pytest.fixture(scope="module")
     def benchmark():
         def fnc(wrapped, *args, **kwargs):
             return wrapped(*args, **kwargs)
+
         return fnc
+
 
 class Test_LSTAlign:
     @classmethod
@@ -33,47 +36,55 @@ class Test_LSTAlign:
         ntimes: int = 10,
         nfreqs: int = 5,
         npols: int = 4,
-        nants: int  = 4,
+        nants: int = 4,
         ndays: int = 1,
         creator: callable = mockuvd.create_uvd_identifiable,
     ):
-
         uvds = mockuvd.make_dataset(
             ndays=ndays,
             nfiles=1,
             creator=creator,
-            pols=('xx', 'yy', 'xy', 'yx')[:npols],
-            freqs = np.linspace(100e6, 200e6, nfreqs),
-            ants = np.arange(nants),
+            pols=("xx", "yy", "xy", "yx")[:npols],
+            freqs=np.linspace(100e6, 200e6, nfreqs),
+            ants=np.arange(nants),
             ntimes=ntimes,
             time_axis_faster_than_bls=False,
         )
         uvds = [uvd[0] for uvd in uvds]  # flatten to single list
 
-        data = np.concatenate([uvd.data_array.reshape((ntimes, -1, nfreqs, npols)) for uvd in uvds], axis=0)
+        data = np.concatenate(
+            [uvd.data_array.reshape((ntimes, -1, nfreqs, npols)) for uvd in uvds],
+            axis=0,
+        )
         freq_array = uvds[0].freq_array
-        data_lsts = np.concatenate([np.unique(uvds[0].lst_array),]*len(uvds))
+        data_lsts = np.concatenate(
+            [
+                np.unique(uvds[0].lst_array),
+            ]
+            * len(uvds)
+        )
         antpairs = uvds[0].get_antpairs()
         antpos = uvds[0].antenna_positions
 
         # Ensure that each LST is in its own bin
         lsts = np.sort(np.unique(data_lsts))
 
-        lst_bin_edges = np.concatenate((
-            [lsts[0] - (lsts[1] - lsts[0])/2],
-            (lsts[1:] + lsts[:-1])/2,
-            [lsts[-1] + (lsts[-1] - lsts[-2])/2]
-        ))
+        lst_bin_edges = np.concatenate(
+            (
+                [lsts[0] - (lsts[1] - lsts[0]) / 2],
+                (lsts[1:] + lsts[:-1]) / 2,
+                [lsts[-1] + (lsts[-1] - lsts[-2]) / 2],
+            )
+        )
 
         return dict(
-            data = data,
-            data_lsts = data_lsts,
+            data=data,
+            data_lsts=data_lsts,
             antpairs=antpairs,
             lst_bin_edges=lst_bin_edges,
             freq_array=freq_array,
             antpos=antpos,
         )
-
 
     def test_bad_inputs(self):
         # Test that we get the right errors for bad inputs
@@ -82,12 +93,12 @@ class Test_LSTAlign:
         def lst_align_with(**kw):
             return lstbin_simple.lst_align(**{**kwargs, **kw})
 
-        data = np.ones(kwargs['data'].shape[:-1] + (5,))
+        data = np.ones(kwargs["data"].shape[:-1] + (5,))
         with pytest.raises(ValueError, match="data has more than 4 pols"):
             lst_align_with(data=data)
 
         with pytest.raises(ValueError, match="data should have shape"):
-            lst_align_with(freq_array=kwargs['freq_array'][:-1])
+            lst_align_with(freq_array=kwargs["freq_array"][:-1])
 
         with pytest.raises(ValueError, match="flags should have shape"):
             lst_align_with(flags=np.ones(13, dtype=bool))
@@ -97,11 +108,15 @@ class Test_LSTAlign:
             lst_align_with(nsamples=np.ones(13))
 
         # Use only one bin edge
-        with pytest.raises(ValueError, match="lst_bin_edges must have at least 2 elements"):
+        with pytest.raises(
+            ValueError, match="lst_bin_edges must have at least 2 elements"
+        ):
             lst_align_with(lst_bin_edges=np.ones(1))
 
         # Try rephasing without freq_array or antpos
-        with pytest.raises(ValueError, match="freq_array and antpos is needed for rephase"):
+        with pytest.raises(
+            ValueError, match="freq_array and antpos is needed for rephase"
+        ):
             lst_align_with(rephase=True, antpos=None)
 
     def test_increasing_lsts_one_per_bin(self, benchmark):
@@ -113,7 +128,7 @@ class Test_LSTAlign:
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d, kwargs['data'])
+        np.testing.assert_allclose(d, kwargs["data"])
         assert not np.any(f)
         assert np.all(n == 1.0)
         assert len(bins) == 6
@@ -127,7 +142,7 @@ class Test_LSTAlign:
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs['data'][:7])
+        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
         assert not np.any(f)
         assert np.all(n == 1.0)
         assert len(bins) == 7
@@ -136,17 +151,19 @@ class Test_LSTAlign:
         kwargs = self.get_lst_align_data(ndays=2, ntimes=7)
 
         # Flag everything after the first day, and make the data there crazy.
-        flags = np.zeros_like(kwargs['data'], dtype=bool)
+        flags = np.zeros_like(kwargs["data"], dtype=bool)
         flags[7:] = True
-        kwargs['data'][7:] = 1000.0
+        kwargs["data"][7:] = 1000.0
 
-        bins, d, f, n, inp = benchmark(lstbin_simple.lst_align, rephase=False, flags=flags, **kwargs)
+        bins, d, f, n, inp = benchmark(
+            lstbin_simple.lst_align, rephase=False, flags=flags, **kwargs
+        )
 
         d = np.squeeze(np.asarray(d))
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs['data'][:7])
+        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
         assert not np.any(f[:, 0])
         assert np.all(f[:, 1])
         assert len(bins) == 7
@@ -155,28 +172,31 @@ class Test_LSTAlign:
         kwargs = benchmark(self.get_lst_align_data, ndays=2, ntimes=7)
 
         # Flag everything after the first day, and make the data there crazy.
-        nsamples = np.ones_like(kwargs['data'], dtype=float)
+        nsamples = np.ones_like(kwargs["data"], dtype=float)
         nsamples[7:] = 0.0
-        kwargs['data'][7:] = 1000.0
+        kwargs["data"][7:] = 1000.0
 
-        bins, d, f, n, inp = lstbin_simple.lst_align(rephase=False, nsamples=nsamples, **kwargs)
+        bins, d, f, n, inp = lstbin_simple.lst_align(
+            rephase=False, nsamples=nsamples, **kwargs
+        )
 
         d = np.squeeze(np.asarray(d))
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs['data'][:7])
+        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
         assert not np.any(f)
         assert np.all(n[:, 0] == 1.0)
         assert np.all(n[:, 1] == 0.0)
         assert len(bins) == 7
 
-
     def test_rephase(self, benchmark):
         """Test that rephasing where each bin is already at center does nothing."""
         kwargs = self.get_lst_align_data(ntimes=7)
 
-        bins0, d0, f0, n0, inp = benchmark(lstbin_simple.lst_align, rephase=True, **kwargs)
+        bins0, d0, f0, n0, inp = benchmark(
+            lstbin_simple.lst_align, rephase=True, **kwargs
+        )
         bins, d, f, n, inp = lstbin_simple.lst_align(rephase=False, **kwargs)
         np.testing.assert_allclose(d, d0, rtol=1e-6)
         np.testing.assert_allclose(f, f0, rtol=1e-6)
@@ -184,42 +204,57 @@ class Test_LSTAlign:
         assert len(bins) == len(bins0)
 
     def test_lstbinedges_modulus(self, benchmark):
-
         kwargs = self.get_lst_align_data(ntimes=7)
         edges = kwargs.pop("lst_bin_edges")
 
         lst_bin_edges = edges.copy()
-        lst_bin_edges -= 4*np.pi
+        lst_bin_edges -= 4 * np.pi
 
-        bins, d0, f0, n0, inp = benchmark(lstbin_simple.lst_align, lst_bin_edges=lst_bin_edges, **kwargs)
+        bins, d0, f0, n0, inp = benchmark(
+            lstbin_simple.lst_align, lst_bin_edges=lst_bin_edges, **kwargs
+        )
 
         lst_bin_edges = edges.copy()
-        lst_bin_edges += 4*np.pi
+        lst_bin_edges += 4 * np.pi
 
-        bins, d, f, n, inp = lstbin_simple.lst_align(lst_bin_edges=lst_bin_edges, **kwargs)
+        bins, d, f, n, inp = lstbin_simple.lst_align(
+            lst_bin_edges=lst_bin_edges, **kwargs
+        )
 
         np.testing.assert_allclose(d, d0)
         np.testing.assert_allclose(f, f0)
         np.testing.assert_allclose(n, n0)
 
-        with pytest.raises(ValueError, match="lst_bin_edges must be monotonically increasing."):
+        with pytest.raises(
+            ValueError, match="lst_bin_edges must be monotonically increasing."
+        ):
             lstbin_simple.lst_align(lst_bin_edges=lst_bin_edges[::-1], **kwargs)
+
 
 def test_argparser_returns():
     args = lstbin_simple.lst_bin_arg_parser()
     assert args is not None
 
+
 class Test_ReduceLSTBins:
     @classmethod
     def get_input_data(
-        cls,
-        nfreqs: int=3, npols: int = 1, nbls: int = 6, ntimes: tuple[int] = (4, )
+        cls, nfreqs: int = 3, npols: int = 1, nbls: int = 6, ntimes: tuple[int] = (4,)
     ):
         data = np.random.random((nbls, nfreqs, npols))
 
         # Make len(ntimes) LST bins, each with ntimes[i] time-entries, all the same
         # data.
-        data = [np.array([data, ]*nt).reshape((nt,) + data.shape)*(i+1) for i, nt in enumerate(ntimes)]
+        data = [
+            np.array(
+                [
+                    data,
+                ]
+                * nt
+            ).reshape((nt,) + data.shape)
+            * (i + 1)
+            for i, nt in enumerate(ntimes)
+        ]
         flags = [np.zeros(d.shape, dtype=bool) for d in data]
         nsamples = [np.ones(d.shape, dtype=float) for d in data]
 
@@ -227,14 +262,19 @@ class Test_ReduceLSTBins:
 
     def test_one_point_per_bin(self, benchmark):
         d, f, n = self.get_input_data(ntimes=(1,))
-        rdc= benchmark(lstbin_simple.reduce_lst_bins, d, f, n)
+        rdc = benchmark(lstbin_simple.reduce_lst_bins, d, f, n)
 
-        assert rdc['data'].shape == rdc['flags'].shape == rdc['std'].shape == rdc['nsamples'].shape
+        assert (
+            rdc["data"].shape
+            == rdc["flags"].shape
+            == rdc["std"].shape
+            == rdc["nsamples"].shape
+        )
 
         # reduce_data swaps the order of bls/times
-        dd = rdc['data'].swapaxes(0, 1)
-        ff = rdc['flags'].swapaxes(0, 1)
-        nn = rdc['nsamples'].swapaxes(0, 1)
+        dd = rdc["data"].swapaxes(0, 1)
+        ff = rdc["flags"].swapaxes(0, 1)
+        nn = rdc["nsamples"].swapaxes(0, 1)
 
         np.testing.assert_allclose(dd[0], d[0][0])
         assert not np.any(ff)
@@ -245,22 +285,27 @@ class Test_ReduceLSTBins:
         print(d[0].shape, len(d))
         rdc = lstbin_simple.reduce_lst_bins(d, f, n)
 
-        assert rdc['data'].shape[1] == 2  # 2 LST bins
-        assert np.all(np.isnan(rdc['data'][:, 0]))
-        assert np.all(rdc['flags'][:, 0])
-        assert np.all(rdc['nsamples'][:, 0] == 0.0)
+        assert rdc["data"].shape[1] == 2  # 2 LST bins
+        assert np.all(np.isnan(rdc["data"][:, 0]))
+        assert np.all(rdc["flags"][:, 0])
+        assert np.all(rdc["nsamples"][:, 0] == 0.0)
 
-    @pytest.mark.parametrize("ntimes", [(4, ), (5, 4)])
+    @pytest.mark.parametrize("ntimes", [(4,), (5, 4)])
     def test_multi_points_per_bin(self, ntimes, benchmark):
         d, f, n = self.get_input_data(ntimes=ntimes)
         rdc = benchmark(lstbin_simple.reduce_lst_bins, d, f, n)
 
-        assert rdc['data'].shape == rdc['flags'].shape == rdc['std'].shape == rdc['nsamples'].shape
+        assert (
+            rdc["data"].shape
+            == rdc["flags"].shape
+            == rdc["std"].shape
+            == rdc["nsamples"].shape
+        )
 
         # reduce_data swaps the order of bls/times
-        dd = rdc['data'].swapaxes(0, 1)
-        ff = rdc['flags'].swapaxes(0, 1)
-        nn = rdc['nsamples'].swapaxes(0, 1)
+        dd = rdc["data"].swapaxes(0, 1)
+        ff = rdc["flags"].swapaxes(0, 1)
+        nn = rdc["nsamples"].swapaxes(0, 1)
 
         assert not np.any(ff)
         for lst in range(len(ntimes)):
@@ -271,15 +316,19 @@ class Test_ReduceLSTBins:
         d, f, n = self.get_input_data(ntimes=(4,))
         f[0][2:] = True
         d[0][2:] = 1000.0
-        rdc = lstbin_simple.reduce_lst_bins(d,f,n)
+        rdc = lstbin_simple.reduce_lst_bins(d, f, n)
 
-        assert rdc['data'].shape == rdc['flags'].shape == rdc['std'].shape == rdc['nsamples'].shape
+        assert (
+            rdc["data"].shape
+            == rdc["flags"].shape
+            == rdc["std"].shape
+            == rdc["nsamples"].shape
+        )
 
         # reduce_data swaps the order of bls/times
-        dd = rdc['data'].swapaxes(0, 1)
-        ff = rdc['flags'].swapaxes(0, 1)
-        nn = rdc['nsamples'].swapaxes(0, 1)
-
+        dd = rdc["data"].swapaxes(0, 1)
+        ff = rdc["flags"].swapaxes(0, 1)
+        nn = rdc["nsamples"].swapaxes(0, 1)
 
         np.testing.assert_allclose(dd[0], d[0][0])
         assert not np.any(ff)
@@ -289,7 +338,8 @@ class Test_ReduceLSTBins:
         d, f, n = self.get_input_data(ntimes=(4,))
         rdc = lstbin_simple.reduce_lst_bins(d, f, n, get_mad=True)
 
-        assert np.all(rdc['median'] == rdc['data'])
+        assert np.all(rdc["median"] == rdc["data"])
+
 
 def test_apply_calfile_rules(tmpdir_factory):
     direc = tmpdir_factory.mktemp("test_apply_calfile_rules")
@@ -304,8 +354,8 @@ def test_apply_calfile_rules(tmpdir_factory):
 
     data_files, calfiles = lstbin_simple.apply_calfile_rules(
         [[str(d) for d in datas]],
-        calfile_rules = [('.uvh5', '.calfile')],
-        ignore_missing=False
+        calfile_rules=[(".uvh5", ".calfile")],
+        ignore_missing=False,
     )
     assert len(data_files[0]) == 3
     assert len(calfiles[0]) == 3
@@ -314,29 +364,28 @@ def test_apply_calfile_rules(tmpdir_factory):
     with pytest.raises(IOError, match="does not exist"):
         lstbin_simple.apply_calfile_rules(
             [[str(d) for d in datas]],
-            calfile_rules = [('.uvh5', '.calfile')],
-            ignore_missing=False
+            calfile_rules=[(".uvh5", ".calfile")],
+            ignore_missing=False,
         )
 
     data_files, calfiles = lstbin_simple.apply_calfile_rules(
         [[str(d) for d in datas]],
-        calfile_rules = [('.uvh5', '.calfile')],
-        ignore_missing=True
+        calfile_rules=[(".uvh5", ".calfile")],
+        ignore_missing=True,
     )
     assert len(data_files[0]) == 2
     assert len(calfiles[0]) == 2
 
 
 class Test_LSTAverage:
-
     def test_sigma_clip_without_outliers(self, benchmark):
-        shape = (7,8,9)
+        shape = (7, 8, 9)
         np.random.seed(42)
-        data = np.random.normal(size=shape) + np.random.normal(size=shape)*1j
+        data = np.random.normal(size=shape) + np.random.normal(size=shape) * 1j
         nsamples = np.ones_like(data)
         flags = np.zeros_like(data, dtype=bool)
 
-        data_n, flg_n, std_n, norm_n, daysbinned =lstbin_simple.lst_average(
+        data_n, flg_n, std_n, norm_n, daysbinned = lstbin_simple.lst_average(
             data=data,
             nsamples=nsamples,
             flags=flags,
@@ -352,18 +401,20 @@ class Test_LSTAverage:
         )
 
         assert data.shape == flg.shape == std.shape == norm.shape == nsamples.shape[1:]
-        np.testing.assert_allclose(data,data_n)
+        np.testing.assert_allclose(data, data_n)
 
     def test_average_repeated(self):
-        shape = (7,8,9)
-        _data = np.random.random(shape) + np.random.random(shape)*1j
+        shape = (7, 8, 9)
+        _data = np.random.random(shape) + np.random.random(shape) * 1j
 
         data = np.array([_data, _data, _data])
         nsamples = np.ones_like(data)
         flags = np.zeros_like(data, dtype=bool)
 
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=data, nsamples=nsamples, flags=flags,
+            data=data,
+            nsamples=nsamples,
+            flags=flags,
         )
 
         assert np.allclose(data_n, _data)
@@ -374,7 +425,9 @@ class Test_LSTAverage:
         # Now flag the last "night"
         flags[-1] = True
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=data, nsamples=nsamples, flags=flags,
+            data=data,
+            nsamples=nsamples,
+            flags=flags,
         )
 
         assert np.allclose(data_n, _data)
@@ -386,19 +439,24 @@ class Test_LSTAverage:
         shape = (5000, 1, 2, 2)  # 1000 nights, doesn't matter what the other axis is.
 
         std = 2.0
-        data = np.random.normal(scale=std, size=shape) + np.random.normal(scale=std, size=shape)*1j
+        data = (
+            np.random.normal(scale=std, size=shape)
+            + np.random.normal(scale=std, size=shape) * 1j
+        )
         nsamples = np.ones_like(data, dtype=float)
         flags = np.zeros_like(data, dtype=bool)
 
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=data, nsamples=nsamples, flags=flags,
+            data=data,
+            nsamples=nsamples,
+            flags=flags,
         )
 
         # Check the averaged data is within 6 sigma of the population mean
-        np.testing.assert_allclose(data_n, 0.0, atol=std*6/np.sqrt(shape[0]))
+        np.testing.assert_allclose(data_n, 0.0, atol=std * 6 / np.sqrt(shape[0]))
 
         # Check the standard deviation is within 20% of the true value
-        np.testing.assert_allclose(std_n, std + std*1j, rtol=0.2)
+        np.testing.assert_allclose(std_n, std + std * 1j, rtol=0.2)
 
         assert not np.any(flg_n)
 
@@ -420,16 +478,18 @@ class Test_LSTAverage:
         else:
             flags = np.random.random(shape) > 0.1
 
-        data = np.random.normal(scale=std) + np.random.normal(scale=std)*1j
+        data = np.random.normal(scale=std) + np.random.normal(scale=std) * 1j
 
         flags = np.zeros(data.shape, dtype=bool)
 
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=data, nsamples=nsamples, flags=flags,
+            data=data,
+            nsamples=nsamples,
+            flags=flags,
         )
 
         # Check the averaged data is within 6 sigma of the population mean
-        assert np.allclose(data_n, 0.0, atol=std*6/np.sqrt(shape[0]))
+        assert np.allclose(data_n, 0.0, atol=std * 6 / np.sqrt(shape[0]))
 
         # In reality the std is infinity where flags is True
         std[flags] = np.inf
@@ -437,13 +497,13 @@ class Test_LSTAverage:
 
         sample_var_expectation = sve = w * (shape[0] - 1)
         # Check the standard deviation is within 20% of the true value
-        np.testing.assert_allclose(std_n, np.sqrt(sve) + np.sqrt(sve)*1j, rtol=0.2)
+        np.testing.assert_allclose(std_n, np.sqrt(sve) + np.sqrt(sve) * 1j, rtol=0.2)
 
         assert not np.any(flg_n)
 
     def test_inpaint_mode(self):
-        shape = (3,2,4, 1)  # nights, bls, freqs, pols
-        _data = np.random.random(shape) + np.random.random(shape)*1j
+        shape = (3, 2, 4, 1)  # nights, bls, freqs, pols
+        _data = np.random.random(shape) + np.random.random(shape) * 1j
         nsamples = np.ones(_data.shape, dtype=float)
         flags = np.zeros(_data.shape, dtype=bool)
 
@@ -462,7 +522,6 @@ class Test_LSTAverage:
         assert np.allclose(nf, ni)
         assert np.allclose(dbf, dbi)
 
-
         # Now test with a whole LST bin flagged for a single bl-chan-pol (but inpainted)
         flags[:, 0, 0, 0] = True
         df, ff, stdf, nf, dbf = lstbin_simple.lst_average(
@@ -475,10 +534,10 @@ class Test_LSTAverage:
 
         # The data and std in the fully-flagged bin should be different, but Nsamples
         # and Flags should be the same.
-        assert not np.allclose(df[0,0,0], di[0,0,0])
+        assert not np.allclose(df[0, 0, 0], di[0, 0, 0])
         assert np.allclose(df[1:], di[1:])
         assert np.allclose(ff, fi)
-        assert not np.allclose(stdf[0,0,0], stdi[0,0,0])
+        assert not np.allclose(stdf[0, 0, 0], stdi[0, 0, 0])
         assert np.allclose(stdf[1:], stdi[1:])
         assert np.allclose(nf, ni)
         assert np.allclose(dbf, dbi)
@@ -501,125 +560,146 @@ class Test_LSTAverage:
         np.testing.assert_allclose(stdf, stdi)
         assert np.allclose(nf, ni)
         assert np.allclose(dbf, dbi)
-        
+
         # However, if we had explicitly told the routine that the blt was inpainted,
         # we'd get a different result...
-        _d, _f = lstbin_simple.get_masked_data(_data, nsamples, flags, inpainted=np.ones_like(flags),inpainted_mode=False)
+        _d, _f = lstbin_simple.get_masked_data(
+            _data, nsamples, flags, inpainted=np.ones_like(flags), inpainted_mode=False
+        )
         df, ff, stdf, nf, dbf = lstbin_simple.lst_average(
-            data=_d, nsamples=nsamples, flags=_f, inpainted_mode=False,
+            data=_d,
+            nsamples=nsamples,
+            flags=_f,
+            inpainted_mode=False,
         )
 
-        _d, _f = lstbin_simple.get_masked_data(_data, nsamples, flags, inpainted=np.ones_like(flags),inpainted_mode=True)
+        _d, _f = lstbin_simple.get_masked_data(
+            _data, nsamples, flags, inpainted=np.ones_like(flags), inpainted_mode=True
+        )
         di, fi, stdi, ni, dbi = lstbin_simple.lst_average(
-            data=_d, nsamples=nsamples, flags=_f, inpainted_mode=True,
+            data=_d,
+            nsamples=nsamples,
+            flags=_f,
+            inpainted_mode=True,
         )
 
         # The LST-binned data will be different for blt=0, pol=0:
-        assert not np.allclose(df[0,:,0], di[0,:,0])
+        assert not np.allclose(df[0, :, 0], di[0, :, 0])
         assert np.allclose(df[1:], di[1:])
         assert np.allclose(ff, fi)
-        assert not np.allclose(stdf[0,:,0], stdi[0,:,0])
+        assert not np.allclose(stdf[0, :, 0], stdi[0, :, 0])
         assert np.allclose(stdf[1:], stdi[1:])
         assert np.allclose(nf, ni)
         assert np.allclose(dbf, dbi)
 
-        
-
-
     def test_flag_below_min_N(self):
-        shape = (7,8,9, 2)
-        _data = np.random.random(shape) + np.random.random(shape)*1j
+        shape = (7, 8, 9, 2)
+        _data = np.random.random(shape) + np.random.random(shape) * 1j
         nsamples = np.ones(_data.shape, dtype=float)
         flags = np.zeros(_data.shape, dtype=bool)
 
         # No samples have more than min_N, so they should all be flagged.
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=_data, nsamples=nsamples, flags=flags, sigma_clip_min_N=8,
-            flag_below_min_N=True
+            data=_data,
+            nsamples=nsamples,
+            flags=flags,
+            sigma_clip_min_N=8,
+            flag_below_min_N=True,
         )
 
         assert np.all(flg_n)
-        assert np.all(norm_n==7)  # Even though they're flagged, we track the nsamples
+        assert np.all(norm_n == 7)  # Even though they're flagged, we track the nsamples
         assert not np.all(np.isinf(std_n))
         assert not np.all(np.isnan(data_n))
 
         # this time, there's enough samples, but too many are flagged...
         flags[:5] = True
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=_data, nsamples=nsamples, flags=flags, sigma_clip_min_N=5,
-            flag_below_min_N=True
+            data=_data,
+            nsamples=nsamples,
+            flags=flags,
+            sigma_clip_min_N=5,
+            flag_below_min_N=True,
         )
 
         assert np.all(flg_n)
         # just because we're flagging it, doesn't mean we need to set nsamples=0
         # or the std to inf. We have info there, we're just choosing not to use it.
-        assert np.all(norm_n==2)
+        assert np.all(norm_n == 2)
         assert not np.any(np.isinf(std_n))
-        
+
         # this time, only one column is flagged too much...
         # this time, there's enough samples, but too many are flagged...
         flags[:] = False
         flags[:5, 0] = True
         data_n, flg_n, std_n, norm_n, db = lstbin_simple.lst_average(
-            data=_data, nsamples=nsamples, flags=flags, sigma_clip_min_N=5,
-            flag_below_min_N=True
+            data=_data,
+            nsamples=nsamples,
+            flags=flags,
+            sigma_clip_min_N=5,
+            flag_below_min_N=True,
         )
 
         assert np.all(flg_n[0])
-        assert np.all(norm_n[0]==2)
+        assert np.all(norm_n[0] == 2)
         assert not np.any(np.isinf(std_n[0]))
 
         print(np.sum(flg_n[1:]), flg_n[1:].size)
         assert not np.any(flg_n[1:])
-        assert np.all(norm_n[1:]==7)
+        assert np.all(norm_n[1:] == 7)
         assert not np.any(np.isinf(std_n[1:]))
         assert not np.any(np.isnan(data_n[1:]))
-        
+
 
 def create_small_array_uvd(identifiable: bool = False, **kwargs):
     kwargs.update(
         freqs=np.linspace(150e6, 160e6, 100),
-        ants=[0,1,2,127,128],
-        antpairs=[(0,0), (0,1), (0,2), (1, 1), (1,2), (2, 2)],
-        pols=('xx', 'yy')
+        ants=[0, 1, 2, 127, 128],
+        antpairs=[(0, 0), (0, 1), (0, 2), (1, 1), (1, 2), (2, 2)],
+        pols=("xx", "yy"),
     )
     if identifiable:
         return mockuvd.create_uvd_identifiable(**kwargs)
     else:
         return mockuvd.create_uvd_ones(**kwargs)
 
+
 @pytest.fixture(scope="function")
 def uvd():
     return create_small_array_uvd()
+
 
 @pytest.fixture(scope="function")
 def uvd_redavg():
     return create_small_array_uvd(redundantly_averaged=True)
 
+
 @pytest.fixture(scope="function")
 def uvc(uvd):
     return UVCal.initialize_from_uvdata(
         uvd,
-        cal_style = "redundant",
-        gain_convention = "multiply",
-        jones_array = "linear",
-        cal_type = "gain",
+        cal_style="redundant",
+        gain_convention="multiply",
+        jones_array="linear",
+        cal_type="gain",
         metadata_only=False,
     )
+
 
 @pytest.fixture(scope="function")
 def uvd_file(uvd, tmpdir_factory) -> Path:
     # Write to file, so we can run lst_bin_files
     tmp = Path(tmpdir_factory.mktemp("test_partial_times"))
-    mock = tmp / 'mock.uvh5'
+    mock = tmp / "mock.uvh5"
     uvd.write_uvh5(str(mock), clobber=True)
     return mock
+
 
 @pytest.fixture(scope="function")
 def uvd_redavg_file(uvd_redavg, tmpdir_factory) -> Path:
     # Write to file, so we can run lst_bin_files
     tmp = Path(tmpdir_factory.mktemp("test_partial_times"))
-    mock = tmp / 'mock.uvh5'
+    mock = tmp / "mock.uvh5"
     uvd_redavg.write_uvh5(str(mock), clobber=True)
     return mock
 
@@ -628,29 +708,30 @@ def uvd_redavg_file(uvd_redavg, tmpdir_factory) -> Path:
 def uvc_file(uvc, uvd_file: Path) -> Path:
     # Write to file, so we can run lst_bin_files
     tmp = uvd_file.parent
-    fl = f'{tmp}/mock.calfits'
+    fl = f"{tmp}/mock.calfits"
     uvc.write_calfits(str(fl), clobber=True)
     return fl
+
 
 class Test_LSTBinFilesForBaselines:
     def test_defaults(self, uvd, uvd_file):
         lstbins, d0, f0, n0, inpflg, times0 = lstbin_simple.lst_bin_files_for_baselines(
             data_files=[uvd_file],
-            lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()+0.01],
+            lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max() + 0.01],
             antpairs=uvd.get_antpairs(),
-            rephase=False
+            rephase=False,
         )
 
         lstbins, d, f, n, inpflg, times = lstbin_simple.lst_bin_files_for_baselines(
             data_files=[uvd_file],
-            lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()+0.01],
+            lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max() + 0.01],
             antpairs=uvd.get_antpairs(),
             freqs=uvd.freq_array,
             pols=uvd.polarization_array,
-            time_idx = [np.ones(uvd.Ntimes, dtype=bool)],
+            time_idx=[np.ones(uvd.Ntimes, dtype=bool)],
             time_arrays=[np.unique(uvd.time_array)],
-            lsts = np.unique(uvd.lst_array),
-            rephase=False
+            lsts=np.unique(uvd.lst_array),
+            rephase=False,
         )
 
         np.testing.assert_allclose(d0, d)
@@ -663,7 +744,7 @@ class Test_LSTBinFilesForBaselines:
             data_files=[uvd_file],
             lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
             antpairs=[(127, 128)],
-            rephase=True
+            rephase=True,
         )
 
         assert np.all(f0)
@@ -674,17 +755,26 @@ class Test_LSTBinFilesForBaselines:
             data_files=[uvd_file],
             lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
             antpairs=uvd.get_antpairs() + [(127, 128)],
-            rephase=True
+            rephase=True,
         )
 
-        assert np.all(f0[0][:, -1])  # last baseline is the extra one that's all flagged.
+        assert np.all(
+            f0[0][:, -1]
+        )  # last baseline is the extra one that's all flagged.
 
     def test_freqrange(self, uvd, uvd_file, uvc_file):
         """Test that providing freq_range works."""
-        bins, data, flags, nsamples,  inpflg, times = lstbin_simple.lst_bin_files_for_baselines(
+        (
+            bins,
+            data,
+            flags,
+            nsamples,
+            inpflg,
+            times,
+        ) = lstbin_simple.lst_bin_files_for_baselines(
             data_files=[uvd_file],
             lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
-            cal_files = [uvc_file],
+            cal_files=[uvc_file],
             freq_min=153e6,
             freq_max=158e6,
             antpairs=uvd.get_antpairs(),
@@ -693,7 +783,7 @@ class Test_LSTBinFilesForBaselines:
         assert data[0].shape[-2] < uvd.Nfreqs
 
     def test_bad_pols(self, uvd, uvd_file):
-        with pytest.raises(KeyError, match='7'):
+        with pytest.raises(KeyError, match="7"):
             lstbin_simple.lst_bin_files_for_baselines(
                 data_files=[uvd_file],
                 lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
@@ -702,7 +792,9 @@ class Test_LSTBinFilesForBaselines:
             )
 
     def test_incorrect_red_input(self, uvd, uvd_file, uvc_file):
-        with pytest.raises(ValueError, match='reds must be provided if redundantly_averaged is True'):
+        with pytest.raises(
+            ValueError, match="reds must be provided if redundantly_averaged is True"
+        ):
             lstbin_simple.lst_bin_files_for_baselines(
                 data_files=[uvd_file],
                 lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
@@ -710,7 +802,9 @@ class Test_LSTBinFilesForBaselines:
                 antpairs=uvd.get_antpairs(),
             )
 
-        with pytest.raises(ValueError, match="Cannot apply calibration if redundantly_averaged is True"):
+        with pytest.raises(
+            ValueError, match="Cannot apply calibration if redundantly_averaged is True"
+        ):
             lstbin_simple.lst_bin_files_for_baselines(
                 data_files=[uvd_file],
                 lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
@@ -718,7 +812,9 @@ class Test_LSTBinFilesForBaselines:
                 redundantly_averaged=True,
                 reds=RedundantGroups.from_antpos(
                     dict(zip(uvd.antenna_numbers, uvd.antenna_positions)),
-                    pols=uvutils.polnum2str(uvd.polarization_array, x_orientation=uvd.x_orientation),
+                    pols=uvutils.polnum2str(
+                        uvd.polarization_array, x_orientation=uvd.x_orientation
+                    ),
                 ),
                 antpairs=uvd.get_antpairs(),
             )
@@ -726,7 +822,10 @@ class Test_LSTBinFilesForBaselines:
     def test_simple_redundant_averaged_file(self, uvd_redavg, uvd_redavg_file):
         lstbins, d0, f0, n0, inpflg, times0 = lstbin_simple.lst_bin_files_for_baselines(
             data_files=[uvd_redavg_file],
-            lst_bin_edges=[uvd_redavg.lst_array.min()-0.1, uvd_redavg.lst_array.max()+0.1],
+            lst_bin_edges=[
+                uvd_redavg.lst_array.min() - 0.1,
+                uvd_redavg.lst_array.max() + 0.1,
+            ],
             redundantly_averaged=True,
             rephase=False,
             antpairs=uvd_redavg.get_antpairs(),
@@ -736,7 +835,13 @@ class Test_LSTBinFilesForBaselines:
         )
 
         assert len(d0) == 1
-        assert d0[0].shape == (uvd_redavg.Ntimes, uvd_redavg.Nbls, uvd_redavg.Nfreqs, uvd_redavg.Npols)
+        assert d0[0].shape == (
+            uvd_redavg.Ntimes,
+            uvd_redavg.Nbls,
+            uvd_redavg.Nfreqs,
+            uvd_redavg.Npols,
+        )
+
 
 def test_make_lst_grid():
     lst_grid = lstbin_simple.make_lst_grid(0.01, begin_lst=None)
@@ -749,10 +854,13 @@ def test_make_lst_grid():
     assert len(lst_grid) == 628
     assert np.isclose(lst_grid[0], 3.1365901175171982)
 
+
 class Test_GetAllUnflaggedBaselines:
     @pytest.mark.parametrize("redundantly_averaged", [True, False])
     @pytest.mark.parametrize("only_last_file_per_night", [True, False])
-    def test_get_all_baselines(self, tmp_path_factory, redundantly_averaged, only_last_file_per_night):
+    def test_get_all_baselines(
+        self, tmp_path_factory, redundantly_averaged, only_last_file_per_night
+    ):
         tmp = tmp_path_factory.mktemp("get_all_baselines")
         uvds = mockuvd.make_dataset(
             ndays=3,
@@ -784,13 +892,19 @@ class Test_GetAllUnflaggedBaselines:
         )
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
 
-        with pytest.raises(ValueError, match='Cannot ignore antennas if the files are redundantly averaged'):
+        with pytest.raises(
+            ValueError,
+            match="Cannot ignore antennas if the files are redundantly averaged",
+        ):
             lstbin_simple.get_all_unflagged_baselines(data_files, ignore_ants=[0, 1])
 
-        with pytest.raises(ValueError, match='Cannot exclude antennas if the files are redundantly averaged'):
+        with pytest.raises(
+            ValueError,
+            match="Cannot exclude antennas if the files are redundantly averaged",
+        ):
             lstbin_simple.get_all_unflagged_baselines(
                 data_files,
-                ex_ant_yaml_files=['non-existent-file.yaml'],
+                ex_ant_yaml_files=["non-existent-file.yaml"],
             )
 
         uvds_different_xorient = mockuvd.make_dataset(
@@ -799,47 +913,58 @@ class Test_GetAllUnflaggedBaselines:
             ntimes=2,
             ants=np.arange(10),
             creator=create_small_array_uvd,
-            x_orientation='east',
+            x_orientation="east",
             redundantly_averaged=True,
         )
 
-        data_files = mockuvd.write_files_in_hera_format(uvds + uvds_different_xorient, tmp)
+        data_files = mockuvd.write_files_in_hera_format(
+            uvds + uvds_different_xorient, tmp
+        )
 
-        with pytest.raises(ValueError, match='Not all files have the same xorientation!'):
+        with pytest.raises(
+            ValueError, match="Not all files have the same xorientation!"
+        ):
             lstbin_simple.get_all_unflagged_baselines(data_files)
+
 
 class Test_LSTBinFiles:
     def test_golden_data(self, tmp_path_factory):
         tmp = tmp_path_factory.mktemp("lstbin_golden_data")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=4, ntimes=2, identifiable=True,
-            creator=create_small_array_uvd, time_axis_faster_than_bls=True
+            ndays=3,
+            nfiles=4,
+            ntimes=2,
+            identifiable=True,
+            creator=create_small_array_uvd,
+            time_axis_faster_than_bls=True,
         )
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
         print(len(uvds))
         cfl = tmp / "lstbin_config_file.yaml"
         print(cfl)
         lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
         )
 
         out_files = lstbin_simple.lst_bin_files(
-            config_file=cfl, rephase=False,
-            golden_lsts=uvds[0][1].lst_array.min() + 0.0001
+            config_file=cfl,
+            rephase=False,
+            golden_lsts=uvds[0][1].lst_array.min() + 0.0001,
         )
 
         assert len(out_files) == 4
-        assert out_files[1]['GOLDEN']
+        assert out_files[1]["GOLDEN"]
         assert not out_files[0]["GOLDEN"]
         assert not out_files[2]["GOLDEN"]
         assert not out_files[3]["GOLDEN"]
 
         uvd = UVData()
-        uvd.read(out_files[1]['GOLDEN'])
-
+        uvd.read(out_files[1]["GOLDEN"])
 
         # Read the Golden File
-        golden_hd = io.HERAData(out_files[1]['GOLDEN'])
+        golden_hd = io.HERAData(out_files[1]["GOLDEN"])
         gd, gf, gn = golden_hd.read()
 
         assert gd.shape[0] == 3  # ndays
@@ -850,8 +975,8 @@ class Test_LSTBinFiles:
         assert len(gd.keys()) == 12
 
         # Check that autos are all the same
-        assert np.all(gd[(0,0,'ee')] == gd[(1, 1,'ee')])
-        assert np.all(gd[(0,0,'ee')] == gd[(2, 2,'ee')])
+        assert np.all(gd[(0, 0, "ee")] == gd[(1, 1, "ee")])
+        assert np.all(gd[(0, 0, "ee")] == gd[(2, 2, "ee")])
 
         # Since each day is at exactly the same LST by construction, the golden data
         # over time should be the same.
@@ -861,19 +986,26 @@ class Test_LSTBinFiles:
             for day in data:
                 np.testing.assert_allclose(data[0], day, atol=1e-6)
 
-        assert not np.allclose(gd[(0, 1, 'ee')][0], gd[(0, 2, 'ee')][0])
-        assert not np.allclose(gd[(1, 2, 'ee')][0], gd[(0, 2, 'ee')][0])
-        assert not np.allclose(gd[(1, 2, 'ee')][0], gd[(0, 1, 'ee')][0])
-
+        assert not np.allclose(gd[(0, 1, "ee")][0], gd[(0, 2, "ee")][0])
+        assert not np.allclose(gd[(1, 2, "ee")][0], gd[(0, 2, "ee")][0])
+        assert not np.allclose(gd[(1, 2, "ee")][0], gd[(0, 1, "ee")][0])
 
     def test_save_chans(self, tmp_path_factory):
         tmp = tmp_path_factory.mktemp("lstbin_golden_data")
-        uvds = mockuvd.make_dataset(ndays=3, nfiles=4, ntimes=2, identifiable=True, creator=create_small_array_uvd)
+        uvds = mockuvd.make_dataset(
+            ndays=3,
+            nfiles=4,
+            ntimes=2,
+            identifiable=True,
+            creator=create_small_array_uvd,
+        )
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
 
         cfl = tmp / "lstbin_config_file.yaml"
         lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
         )
 
         out_files = lstbin_simple.lst_bin_files(
@@ -883,10 +1015,10 @@ class Test_LSTBinFiles:
         assert len(out_files) == 4
         # Ensure there's a REDUCEDCHAN file for each output LST
         for fl in out_files:
-            assert fl['REDUCEDCHAN']
+            assert fl["REDUCEDCHAN"]
 
             # Read the Golden File
-            hd = io.HERAData(fl['REDUCEDCHAN'])
+            hd = io.HERAData(fl["REDUCEDCHAN"])
             gd, gf, gn = hd.read()
 
             assert gd.shape[0] == 3  # ndays
@@ -897,8 +1029,8 @@ class Test_LSTBinFiles:
             assert len(gd.keys()) == 12
 
             # Check that autos are all the same
-            assert np.all(gd[(0,0,'ee')] == gd[(1, 1,'ee')])
-            assert np.all(gd[(0,0,'ee')] == gd[(2, 2,'ee')])
+            assert np.all(gd[(0, 0, "ee")] == gd[(1, 1, "ee")])
+            assert np.all(gd[(0, 0, "ee")] == gd[(2, 2, "ee")])
 
             # Since each day is at exactly the same LST by construction, the golden data
             # over time should be the same.
@@ -906,92 +1038,104 @@ class Test_LSTBinFiles:
                 for day in data:
                     np.testing.assert_allclose(data[0], day, rtol=1e-6)
 
-            assert not np.allclose(gd[(0, 1, 'ee')][0], gd[(0, 2, 'ee')][0])
-            assert not np.allclose(gd[(1, 2, 'ee')][0], gd[(0, 2, 'ee')][0])
-            assert not np.allclose(gd[(1, 2, 'ee')][0], gd[(0, 1, 'ee')][0])
+            assert not np.allclose(gd[(0, 1, "ee")][0], gd[(0, 2, "ee")][0])
+            assert not np.allclose(gd[(1, 2, "ee")][0], gd[(0, 2, "ee")][0])
+            assert not np.allclose(gd[(1, 2, "ee")][0], gd[(0, 1, "ee")][0])
 
     def test_baseline_chunking(self, tmp_path_factory):
         tmp = tmp_path_factory.mktemp("baseline_chunking")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=4, ntimes=2,
+            ndays=3,
+            nfiles=4,
+            ntimes=2,
             creator=mockuvd.create_uvd_identifiable,
-            antpairs = [(i,j) for i in range(10) for j in range(i, 10)],  # 55 antpairs
-            pols = ['xx', 'yy'],
+            antpairs=[(i, j) for i in range(10) for j in range(i, 10)],  # 55 antpairs
+            pols=["xx", "yy"],
             freqs=np.linspace(140e6, 180e6, 12),
         )
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
 
         cfl = tmp / "lstbin_config_file.yaml"
         config_info = lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
         )
 
         out_files = lstbin_simple.lst_bin_files(
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}.uvh5",
-            write_med_mad=True
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}.uvh5",
+            write_med_mad=True,
         )
         out_files_chunked = lstbin_simple.lst_bin_files(
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}.chunked.uvh5",
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}.chunked.uvh5",
             Nbls_to_load=10,
-            write_med_mad=True
+            write_med_mad=True,
         )
 
         for flset, flsetc in zip(out_files, out_files_chunked):
-            assert flset[('LST', False)] != flsetc[('LST', False)]
+            assert flset[("LST", False)] != flsetc[("LST", False)]
             uvdlst = UVData()
-            uvdlst.read(flset[('LST', False)])
+            uvdlst.read(flset[("LST", False)])
 
             uvdlstc = UVData()
-            uvdlstc.read(flsetc[('LST', False)])
+            uvdlstc.read(flsetc[("LST", False)])
 
             assert uvdlst == uvdlstc
 
-            assert flset[('MED', False)] != flsetc[('MED', False)]
+            assert flset[("MED", False)] != flsetc[("MED", False)]
             uvdlst = UVData()
-            uvdlst.read(flset[('MED', False)])
+            uvdlst.read(flset[("MED", False)])
 
             uvdlstc = UVData()
-            uvdlstc.read(flsetc[('MED', False)])
+            uvdlstc.read(flsetc[("MED", False)])
 
             assert uvdlst == uvdlstc
-             
-    def test_compare_nontrivial_cal(
-        self, tmp_path_factory
-    ):
+
+    def test_compare_nontrivial_cal(self, tmp_path_factory):
         tmp = tmp_path_factory.mktemp("nontrivial_cal")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=4, ntimes=2,
+            ndays=3,
+            nfiles=4,
+            ntimes=2,
             creator=mockuvd.create_uvd_identifiable,
-            antpairs = [(i,j) for i in range(7) for j in range(i, 7)],  # 55 antpairs
-            pols = ('xx', 'yy'),
+            antpairs=[(i, j) for i in range(7) for j in range(i, 7)],  # 55 antpairs
+            pols=("xx", "yy"),
             freqs=np.linspace(140e6, 180e6, 3),
         )
-        uvcs = [
-            [mockuvd.make_uvc_identifiable(d) for d in uvd ] for uvd in uvds
-        ]
+        uvcs = [[mockuvd.make_uvc_identifiable(d) for d in uvd] for uvd in uvds]
 
         for night in uvds:
             print([np.unique(night[0].lst_array)])
 
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
         cal_files = mockuvd.write_cals_in_hera_format(uvcs, tmp)
-        decal_files = [[df.replace(".uvh5", ".decal.uvh5") for df in dfl] for dfl in data_files]
+        decal_files = [
+            [df.replace(".uvh5", ".decal.uvh5") for df in dfl] for dfl in data_files
+        ]
 
         for flist, clist, ulist in zip(data_files, cal_files, decal_files):
             for df, cf, uf in zip(flist, clist, ulist):
                 apply_cal.apply_cal(
-                    df, uf, cf,
-                    gain_convention='divide',  # go the wrong way
+                    df,
+                    uf,
+                    cf,
+                    gain_convention="divide",  # go the wrong way
                     clobber=True,
                 )
 
         # First, let's go the other way to check if we get the same thing back directly
-        recaled_files = [[df.replace(".uvh5", ".recal.uvh5") for df in dfl] for dfl in data_files]
+        recaled_files = [
+            [df.replace(".uvh5", ".recal.uvh5") for df in dfl] for dfl in data_files
+        ]
         for flist, clist, ulist in zip(recaled_files, cal_files, decal_files):
             for df, cf, uf in zip(flist, clist, ulist):
                 apply_cal.apply_cal(
-                    uf, df, cf,
-                    gain_convention='multiply',  # go the wrong way
+                    uf,
+                    df,
+                    cf,
+                    gain_convention="multiply",  # go the wrong way
                     clobber=True,
                 )
 
@@ -1006,32 +1150,39 @@ class Test_LSTBinFiles:
 
         cfl = tmp / "lstbin_config_file.yaml"
         lstbin_simple.make_lst_bin_config_file(
-            cfl, decal_files, ntimes_per_file=2,
+            cfl,
+            decal_files,
+            ntimes_per_file=2,
         )
 
         out_files_recal = lstbin_simple.lst_bin_files(
-            config_file=cfl, calfile_rules=[(".decal.uvh5", ".calfits")],
+            config_file=cfl,
+            calfile_rules=[(".decal.uvh5", ".calfits")],
             fname_format="zen.{kind}.{lst:7.5f}.recal.uvh5",
             Nbls_to_load=10,
-            rephase=False
+            rephase=False,
         )
 
         lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2, clobber=True,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
         )
         out_files = lstbin_simple.lst_bin_files(
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}.uvh5",
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}.uvh5",
             Nbls_to_load=11,
-            rephase=False
+            rephase=False,
         )
 
         for flset, flsetc in zip(out_files, out_files_recal):
-            assert flset[('LST', False)] != flsetc[('LST', False)]
+            assert flset[("LST", False)] != flsetc[("LST", False)]
             uvdlst = UVData()
-            uvdlst.read(flset[('LST', False)])
+            uvdlst.read(flset[("LST", False)])
 
             uvdlstc = UVData()
-            uvdlstc.read(flsetc[('LST', False)])
+            uvdlstc.read(flsetc[("LST", False)])
             print(np.unique(uvdlstc.lst_array))
             expected = mockuvd.identifiable_data_from_uvd(uvdlst, reshape=False)
 
@@ -1044,9 +1195,15 @@ class Test_LSTBinFiles:
                     # when we put in flags, we end up setting the data to nan (and
                     # never using it...)
                     np.testing.assert_allclose(
-                        np.where(uvdlst.get_flags(ap+(pol,)), 1.0, uvdlstc.get_data(ap+(pol,))),
-                        np.where(uvdlst.get_flags(ap+(pol,)), 1.0, expected[i, :, :, j]),
-                        rtol=1e-4
+                        np.where(
+                            uvdlst.get_flags(ap + (pol,)),
+                            1.0,
+                            uvdlstc.get_data(ap + (pol,)),
+                        ),
+                        np.where(
+                            uvdlst.get_flags(ap + (pol,)), 1.0, expected[i, :, :, j]
+                        ),
+                        rtol=1e-4,
                     )
 
             # Don't worry about history here, because we know they use different inputs
@@ -1056,65 +1213,82 @@ class Test_LSTBinFiles:
     @pytest.mark.parametrize(
         "random_ants_to_drop, rephase, sigma_clip_thresh, flag_strategy, pols, freq_range",
         [
-            (0, True, 0.0, (0,0,0), ('xx', 'yy'), None),
-            (0, True, 0.0, (0,0,0), ('xx', 'yy', 'xy', 'yx'), None),
-            (0, True, 0.0, (0,0,0), ('xx', 'yy'), (150e6, 180e6)),
-            (0, True, 0.0, (2,1,3), ('xx', 'yy'), None),
-            (0, True, 3.0, (0,0,0), ('xx', 'yy'), None),
-            (0, False, 0.0, (0,0,0), ('xx', 'yy'), None),
-            (3, True, 0.0, (0,0,0), ('xx', 'yy'), None),
-        ]
+            (0, True, 0.0, (0, 0, 0), ("xx", "yy"), None),
+            (0, True, 0.0, (0, 0, 0), ("xx", "yy", "xy", "yx"), None),
+            (0, True, 0.0, (0, 0, 0), ("xx", "yy"), (150e6, 180e6)),
+            (0, True, 0.0, (2, 1, 3), ("xx", "yy"), None),
+            (0, True, 3.0, (0, 0, 0), ("xx", "yy"), None),
+            (0, False, 0.0, (0, 0, 0), ("xx", "yy"), None),
+            (3, True, 0.0, (0, 0, 0), ("xx", "yy"), None),
+        ],
     )
     def test_nontrivial_cal(
-        self, tmp_path_factory, random_ants_to_drop: int, rephase: bool,
-        sigma_clip_thresh: float, flag_strategy: tuple[int, int, int],
-        pols: tuple[str], freq_range: tuple[float, float] | None,
-        benchmark
+        self,
+        tmp_path_factory,
+        random_ants_to_drop: int,
+        rephase: bool,
+        sigma_clip_thresh: float,
+        flag_strategy: tuple[int, int, int],
+        pols: tuple[str],
+        freq_range: tuple[float, float] | None,
+        benchmark,
     ):
-
         tmp = tmp_path_factory.mktemp("nontrivial_cal")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=2, ntimes=2, ants=np.arange(7),
+            ndays=3,
+            nfiles=2,
+            ntimes=2,
+            ants=np.arange(7),
             creator=mockuvd.create_uvd_identifiable,
-            pols = pols,
+            pols=pols,
             freqs=np.linspace(140e6, 180e6, 3),
             random_ants_to_drop=random_ants_to_drop,
         )
 
         uvcs = [
-            [mockuvd.make_uvc_identifiable(d, *flag_strategy) for d in uvd ] for uvd in uvds
+            [mockuvd.make_uvc_identifiable(d, *flag_strategy) for d in uvd]
+            for uvd in uvds
         ]
 
         data_files = mockuvd.write_files_in_hera_format(uvds, tmp)
         cal_files = mockuvd.write_cals_in_hera_format(uvcs, tmp)
-        decal_files = [[df.replace(".uvh5", ".decal.uvh5") for df in dfl] for dfl in data_files]
+        decal_files = [
+            [df.replace(".uvh5", ".decal.uvh5") for df in dfl] for dfl in data_files
+        ]
 
         for flist, clist, ulist in zip(data_files, cal_files, decal_files):
             for df, cf, uf in zip(flist, clist, ulist):
                 apply_cal.apply_cal(
-                    df, uf, cf,
-                    gain_convention='divide',  # go the wrong way
+                    df,
+                    uf,
+                    cf,
+                    gain_convention="divide",  # go the wrong way
                     clobber=True,
                 )
 
         cfl = tmp / "lstbin_config_file.yaml"
         lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2, clobber=True,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
         )
         out_files = benchmark(
             lstbin_simple.lst_bin_files,
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}.uvh5",
-            Nbls_to_load=11, rephase=rephase,
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}.uvh5",
+            Nbls_to_load=11,
+            rephase=rephase,
             sigma_clip_thresh=sigma_clip_thresh,
             sigma_clip_min_N=2,
             freq_min=freq_range[0] if freq_range is not None else None,
             freq_max=freq_range[1] if freq_range is not None else None,
-            overwrite=True
+            overwrite=True,
         )
         assert len(out_files) == 2
         for flset in out_files:
             uvdlst = UVData()
-            uvdlst.read(flset[('LST', False)])
+            uvdlst.read(flset[("LST", False)])
 
             # Don't worry about history here, because we know they use different inputs
             expected = mockuvd.identifiable_data_from_uvd(uvdlst, reshape=False)
@@ -1133,23 +1307,29 @@ class Test_LSTBinFiles:
                     print(uvdlst.get_data(ap))
                     print(expected[i])
                     np.testing.assert_allclose(
-                        np.where(uvdlst.get_flags(ap+(pol,)), 1.0, uvdlst.get_data(ap+(pol,))),
-                        np.where(uvdlst.get_flags(ap+(pol,)), 1.0, expected[i, :, :, j]),
-                        rtol=1e-4 if (not rephase or (ap[0] == ap[1] and pol[0]==pol[1])) else 1e-3
+                        np.where(
+                            uvdlst.get_flags(ap + (pol,)),
+                            1.0,
+                            uvdlst.get_data(ap + (pol,)),
+                        ),
+                        np.where(
+                            uvdlst.get_flags(ap + (pol,)), 1.0, expected[i, :, :, j]
+                        ),
+                        rtol=1e-4
+                        if (not rephase or (ap[0] == ap[1] and pol[0] == pol[1]))
+                        else 1e-3,
                     )
 
-
     @pytest.mark.parametrize("tell_it", (True, False))
-    def test_redundantly_averaged(
-        self, tmp_path_factory, tell_it
-    ):
-
+    def test_redundantly_averaged(self, tmp_path_factory, tell_it):
         tmp = tmp_path_factory.mktemp("nontrivial_cal")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=2, ntimes=2,
+            ndays=3,
+            nfiles=2,
+            ntimes=2,
             creator=mockuvd.create_uvd_identifiable,
-            antpairs = [(i,j) for i in range(7) for j in range(i, 7)],  # 55 antpairs
-            pols = ('xx', 'yx'),
+            antpairs=[(i, j) for i in range(7) for j in range(i, 7)],  # 55 antpairs
+            pols=("xx", "yx"),
             freqs=np.linspace(140e6, 180e6, 3),
             redundantly_averaged=True,
         )
@@ -1158,11 +1338,16 @@ class Test_LSTBinFiles:
 
         cfl = tmp / "lstbin_config_file.yaml"
         config_info = lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2, clobber=True,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
         )
         out_files = lstbin_simple.lst_bin_files(
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}.uvh5",
-            Nbls_to_load=11, rephase=False,
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}.uvh5",
+            Nbls_to_load=11,
+            rephase=False,
             sigma_clip_thresh=0.0,
             sigma_clip_min_N=2,
             redundantly_averaged=True if tell_it else None,
@@ -1172,7 +1357,7 @@ class Test_LSTBinFiles:
 
         for flset in out_files:
             uvdlst = UVData()
-            uvdlst.read(flset[('LST', False)])
+            uvdlst.read(flset[("LST", False)])
 
             # Don't worry about history here, because we know they use different inputs
             expected = mockuvd.identifiable_data_from_uvd(uvdlst, reshape=False)
@@ -1190,18 +1375,22 @@ class Test_LSTBinFiles:
                     # when we put in flags, we end up setting the data to 1.0 (and
                     # never using it...)
                     np.testing.assert_allclose(
-                        uvdlst.get_data(ap+(pol,)),
-                        np.where(uvdlst.get_flags(ap+(pol,)), 1.0, expected[i, :, :, j]),
-                        rtol=1e-4
+                        uvdlst.get_data(ap + (pol,)),
+                        np.where(
+                            uvdlst.get_flags(ap + (pol,)), 1.0, expected[i, :, :, j]
+                        ),
+                        rtol=1e-4,
                     )
 
     def test_output_file_select(self, tmp_path_factory):
         tmp = tmp_path_factory.mktemp("output_file_select")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=4, ntimes=2,
+            ndays=3,
+            nfiles=4,
+            ntimes=2,
             creator=mockuvd.create_uvd_identifiable,
-            antpairs = [(i,j) for i in range(4) for j in range(i, 4)],  # 55 antpairs
-            pols = ('xx', 'yx'),
+            antpairs=[(i, j) for i in range(4) for j in range(i, 4)],  # 55 antpairs
+            pols=("xx", "yx"),
             freqs=np.linspace(140e6, 180e6, 3),
         )
 
@@ -1209,33 +1398,41 @@ class Test_LSTBinFiles:
 
         cfl = tmp / "lstbin_config_file.yaml"
         config_info = lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2, clobber=True,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
         )
         lstbf = partial(
-            lstbin_simple.lst_bin_files, config_file=cfl, 
+            lstbin_simple.lst_bin_files,
+            config_file=cfl,
             fname_format="zen.{kind}.{lst:7.5f}.uvh5",
-            Nbls_to_load=11, rephase=False,
+            Nbls_to_load=11,
+            rephase=False,
         )
 
         out_files = lstbf(output_file_select=0)
         assert len(out_files) == 1
 
-
         out_files = lstbf(output_file_select=(1, 2))
         assert len(out_files) == 2
 
-        with pytest.raises(ValueError, match='output_file_select must be less than the number of output files'):
+        with pytest.raises(
+            ValueError,
+            match="output_file_select must be less than the number of output files",
+        ):
             lstbf(output_file_select=100)
-
 
     def test_inpaint_mode_no_flags(self, tmp_path_factory):
         """Test that using inpaint mode does nothing when there's no flags."""
         tmp = tmp_path_factory.mktemp("inpaint_no_flags")
         uvds = mockuvd.make_dataset(
-            ndays=3, nfiles=1, ntimes=2,
+            ndays=3,
+            nfiles=1,
+            ntimes=2,
             creator=mockuvd.create_uvd_identifiable,
-            antpairs = [(i,j) for i in range(3) for j in range(i, 3)],  # 55 antpairs
-            pols = ('xx', 'yx'),
+            antpairs=[(i, j) for i in range(3) for j in range(i, 3)],  # 55 antpairs
+            pols=("xx", "yx"),
             freqs=np.linspace(140e6, 180e6, 3),
             redundantly_averaged=True,
         )
@@ -1244,21 +1441,93 @@ class Test_LSTBinFiles:
 
         cfl = tmp / "lstbin_config_file.yaml"
         config_info = lstbin_simple.make_lst_bin_config_file(
-            cfl, data_files, ntimes_per_file=2, clobber=True,
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
         )
         out_files = lstbin_simple.lst_bin_files(
-            config_file=cfl, fname_format="zen.{kind}.{lst:7.5f}{inpaint_mode}.uvh5",
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}{inpaint_mode}.uvh5",
             rephase=False,
             sigma_clip_thresh=None,
             sigma_clip_min_N=2,
             output_flagged=True,
-            output_inpainted=True
+            output_inpainted=True,
         )
 
         assert len(out_files) == 1
 
         for flset in out_files:
-            flagged = UVData.from_file(flset[('LST', False)])
-            inpainted = UVData.from_file(flset[('LST', True)])
+            flagged = UVData.from_file(flset[("LST", False)])
+            inpainted = UVData.from_file(flset[("LST", True)])
 
             assert flagged == inpainted
+
+    def test_inpaint_mode_no_flags_where_inpainted(self, tmp_path_factory):
+        """Test that ."""
+        tmp = tmp_path_factory.mktemp("inpaint_no_flags")
+        uvds = mockuvd.make_dataset(
+            ndays=3,
+            nfiles=1,
+            ntimes=2,
+            creator=mockuvd.create_uvd_identifiable,
+            antpairs=[(i, j) for i in range(3) for j in range(i, 3)],  # 55 antpairs
+            pols=("xx", "yx"),
+            freqs=np.linspace(140e6, 180e6, 3),
+            redundantly_averaged=True,
+        )
+
+        data_files = mockuvd.write_files_in_hera_format(
+            uvds, tmp, add_where_inpainted_files=True
+        )
+
+        cfl = tmp / "lstbin_config_file.yaml"
+        config_info = lstbin_simple.make_lst_bin_config_file(
+            cfl,
+            data_files,
+            ntimes_per_file=2,
+            clobber=True,
+        )
+        out_files = lstbin_simple.lst_bin_files(
+            config_file=cfl,
+            fname_format="zen.{kind}.{lst:7.5f}{inpaint_mode}.uvh5",
+            rephase=False,
+            sigma_clip_thresh=None,
+            sigma_clip_min_N=2,
+            output_flagged=True,
+            output_inpainted=True,
+            where_inpainted_file_rules=[(".uvh5", ".where_inpainted.h5")],
+        )
+
+        assert len(out_files) == 1
+
+        for flset in out_files:
+            flagged = UVData.from_file(flset[("LST", False)])
+            inpainted = UVData.from_file(flset[("LST", True)])
+
+            assert flagged == inpainted
+
+
+def test_get_where_inpainted(tmp_path_factory):
+    tmp: Path = tmp_path_factory.mktemp("get_where_inpainted")
+
+    fls = []
+    for outer in ["abc", "def"]:
+        these = []
+        for filename in outer:
+            (tmp / f"{filename}.uvh5").touch()
+            (tmp / f"{filename}.where_inpainted.h5").touch()
+            these.append(tmp / f"{filename}.uvh5")
+        fls.append(these)
+
+    out = lstbin_simple._get_where_inpainted_files(
+        fls, [(".uvh5", ".where_inpainted.h5")]
+    )
+
+    assert len(out) == 2
+    assert len(out[0]) == 3
+    assert len(out[1]) == 3
+
+    with pytest.raises(IOError, match="Where inpainted file"):
+        lstbin_simple._get_where_inpainted_files(fls, [(".uvh5", ".non_existent.h5")])

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -1070,3 +1070,39 @@ class TestMatchFilesToLSTBins:
 
         # Ensure all files are matched
         assert len(files_matched) == len(fls)
+
+
+class Test_LSTBranchCut:
+    def test_simple_ascending(self):
+        lsts = np.linspace(0, 1.0, 100)
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert best == 0
+
+    def test_simple_descending(self):
+        lsts = np.linspace(1.0, 0, 100)
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert best == 0
+
+    def test_simple_ascending_with_offset(self):
+        lsts = np.linspace(0.1, 1.1, 100)
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert np.isclose(best, 0.1)
+
+    def test_wrap_around_2pi(self):
+        lsts = np.linspace(3*np.pi/2, 5*np.pi/2, 100)
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert np.isclose(best, 3*np.pi/2)
+
+    def test_wrap_around_2pi_starting_low(self):
+        lsts0 = np.linspace(0, np.pi/2)
+        lsts1 = np.linspace(3*np.pi/2, 2*np.pi)
+        lsts = np.concatenate([lsts0, lsts1])
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert np.isclose(best, 3*np.pi/2)
+
+    def test_with_crazy_periods(self):
+        lsts = np.linspace(0, 1.0, 100)
+        n = np.random.random_integers(10, size=100)
+        lsts += n*2*np.pi
+        best = utils.get_best_lst_branch_cut(lsts)
+        assert best == 0

--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -26,6 +26,7 @@ from ..data import DATA_PATH
 from . import mock_uvdata as mockuvd
 from pathlib import Path
 
+
 class Test_Pol_Ops(object):
     def test_comply_pol(self):
         assert utils.comply_pol('XX') == 'xx'
@@ -425,12 +426,12 @@ def test_lst_rephase_vectorized():
     for i, antpair in enumerate(antpairs):
         for j, pol in enumerate(pols):
             data_drift[:, i, :, j] = data[antpair + (pol,)].copy()
-    
+
     # basic test: single dlst for all integrations
-    _data = utils.lst_rephase(data_drift, blvec, freqs, dlst, lat=0.0, inplace=False)    
-    
+    _data = utils.lst_rephase(data_drift, blvec, freqs, dlst, lat=0.0, inplace=False)
+
     # check error at transit
-    phs_err = np.angle(_data[itime, ibl, ifreq, ipol] / data_drift[itime+1, ibl, ifreq, ipol])
+    phs_err = np.angle(_data[itime, ibl, ifreq, ipol] / data_drift[itime + 1, ibl, ifreq, ipol])
     assert np.isclose(phs_err, 0, atol=1e-7)
     # check error across file
     phs_err = np.angle(_data[:-1, ibl, ifreq, ipol] / data_drift[1:, ibl, ifreq, ipol])
@@ -440,7 +441,7 @@ def test_lst_rephase_vectorized():
     dlst = np.array([np.median(np.diff(lsts))] * data.shape[0])
     _data = utils.lst_rephase(data_drift, blvec, freqs, dlst, lat=0.0, inplace=False)
     # check error at transit
-    phs_err = np.angle(_data[itime, ibl, ifreq, ipol] / data_drift[itime+1, ibl, ifreq, ipol])
+    phs_err = np.angle(_data[itime, ibl, ifreq, ipol] / data_drift[itime + 1, ibl, ifreq, ipol])
     assert np.isclose(phs_err, 0, atol=1e-7)
     # check err across file
     phs_err = np.angle(_data[:-1, ibl, ifreq, ipol] / data_drift[1:, ibl, ifreq, ipol])
@@ -455,6 +456,7 @@ def test_lst_rephase_vectorized():
     # check error across file
     phs_err = np.angle(_data[:, ibl, ifreq, ipol] / data_drift[50, ibl, ifreq, ipol])
     assert np.abs(phs_err).max() < 1e-4
+
 
 def test_lst_rephase():
     # load point source sim w/ array at latitude = 0
@@ -926,14 +928,15 @@ def test_select_spw_ranges_run_script_code(tmpdir):
 def tmpdir(tmp_path_factory):
     return tmp_path_factory.mktemp('test_match_files_to_lst_bins')
 
+
 class TestMatchFilesToLSTBins:
     def make_empty_day(self, nfiles: int, **kwargs):
-        # We make the internal data really small here, since we care only about the 
+        # We make the internal data really small here, since we care only about the
         # time metadata
         return mockuvd.make_day(
             nfiles=nfiles,
             ants=[0, 1, 2],
-            antpairs=[(0,0), (0,1)],
+            antpairs=[(0, 0), (0, 1)],
             freqs=np.array([155e6]),
             creator=mockuvd.create_mock_hera_obs,
             pols=('xx',),
@@ -945,7 +948,7 @@ class TestMatchFilesToLSTBins:
     @pytest.mark.parametrize('time_axis_faster_than_bls', [True, False, None])
     @pytest.mark.parametrize('jd_regex', (r"zen\.(\d+\.\d+)\.", None))
     def test_simple_zero2pi(
-        self, 
+        self,
         files_sorted: bool,
         blts_are_rectangular: bool,
         time_axis_faster_than_bls: bool,
@@ -956,14 +959,14 @@ class TestMatchFilesToLSTBins:
         which should match all files. This makes it easy to test different input
         parameter combinations.
         """
-        
+
         uvds = self.make_empty_day(nfiles=10, time_axis_faster_than_bls=bool(time_axis_faster_than_bls))
         fls = mockuvd.write_files_in_hera_format(uvds, tmpdir)
 
         # Ensure that using lst-bin edges of (0, 2pi) works fine
         out_fls = utils.match_files_to_lst_bins(
-            lst_edges=(0, 2*np.pi), 
-            file_list = fls,
+            lst_edges=(0, 2 * np.pi),
+            file_list=fls,
             files_sorted=files_sorted,
             blts_are_rectangular=blts_are_rectangular,
             jd_regex=jd_regex,
@@ -979,13 +982,13 @@ class TestMatchFilesToLSTBins:
         """
         uvds = self.make_empty_day(nfiles=10)
         fls = mockuvd.write_files_in_hera_format(uvds, tmpdir)
-        
+
         # To make it interesting, choose one big LST bin that covers about half the
         # files, including a partial file at the end.
-        lst_edges=(uvds[0].lst_array.min(), (uvds[5].lst_array.min() +uvds[5].lst_array.max())/2 )
+        lst_edges = (uvds[0].lst_array.min(), (uvds[5].lst_array.min() + uvds[5].lst_array.max()) / 2)
         out_fls = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
         )
         assert len(out_fls) == 1
@@ -993,7 +996,7 @@ class TestMatchFilesToLSTBins:
 
         out_fls_meta = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
             jd_regex=None,
         )
@@ -1011,16 +1014,16 @@ class TestMatchFilesToLSTBins:
         total_dlst = dlst * nfiles * 2
 
         uvds = self.make_empty_day(
-            nfiles=nfiles, lst_start=2*np.pi - total_dlst/2, integration_time=tint,
+            nfiles=nfiles, lst_start=2 * np.pi - total_dlst / 2, integration_time=tint,
         )
         fls = mockuvd.write_files_in_hera_format(uvds, tmpdir)
 
         # To make it interesting, choose one big LST bin that covers about half the
         # files, including a partial file at the end.
-        lst_edges=(3*np.pi/2, np.pi/2)
+        lst_edges = (3 * np.pi / 2, np.pi / 2)
         out_fls = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
         )
         assert len(out_fls) == 1
@@ -1028,38 +1031,38 @@ class TestMatchFilesToLSTBins:
 
         # To make it interesting, choose one big LST bin that covers about half the
         # files, including a partial file at the end.
-        lst_edges=(3*np.pi/2, 2*np.pi)
+        lst_edges = (3 * np.pi / 2, 2 * np.pi)
         out_fls = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
         )
         assert len(out_fls) == 1
-        assert len(out_fls[0]) == nfiles//2
+        assert len(out_fls[0]) == nfiles // 2
 
         # To make it interesting, choose one big LST bin that covers about half the
         # files, including a partial file at the end.
-        lst_edges=(0, np.pi/2)
+        lst_edges = (0, np.pi / 2)
         out_fls = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
         )
         assert len(out_fls) == 1
-        assert len(out_fls[0]) == nfiles//2
-        
+        assert len(out_fls[0]) == nfiles // 2
+
     def test_one_file_per_lstbin(self, tmpdir):
         uvds = self.make_empty_day(nfiles=10, jd_start=0.2)
         fls = mockuvd.write_files_in_hera_format(uvds, tmpdir)
-        
-        lst_edges=[
+
+        lst_edges = [
             uvd.lst_array.min() for uvd in uvds
         ]
         lst_edges.append(uvds[-1].lst_array.max())
-        
+
         out_fls = utils.match_files_to_lst_bins(
             lst_edges=lst_edges,
-            file_list = fls,
+            file_list=fls,
             files_sorted=True,
         )
         assert len(out_fls) == len(lst_edges) - 1
@@ -1089,20 +1092,20 @@ class Test_LSTBranchCut:
         assert np.isclose(best, 0.1)
 
     def test_wrap_around_2pi(self):
-        lsts = np.linspace(3*np.pi/2, 5*np.pi/2, 100)
+        lsts = np.linspace(3 * np.pi / 2, 5 * np.pi / 2, 100)
         best = utils.get_best_lst_branch_cut(lsts)
-        assert np.isclose(best, 3*np.pi/2)
+        assert np.isclose(best, 3 * np.pi / 2)
 
     def test_wrap_around_2pi_starting_low(self):
-        lsts0 = np.linspace(0, np.pi/2)
-        lsts1 = np.linspace(3*np.pi/2, 2*np.pi)
+        lsts0 = np.linspace(0, np.pi / 2)
+        lsts1 = np.linspace(3 * np.pi / 2, 2 * np.pi)
         lsts = np.concatenate([lsts0, lsts1])
         best = utils.get_best_lst_branch_cut(lsts)
-        assert np.isclose(best, 3*np.pi/2)
+        assert np.isclose(best, 3 * np.pi / 2)
 
     def test_with_crazy_periods(self):
         lsts = np.linspace(0, 1.0, 100)
         n = np.random.random_integers(10, size=100)
-        lsts += n*2*np.pi
+        lsts += n * 2 * np.pi
         best = utils.get_best_lst_branch_cut(lsts)
         assert best == 0

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -790,8 +790,8 @@ def lst_rephase(
     bls: dict[tp.Baseline, np.ndarray] | np.ndarray,
     freqs: np.ndarray,
     dlst: float | list | np.ndarray,
-    lat: float =-30.721526120689507,
-    inplace: bool=True,
+    lat=-30.721526120689507,
+    inplace=True,
     array=False
 ):
     """
@@ -820,7 +820,7 @@ def lst_rephase(
         if True edit arrays in data in memory, else make a copy and return
     array
         Deprecated parameter that specifies that the input data is an array
-        with shape (ntimes, nfreqs, [npols]). Don't write code with this 
+        with shape (ntimes, nfreqs, [npols]). Don't write code with this
         parameter -- instead just set the baseline axis of data to be length-1.
 
     Notes:
@@ -901,7 +901,7 @@ def lst_rephase(
             if array:
                 warnings.warn(
                     "the 'array' parameter to lst_rephase is deprecated. Please provide data with second-axis of Nbls",
-                    category=DeprecationWarning,    
+                    category=DeprecationWarning,
                 )
                 data = data[:, None]
 
@@ -933,7 +933,7 @@ def lst_rephase(
 
         if not inplace:
             if orig_type in (dict, OrderedDict, DataContainer):
-                return orig_type({k: data[:,i] for i,k in enumerate(keys)})
+                return orig_type({k: data[:, i] for i, k in enumerate(keys)})
             else:
                 if array:
                     return data[:, 0]
@@ -1465,6 +1465,7 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
         else:
             return data
 
+
 def match_files_to_lst_bins(
     lst_edges: tuple[float],
     file_list: Sequence[str | Path],
@@ -1554,12 +1555,12 @@ def match_files_to_lst_bins(
     if len(lst_edges) < 2:
         raise ValueError("lst_edges must have at least 2 elements.")
     lst0 = lst_edges[0]
-    lst_edges=np.array([(lst - lst0)%(2*np.pi) + lst0 for lst in lst_edges])
+    lst_edges = np.array([(lst - lst0) % (2 * np.pi) + lst0 for lst in lst_edges])
     # We can have the case that an edges is at lst0 + 2pi exactly, which would
     # get wrapped around to lst0, but it should stay at lst0+2pi.
-    lst_edges[1:][lst_edges[1:] == lst_edges[0]] += 2*np.pi
+    lst_edges[1:][lst_edges[1:] == lst_edges[0]] += 2 * np.pi
 
-    if np.any(np.diff(lst_edges) < 0 ):
+    if np.any(np.diff(lst_edges) < 0):
         raise ValueError("lst_edges must not extend beyond 2pi total radians from start to finish.")
 
     lstmin, lstmax = lst_edges[0], lst_edges[-1]
@@ -1597,10 +1598,12 @@ def match_files_to_lst_bins(
 
     if jd_regex is not None:
         jd_regex = re.compile(jd_regex)
+
         @cache
         def get_first_time(path: Path) -> float:
             return float(jd_regex.findall(path.name)[0])
     else:
+
         @cache
         def get_first_time(path: Path) -> float:
             meta = _metas[path]
@@ -1609,7 +1612,7 @@ def match_files_to_lst_bins(
     def get_first_file_in_range(meta_list, jd_range: Tuple[float, float]) -> int:
         jdstart, jdend = jd_range
 
-        jdstart_for_file = jdstart - tint*(ntimes_per_file-1) - atol
+        jdstart_for_file = jdstart - tint * (ntimes_per_file - 1) - atol
 
         # The lst-edges might wrap around within a day. If so, when comparing times
         # to the bins, we need to use an OR instead of an AND.
@@ -1630,22 +1633,21 @@ def match_files_to_lst_bins(
                 break
 
             diff = jdstart_for_file - thistime
-            in_range = cmp(jdstart_for_file <= thistime, thistime <= jdend+atol)
+            in_range = cmp(jdstart_for_file <= thistime, thistime <= jdend + atol)
             if np.abs(diff) < best_diff and in_range:
                 # This file has a time that is in our range, and is closest so far
                 # to the start of the range.
                 best_diff = np.abs(diff)
                 best_index = index
 
-
-            move_nfiles = round(diff / (tint*ntimes_per_file))
+            move_nfiles = round(diff / (tint * ntimes_per_file))
 
             if move_nfiles == 0:
                 if in_range:
                     break
                 else:
                     # Move by one file in the right direction, just to be sure.
-                    move_nfiles = int(1*np.sign(diff))
+                    move_nfiles = int(1 * np.sign(diff))
 
             if diff > 0:
                 minidx = max(minidx, index)
@@ -1654,7 +1656,7 @@ def match_files_to_lst_bins(
 
             index += move_nfiles
             if not (minidx < index < maxidx):
-                index = min(maxidx-1, max(minidx+1, (minidx + maxidx) // 2))
+                index = min(maxidx - 1, max(minidx + 1, (minidx + maxidx) // 2))
                 if index < 0:
                     index = 0
                 elif index >= len(meta_list):
@@ -1674,10 +1676,10 @@ def match_files_to_lst_bins(
         # that out later.
         first_file = get_first_file_in_range(metadata_list, (jdstart, jdend))
     except ValueError:
-        return [[] for _ in range(len(lst_edges)-1)]
+        return [[] for _ in range(len(lst_edges) - 1)]
 
     # Now, we have to actually go through the bins in lst_edges and assign files.
-    lstbin_files = [[] for _ in range(len(lst_edges)-1)]
+    lstbin_files = [[] for _ in range(len(lst_edges) - 1)]
     _meta_list = metadata_list[first_file:] + metadata_list[:first_file]  # roll the files
 
     for i, fl in enumerate(_meta_list):
@@ -1686,7 +1688,7 @@ def match_files_to_lst_bins(
         for lstbin, (jdstart, jdend) in enumerate(zip(jd_edges[:-1], jd_edges[1:])):
             # Go through each lst bin
             cmp = operator.and_ if (jdstart < jdend) else operator.or_
-            if cmp(jdstart - (ntimes_per_file-1)*tint - atol <= thistime, thistime < jdend + atol):
+            if cmp(jdstart - (ntimes_per_file - 1) * tint - atol <= thistime, thistime < jdend + atol):
                 lstbin_files[lstbin].append(fl)
             fl_in_range = True
 
@@ -1694,6 +1696,7 @@ def match_files_to_lst_bins(
             break
 
     return lstbin_files
+
 
 def eq2top_m(ha, dec):
     """Return the 3x3 matrix converting equatorial coordinates to topocentric
@@ -1778,19 +1781,20 @@ def chunk_baselines_by_redundant_groups(reds, max_chunk_size):
                 baseline_chunks.append(grp)
     return baseline_chunks
 
-def get_best_lst_branch_cut(lsts):
+
+def get_best_lst_branch_cut(lsts_in):
     # Sort them
-    lsts = np.sort(lsts) % (2*np.pi)
-    
+    lsts = np.sort(lsts_in % (2 * np.pi))
+
     # wrap lstg around in case the biggest gap is right at the start
     lsts = np.concatenate((lsts, [lsts[0]]))
 
     diff_lst = np.diff(lsts)
     while np.any(diff_lst < 0):
-        lsts[np.where(diff_lst < 0)[0] + 1] += 2*np.pi
+        lsts[np.where(diff_lst < 0)[0] + 1] += 2 * np.pi
         diff_lst = np.diff(lsts)
     idxmax = np.argmax(diff_lst) + 1
-    return lsts[idxmax] % (2*np.pi)
+    return lsts[idxmax] % (2 * np.pi)
 
 
 def select_spw_ranges(inputfilename, outputfilename, spw_ranges=None, clobber=False):

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1671,9 +1671,6 @@ def match_files_to_lst_bins(
             return best_index
 
     try:
-        # We subtract one, because the file before the first file in the range
-        # may just get into the range by a tiny bit, and we allow the user to test
-        # that out later.
         first_file = get_first_file_in_range(metadata_list, (jdstart, jdend))
     except ValueError:
         return [[] for _ in range(len(lst_edges) - 1)]

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -563,7 +563,7 @@ def LST2JD(LST, start_jd, allow_other_jd=False, lst_branch_cut=0.0, latitude=-30
                      LSTs to correspond to previous or subsequent days if necessary
 
     lst_branch_cut : type=float, LST that must fall during start_jd even when allow_other_jd
-                     is True. Used as the starting point starting point where LSTs below this
+                     is True. Used as the starting point where LSTs below this
                      value map to later JDs than this LST [radians]
 
     latitude : type=float, degrees North of observer, default=HERA latitude
@@ -1777,6 +1777,20 @@ def chunk_baselines_by_redundant_groups(reds, max_chunk_size):
             else:
                 baseline_chunks.append(grp)
     return baseline_chunks
+
+def get_best_lst_branch_cut(lsts):
+    # Sort them
+    lsts = np.sort(lsts) % (2*np.pi)
+    
+    # wrap lstg around in case the biggest gap is right at the start
+    lsts = np.concatenate((lsts, [lsts[0]]))
+
+    diff_lst = np.diff(lsts)
+    while np.any(diff_lst < 0):
+        lsts[np.where(diff_lst < 0)[0] + 1] += 2*np.pi
+        diff_lst = np.diff(lsts)
+    idxmax = np.argmax(diff_lst) + 1
+    return lsts[idxmax] % (2*np.pi)
 
 
 def select_spw_ranges(inputfilename, outputfilename, spw_ranges=None, clobber=False):

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -49,7 +49,7 @@ if crules is not None:
 else:
     calfile_rules = None
 
-inprules = kwargs.pop("where-inpainted-file-rules")
+inprules = kwargs.pop("where_inpainted_file_rules")
 if inprules is not None:
     inpaint_rules = [(inprules[i], inprules[i + 1]) for i in range(len(inprules) // 2)]
 else:

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -7,11 +7,8 @@
 
 from hera_cal import lstbin_simple as lstbin
 import sys
-import glob
 import json
 from hera_cal._cli_tools import setup_logger, parse_args, filter_kwargs, run_with_profiling
-import logging
-import importlib
 from pathlib import Path
 
 a = lstbin.lst_bin_arg_parser()
@@ -52,15 +49,24 @@ if crules is not None:
 else:
     calfile_rules = None
 
+inprules = kwargs.pop("calfile_rules")
+if inprules is not None:
+    inpaint_rules = [(inprules[i], inprules[i+1]) for i in range(len(inprules)//2)]
+else:
+    inpaint_rules = None
+
 
 kwargs['save_channels'] = tuple(int(ch) for ch in kwargs['save_channels'].split(','))
 kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(','))
 
+kwargs['output_flagged'] = not kwargs.pop('no_flagged_mode')
+kwargs['output_inpainted'] = kwargs.pop("do_inpaint_mode")
 run_with_profiling(
     lstbin.lst_bin_files, 
     args,
     config_file=kwargs.pop('configfile'),
     calfile_rules=calfile_rules, 
+    where_inpainted_file_rules = inpaint_rules,
     write_kwargs=write_kwargs, 
     **kwargs
 )

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -45,16 +45,15 @@ if kwargs['output_file_select'] == ['None']:
 # Turn a list into a list of 2-tuples.
 crules = kwargs.pop("calfile_rules")
 if crules is not None:
-    calfile_rules = [(crules[i], crules[i+1]) for i in range(len(crules)//2)]
+    calfile_rules = [(crules[i], crules[i + 1]) for i in range(len(crules) // 2)]
 else:
     calfile_rules = None
 
-inprules = kwargs.pop("calfile_rules")
+inprules = kwargs.pop("where-inpainted-file-rules")
 if inprules is not None:
-    inpaint_rules = [(inprules[i], inprules[i+1]) for i in range(len(inprules)//2)]
+    inpaint_rules = [(inprules[i], inprules[i + 1]) for i in range(len(inprules) // 2)]
 else:
     inpaint_rules = None
-
 
 kwargs['save_channels'] = tuple(int(ch) for ch in kwargs['save_channels'].split(','))
 kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(','))
@@ -62,11 +61,11 @@ kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(
 kwargs['output_flagged'] = not kwargs.pop('no_flagged_mode')
 kwargs['output_inpainted'] = kwargs.pop("do_inpaint_mode")
 run_with_profiling(
-    lstbin.lst_bin_files, 
+    lstbin.lst_bin_files,
     args,
     config_file=kwargs.pop('configfile'),
-    calfile_rules=calfile_rules, 
-    where_inpainted_file_rules = inpaint_rules,
-    write_kwargs=write_kwargs, 
+    calfile_rules=calfile_rules,
+    where_inpainted_file_rules=inpaint_rules,
+    write_kwargs=write_kwargs,
     **kwargs
 )


### PR DESCRIPTION
This adds an "inpaint" mode for the LST-binner. In this mode, flagged data is assumed to have been in-painted to preserve spectral smoothness. 