### PR TITLE
fix: only flag lstbin if all are flagged and NOT inpainted

### DIFF
--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -611,7 +611,8 @@ def lst_average(
     # np.sum works the same for both masked and non-masked arrays.
     meandata = np.sum(data * nsamples, axis=0)
 
-    lstbin_flagged = np.all(flags, axis=0)
+    lstbin_flagged = np.all(data.mask, axis=0)
+
     if flag_below_min_N:
         lstbin_flagged[ndays_binned < sigma_clip_min_N] = True
 

--- a/hera_cal/tests/test_lstbin_simple.py
+++ b/hera_cal/tests/test_lstbin_simple.py
@@ -533,11 +533,11 @@ class Test_LSTAverage:
             data=_data, nsamples=nsamples, flags=flags, inpainted_mode=True
         )
 
-        # The data and std in the fully-flagged bin should be different, but Nsamples
-        # and Flags should be the same.
+        # The data, flags and std in the fully-flagged bin should be different, but
+        # Nsamples and Flags should be the same.
         assert not np.allclose(df[0, 0, 0], di[0, 0, 0])
         assert np.allclose(df[1:], di[1:])
-        assert np.allclose(ff, fi)
+        assert not np.allclose(ff, fi)
         assert not np.allclose(stdf[0, 0, 0], stdi[0, 0, 0])
         assert np.allclose(stdf[1:], stdi[1:])
         assert np.allclose(nf, ni)


### PR DESCRIPTION
Simple switch to only flagging if all nights are both flagged and not inpainted.