### PR TITLE
Fix LSTBIN for redundantly-averaged inpainted data

### DIFF
--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1453,6 +1453,7 @@ def lst_bin_files_single_outfile(
         f"lst_bin_edges={lst_bin_edges}"
     )
 
+    logger.warning("BEFORE PARTIAL: ", outdir)
     # make it a bit easier to create the outfiles
     create_outfile = partial(
         create_lstbin_output_file,
@@ -1522,6 +1523,7 @@ def lst_bin_files_single_outfile(
 
         slc = slice(nbls_so_far, nbls_so_far + len(bl_chunk))
 
+        logger.warning("HEY HEY JUST BEFORE WRITIG: ", outdir)
         if bi == 0:
             # On the first baseline chunk, create the output file
             # TODO: we're not writing out the where_inpainted data for the GOLDEN
@@ -1872,7 +1874,7 @@ def create_lstbin_output_file(
 
     if lst < lst_branch_cut:
         lst += 2 * np.pi
-
+    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: ", outdir)
     fname = outdir / fname_format.format(
         kind=kind,
         lst=lst,

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1422,6 +1422,11 @@ def lst_bin_files_single_outfile(
         [x - dlst / 2 for x in lst_bins] + [lst_bins[-1] + dlst / 2]
     )
 
+    print('JUST BEFORE: ')
+    for dlist, inplist in zip(data_files, where_inpainted_files):
+        for df, inp in zip(dlist, inplist):
+            print(df.name, inp.name)
+
     (
         tinds,
         time_arrays,
@@ -1435,6 +1440,12 @@ def lst_bin_files_single_outfile(
         input_cals,
         where_inpainted_files,
     )
+
+    print('JUST AFTER: ')
+    for dlist, inplist in zip(data_files, where_inpainted_files):
+        for df, inp in zip(dlist, inplist):
+            print(df.name, inp.name)
+
     # If we have no times at all for this file, just return
     if len(all_lsts) == 0:
         return {}

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1325,6 +1325,12 @@ def lst_bin_files_single_outfile(
     where_inpainted_files = _get_where_inpainted_files(
         data_files, where_inpainted_file_rules
     )
+
+    print('FRESH: ')
+    for dlist, inplist in zip(data_files, where_inpainted_files):
+        for df, inp in zip(dlist, inplist):
+            print(df, inp)
+
     output_flagged, output_inpainted = _configure_inpainted_mode(
         output_flagged, output_inpainted, where_inpainted_files
     )
@@ -1425,7 +1431,7 @@ def lst_bin_files_single_outfile(
     print('JUST BEFORE: ')
     for dlist, inplist in zip(data_files, where_inpainted_files):
         for df, inp in zip(dlist, inplist):
-            print(df.name, inp.name)
+            print(df, inp)
 
     (
         tinds,
@@ -1444,7 +1450,7 @@ def lst_bin_files_single_outfile(
     print('JUST AFTER: ')
     for dlist, inplist in zip(data_files, where_inpainted_files):
         for df, inp in zip(dlist, inplist):
-            print(df.name, inp.name)
+            print(df, inp)
 
     # If we have no times at all for this file, just return
     if len(all_lsts) == 0:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1609,6 +1609,8 @@ def lst_bin_files_single_outfile(
                 flags=rdc["flags"],
                 nsamples=rdc["nsamples"],
             )
+
+            logger.info(f"JUST TO MAKE SURE: {rdc['std'][20,1000,0]}")
             write_baseline_slc_to_file(
                 fl=out_files[("STD", inpainted)],
                 slc=slc,
@@ -1626,7 +1628,7 @@ def lst_bin_files_single_outfile(
                     nsamples=rdc["nsamples"],
                 )
                 write_baseline_slc_to_file(
-                    fl=out_files[("STD", inpainted)],
+                    fl=out_files[("MAD", inpainted)],
                     slc=slc,
                     data=rdc["mad"],
                     flags=rdc["flags"],

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -584,13 +584,13 @@ def lst_average(
     # Multiply by nan instead of just setting as nan, so both real and imag parts are nan
     meandata[~normalizable] *= np.nan
 
-    logger.info(f"Number of flags in 1000th channel for bl 40: {np.sum(flags[:, 20, 1000, 0])}")
-    logger.info(f"Data: {data[:, 20, 1000, 0]}")
-    logger.info(f"Flags: {flags[:, 20, 1000, 0]}")
-    logger.info(f"Nsamples: {nsamples[:, 20, 1000, 0]}")
-    logger.info(f"Mean: {meandata[20, 1000, 0]}")
-    logger.info(f"Data Mask: {data.mask[:, 20, 1000, 0]}")
-    logger.info(f"NORM: {norm[20, 1000, 0]}")
+    # logger.info(f"Number of flags in 1000th channel for bl 40: {np.sum(flags[:, 20, 1000, 0])}")
+    # logger.info(f"Data: {data[:, 20, 1000, 0]}")
+    # logger.info(f"Flags: {flags[:, 20, 1000, 0]}")
+    # logger.info(f"Nsamples: {nsamples[:, 20, 1000, 0]}")
+    # logger.info(f"Mean: {meandata[20, 1000, 0]}")
+    # logger.info(f"Data Mask: {data.mask[:, 20, 1000, 0]}")
+    # logger.info(f"NORM: {norm[20, 1000, 0]}")
 
     # get other stats
     logger.info("Calculating std")
@@ -603,7 +603,7 @@ def lst_average(
         std[normalizable] /= norm[normalizable]
         std = np.sqrt(std.real) + 1j * np.sqrt(std.imag)
 
-    logger.info(f"STD: {std[20, 1000, 0]}")
+    # logger.info(f"STD: {std[20, 1000, 0]}")
 
     std[~normalizable] = np.inf
 
@@ -1610,7 +1610,6 @@ def lst_bin_files_single_outfile(
                 nsamples=rdc["nsamples"],
             )
 
-            logger.info(f"JUST TO MAKE SURE: {rdc['std'][20,1000,0]}")
             write_baseline_slc_to_file(
                 fl=out_files[("STD", inpainted)],
                 slc=slc,

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -894,13 +894,14 @@ def lst_bin_files_for_baselines(
                         )
             for j, pol in enumerate(pols):
                 blpol = bl + (pol,)
+                inp_blpol = inpbl + (pol,)
 
                 if blpol in _data:  # DataContainer takes care of conjugates.
                     data[slc, i, :, j] = _data[blpol]
                     flags[slc, i, :, j] = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
                     if inpainted is not None:
-                        where_inpainted[slc, i, :, j] = inpainted[blpol]
+                        where_inpainted[slc, i, :, j] = inpainted[inp_blpol]
                 else:
                     # This baseline+pol doesn't exist in this file. That's
                     # OK, we don't assume all baselines are in every file.

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1888,7 +1888,9 @@ def create_lstbin_output_file(
     )
     # There's a weird gotcha with pathlib where if you do path / "/file.name"
     # You get just "/file.name" which is in root.
-    fname = outdir / fname.removeprefix('/')
+    if fname.startswith('/'):
+        fname = fname[1:]
+    fname = outdir / fname
 
     logger.info(f"Initializing {fname}")
 

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1333,7 +1333,8 @@ def lst_bin_files_single_outfile(
     # they have no associated calibration)
     data_files = [df for df in data_files if df]
     input_cals = [cf for cf in input_cals if cf]
-    where_inpainted_files = [wif for wif in where_inpainted_files if wif]
+    if where_inpainted_files is not None:
+        where_inpainted_files = [wif for wif in where_inpainted_files if wif]
 
     logger.info("Got the following numbers of data files per night:")
     for dflist in data_files:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -584,14 +584,6 @@ def lst_average(
     # Multiply by nan instead of just setting as nan, so both real and imag parts are nan
     meandata[~normalizable] *= np.nan
 
-    # logger.info(f"Number of flags in 1000th channel for bl 40: {np.sum(flags[:, 20, 1000, 0])}")
-    # logger.info(f"Data: {data[:, 20, 1000, 0]}")
-    # logger.info(f"Flags: {flags[:, 20, 1000, 0]}")
-    # logger.info(f"Nsamples: {nsamples[:, 20, 1000, 0]}")
-    # logger.info(f"Mean: {meandata[20, 1000, 0]}")
-    # logger.info(f"Data Mask: {data.mask[:, 20, 1000, 0]}")
-    # logger.info(f"NORM: {norm[20, 1000, 0]}")
-
     # get other stats
     logger.info("Calculating std")
     with warnings.catch_warnings():
@@ -602,8 +594,6 @@ def lst_average(
         std = np.sum(std * nsamples, axis=0)
         std[normalizable] /= norm[normalizable]
         std = np.sqrt(std.real) + 1j * np.sqrt(std.imag)
-
-    # logger.info(f"STD: {std[20, 1000, 0]}")
 
     std[~normalizable] = np.inf
 
@@ -1429,7 +1419,6 @@ def lst_bin_files_single_outfile(
     ]
     bl_chunks = [blg for blg in bl_chunks if len(blg) > 0]
 
-    logger.info(f"HERE IS BASELINE 20: {all_baselines[20]}")
     dlst = config_opts["dlst"]
     lst_bin_edges = np.array(
         [x - dlst / 2 for x in lst_bins] + [lst_bins[-1] + dlst / 2]

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -851,6 +851,7 @@ def lst_bin_files_for_baselines(
 
             # We need to down-selecton times/freqs (bls and pols will be sub-selected
             # based on those in the data through the next loop)
+            print("HERE I AM: ", meta.path, inpfile, tarr, inpainted.times)
             inpainted.select_or_expand_times(new_times=tarr, skip_bda_check=True)
             inpainted.select_freqs(channels=freq_chans)
         else:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -844,7 +844,7 @@ def lst_bin_files_for_baselines(
         )
         if inpfile is not None:
             # This returns a DataContainer (unless something went wrong) since it should
-            # always be a 'baseline' type of UVFlag.s
+            # always be a 'baseline' type of UVFlag.
             inpainted = io.load_flags(inpfile)
             if not isinstance(inpainted, DataContainer):
                 raise ValueError(f"Expected {inpfile} to be a DataContainer")
@@ -881,6 +881,17 @@ def lst_bin_files_for_baselines(
         for i, bl in enumerate(antpairs):
             if redundantly_averaged:
                 bl = keyed.get_ubl_key(bl)
+
+                # Get the representative baseline key from this bl group that exists
+                # in the where_inpainted data.
+                if inpainted is not None:
+                    for inpbl in reds[bl]:
+                        if inpbl in inpainted:
+                            break
+                    else:
+                        raise ValueError(
+                            f"Could not find any baseline from group {bl} in inpainted file"
+                        )
             for j, pol in enumerate(pols):
                 blpol = bl + (pol,)
 

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1453,7 +1453,7 @@ def lst_bin_files_single_outfile(
         f"lst_bin_edges={lst_bin_edges}"
     )
 
-    logger.warning("BEFORE PARTIAL: ", outdir)
+    logger.warning(f"BEFORE PARTIAL: {outdir}")
     # make it a bit easier to create the outfiles
     create_outfile = partial(
         create_lstbin_output_file,
@@ -1523,7 +1523,7 @@ def lst_bin_files_single_outfile(
 
         slc = slice(nbls_so_far, nbls_so_far + len(bl_chunk))
 
-        logger.warning("HEY HEY JUST BEFORE WRITIG: ", outdir)
+        logger.warning(f"HEY HEY JUST BEFORE WRITING: {outdir}")
         if bi == 0:
             # On the first baseline chunk, create the output file
             # TODO: we're not writing out the where_inpainted data for the GOLDEN
@@ -1874,7 +1874,7 @@ def create_lstbin_output_file(
 
     if lst < lst_branch_cut:
         lst += 2 * np.pi
-    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: ", outdir)
+    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: {outdir}")
     fname = outdir / fname_format.format(
         kind=kind,
         lst=lst,

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1874,7 +1874,17 @@ def create_lstbin_output_file(
 
     if lst < lst_branch_cut:
         lst += 2 * np.pi
-    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: {outdir}")
+
+    herp = fname_format.format(
+        kind=kind,
+        lst=lst,
+        pol="".join(pols),
+        inpaint_mode="inpaint"
+        if inpaint_mode
+        else ("flagged" if inpaint_mode is False else ""),
+    )
+    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: {outdir} {fname_format}\n{herp}")
+
     fname = outdir / fname_format.format(
         kind=kind,
         lst=lst,

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1453,7 +1453,6 @@ def lst_bin_files_single_outfile(
         f"lst_bin_edges={lst_bin_edges}"
     )
 
-    logger.warning(f"BEFORE PARTIAL: {outdir}")
     # make it a bit easier to create the outfiles
     create_outfile = partial(
         create_lstbin_output_file,
@@ -1523,7 +1522,6 @@ def lst_bin_files_single_outfile(
 
         slc = slice(nbls_so_far, nbls_so_far + len(bl_chunk))
 
-        logger.warning(f"HEY HEY JUST BEFORE WRITING: {outdir}")
         if bi == 0:
             # On the first baseline chunk, create the output file
             # TODO: we're not writing out the where_inpainted data for the GOLDEN
@@ -1875,7 +1873,7 @@ def create_lstbin_output_file(
     if lst < lst_branch_cut:
         lst += 2 * np.pi
 
-    herp = fname_format.format(
+    fname = fname_format.format(
         kind=kind,
         lst=lst,
         pol="".join(pols),
@@ -1883,16 +1881,9 @@ def create_lstbin_output_file(
         if inpaint_mode
         else ("flagged" if inpaint_mode is False else ""),
     )
-    logger.warning(f"IN CREATE LSTBIN OUTPUT FILE for {kind}: {outdir} {fname_format}\n{herp}")
-
-    fname = outdir / fname_format.format(
-        kind=kind,
-        lst=lst,
-        pol="".join(pols),
-        inpaint_mode="inpaint"
-        if inpaint_mode
-        else ("flagged" if inpaint_mode is False else ""),
-    )
+    # There's a weird gotcha with pathlib where if you do path / "/file.name"
+    # You get just "/file.name" which is in root.
+    fname = outdir / fname.removeprefix('/')
 
     logger.info(f"Initializing {fname}")
 

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -851,7 +851,6 @@ def lst_bin_files_for_baselines(
 
             # We need to down-selecton times/freqs (bls and pols will be sub-selected
             # based on those in the data through the next loop)
-            print("HERE I AM: ", meta.path, inpfile, tarr, inpainted.times)
             inpainted.select_or_expand_times(new_times=tarr, skip_bda_check=True)
             inpainted.select_freqs(channels=freq_chans)
         else:
@@ -1326,11 +1325,6 @@ def lst_bin_files_single_outfile(
         data_files, where_inpainted_file_rules
     )
 
-    print('FRESH: ')
-    for dlist, inplist in zip(data_files, where_inpainted_files):
-        for df, inp in zip(dlist, inplist):
-            print(df, inp)
-
     output_flagged, output_inpainted = _configure_inpainted_mode(
         output_flagged, output_inpainted, where_inpainted_files
     )
@@ -1413,11 +1407,6 @@ def lst_bin_files_single_outfile(
                 f"{dflist[0].path} and {nants0} for {meta.path} for {meta.path}"
             )
 
-    print('IN BETWEEN: ')
-    for dlist, inplist in zip(data_metas, where_inpainted_files):
-        for df, inp in zip(dlist, inplist):
-            print(df.path, inp)
-
     # Split up the baselines into chunks that will be LST-binned together.
     # This is just to save on RAM.
     if Nbls_to_load is None:
@@ -1434,11 +1423,6 @@ def lst_bin_files_single_outfile(
         [x - dlst / 2 for x in lst_bins] + [lst_bins[-1] + dlst / 2]
     )
 
-    print('JUST BEFORE: ')
-    for dlist, inplist in zip(data_files, where_inpainted_files):
-        for df, inp in zip(dlist, inplist):
-            print(df, inp)
-
     (
         tinds,
         time_arrays,
@@ -1452,10 +1436,6 @@ def lst_bin_files_single_outfile(
         input_cals,
         where_inpainted_files,
     )
-
-    print('JUST AFTER: ')
-    for fl, inp in zip(file_list, where_inpainted_files):
-        print(fl, inp)
 
     # If we have no times at all for this file, just return
     if len(all_lsts) == 0:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1339,6 +1339,7 @@ def lst_bin_files_single_outfile(
     # they have no associated calibration)
     data_files = [df for df in data_files if df]
     input_cals = [cf for cf in input_cals if cf]
+    where_inpainted_files = [wif for wif in where_inpainted_files if wif]
 
     logger.info("Got the following numbers of data files per night:")
     for dflist in data_files:
@@ -1412,6 +1413,11 @@ def lst_bin_files_single_outfile(
                 f"{dflist[0].path} and {nants0} for {meta.path} for {meta.path}"
             )
 
+    print('IN BETWEEN: ')
+    for dlist, inplist in zip(data_metas, where_inpainted_files):
+        for df, inp in zip(dlist, inplist):
+            print(df.path, inp)
+
     # Split up the baselines into chunks that will be LST-binned together.
     # This is just to save on RAM.
     if Nbls_to_load is None:
@@ -1448,9 +1454,8 @@ def lst_bin_files_single_outfile(
     )
 
     print('JUST AFTER: ')
-    for dlist, inplist in zip(data_files, where_inpainted_files):
-        for df, inp in zip(dlist, inplist):
-            print(df, inp)
+    for fl, inp in zip(file_list, where_inpainted_files):
+        print(fl, inp)
 
     # If we have no times at all for this file, just return
     if len(all_lsts) == 0:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -882,26 +882,29 @@ def lst_bin_files_for_baselines(
             if redundantly_averaged:
                 bl = keyed.get_ubl_key(bl)
 
-                # Get the representative baseline key from this bl group that exists
-                # in the where_inpainted data.
-                if inpainted is not None:
-                    for inpbl in reds[bl]:
-                        if inpbl + (pols[0],) in inpainted:
-                            break
-                    else:
-                        raise ValueError(
-                            f"Could not find any baseline from group {bl} in inpainted file"
-                        )
             for j, pol in enumerate(pols):
                 blpol = bl + (pol,)
-                inp_blpol = inpbl + (pol,)
 
                 if blpol in _data:  # DataContainer takes care of conjugates.
                     data[slc, i, :, j] = _data[blpol]
                     flags[slc, i, :, j] = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
+
                     if inpainted is not None:
-                        where_inpainted[slc, i, :, j] = inpainted[inp_blpol]
+                        # Get the representative baseline key from this bl group that
+                        # exists in the where_inpainted data.
+                        if redundantly_averaged:
+                            for inpbl in reds[bl]:
+                                if inpbl + (pol,) in inpainted:
+                                    blpol = inpbl + (pol,)
+                                    break
+                            else:
+                                raise ValueError(
+                                    f"Could not find any baseline from group {bl} in "
+                                    "inpainted file"
+                                )
+
+                        where_inpainted[slc, i, :, j] = inpainted[blpol]
                 else:
                     # This baseline+pol doesn't exist in this file. That's
                     # OK, we don't assume all baselines are in every file.

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -886,7 +886,7 @@ def lst_bin_files_for_baselines(
                 # in the where_inpainted data.
                 if inpainted is not None:
                     for inpbl in reds[bl]:
-                        if inpbl in inpainted:
+                        if inpbl + (pols[0],) in inpainted:
                             break
                     else:
                         raise ValueError(

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -24,9 +24,9 @@ HERA_LOC = EarthLocation.from_geocentric(
 with open(f"{DATA_PATH}/hera_antpos.yaml", "r") as fl:
     HERA_ANTPOS = yaml.safe_load(fl)
 
-start: 46920776.3671875
-end: 234298706.0546875
-delta: 122070.3125
+PHASEII_FREQS = np.arange(
+    46920776.3671875, 234298706.0546875 + 10.0, 122070.3125
+)
 
 
 def create_mock_hera_obs(
@@ -35,9 +35,7 @@ def create_mock_hera_obs(
     lst_start=0.1,
     jd_start: float | None = None,
     ntimes: int = 2,
-    freqs: np.ndarray = np.arange(
-        46920776.3671875, 234298706.0546875 + 10.0, 122070.3125
-    ),
+    freqs: np.ndarray = PHASEII_FREQS,
     pols: list[str] = ["xx", "yy", "xy", "yx"],
     ants: list[int] | None = None,
     antpairs: list[tuple[int, int]] | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm[toml]>=6.2,!=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Makes the following fixes:

* Use the unique identifier baseline for a group when processing redundantly-averaged data, in the `.where_inpainted.` file. 
* trim the where-inpainted files in the same way as the calfiles and datafiles (removing empty nights)
* 🤦🏻 write out the MAD data to the MAD file instead of the STD file...