### PR TITLE
Omnical memory improvements

### DIFF
--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -902,14 +902,14 @@ class OmnicalSolver(linsolve.LinProductSolver):
                 # compute data wgts: dwgts = sum(V_mdl^2 / n^2) = sum(V_mdl^2 * wgts)
                 # don't need to update data weighting with every iteration
                 # clamped weighting is passed to dwgts_u, which is used to update parameters
-                dwgts_u = {k: dmdl_u[k] * dmdl_u[k].conj() * clamp_wgts_u[k] for k in self.keys}
                 sol_wgt_u = {k: 0 for k in sol.keys()}
+                dw_u = {}
                 for k, (gi, gj, uij) in zip(self.keys, terms):
-                    w = dwgts_u[k]
-                    sol_wgt_u[gi] += w
-                    sol_wgt_u[gj] += w
-                    sol_wgt_u[uij] += w
-                dw_u = {k: v[update] * dwgts_u[k] for k, v in self.data.items()}
+                    dwgts_u = dmdl_u[k] * dmdl_u[k].conj() * clamp_wgts_u[k]
+                    sol_wgt_u[gi] += dwgts_u
+                    sol_wgt_u[gj] += dwgts_u
+                    sol_wgt_u[uij] += dwgts_u
+                    dw_u[k] = self.data[k][update] * dwgts_u
             sol_sum_u = {k: 0 for k in sol_u.keys()}
             for k, (gi, gj, uij) in zip(self.keys, terms):
                 # compute sum(wgts * V_meas / V_mdl)

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -953,12 +953,12 @@ class OmnicalSolver(linsolve.LinProductSolver):
                     dmdl_u[k] = v[update_u]
                 for k, v in wgts_u.items():
                     wgts_u[k] = v[update_u]
-                for k, v in wgts_u.items():
-                    clamp_wgts_u[k] = (v if wgt_func is None else v * wgt_func(abs2_u[k]))
-                for k, v in sol_u.items():
-                    sol_u[k] = v[update_u]
                 for k, v in abs2_u.items():
                     abs2_u[k] = v[update_u]
+                for k, v in sol_u.items():
+                    sol_u[k] = v[update_u]
+                for k, v in wgts_u.items():
+                    clamp_wgts_u[k] = (v if wgt_func is None else v * wgt_func(abs2_u[k]))
                 update = tuple(u[update_u] for u in update)
             if verbose:
                 print('    <CHISQ> = %f, <CONV> = %f, CNT = %d', (np.mean(chisq), np.mean(conv), update[0].size))

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -1126,14 +1126,18 @@ class RedundantCalibrator:
         dc = DataContainer(data)
         eqs = self.build_eqs(dc)
         self.phs_avg = {}  # detrend phases within redundant group, used for logcal to avoid phase wraps
+        d_ls, w_ls = {}, {}
         if detrend_phs:
             for grp in self.reds:
                 self.phs_avg[grp[0]] = np.exp(-np.complex64(1j) * np.median(np.unwrap([np.log(dc[bl]).imag for bl in grp], axis=0), axis=0))
                 for bl in grp:
                     self.phs_avg[bl] = self.phs_avg[grp[0]].astype(dc[bl].dtype)
-        d_ls, w_ls = {}, {}
-        for eq, key in eqs.items():
-            d_ls[eq] = dc[key] * self.phs_avg.get(key, np.float32(1))
+            for eq, key in eqs.items():
+                # this makes a copy, which prevents modification of the data when detrending phase
+                d_ls[eq] = dc[key] * self.phs_avg.get(key, np.float32(1))
+        else:
+            for eq, key in eqs.items():
+                d_ls[eq] = dc[key]
         if len(wgts) > 0:
             wc = DataContainer(wgts)
             for eq, key in eqs.items():

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -832,7 +832,7 @@ class OmnicalSolver(linsolve.LinProductSolver):
             **kwargs: keyword arguments of constants (python variables in keys of data that
                 are not to be solved for) which are passed to linsolve.LinProductSolver.
         """
-        linsolve.LinProductSolver.__init__(self, data, sol0, wgts=wgts, **kwargs)
+        linsolve.LinProductSolver.__init__(self, data, sol0, wgts=wgts, build_solver=False, **kwargs)
         self.gain = np.float32(gain)  # float32 to avoid accidentally promoting data to doubles.
 
     def _get_ans0(self, sol, keys=None):
@@ -1887,7 +1887,7 @@ def redcal_iteration(hd, nInt_to_load=None, pol_mode='2pol', bl_error_tol=1.0, e
             # try to solve for gains on antennas excluded from calibration, but keep them flagged
             expand_omni_gains(sol, all_reds_this_pol, data, nsamples, chisq_per_ant=meta['chisq_per_ant'])
 
-            # try one more time to expand visibilities, keeping new ones flagged, but 
+            # try one more time to expand visibilities, keeping new ones flagged, but
             # don't update chisq or chisq_per_ant
             expand_omni_vis(sol, all_reds_this_pol, data, nsamples)
             sol.make_sol_finite()

--- a/hera_cal/redcal.py
+++ b/hera_cal/redcal.py
@@ -837,7 +837,9 @@ class OmnicalSolver(linsolve.LinProductSolver):
 
     def _get_ans0(self, sol, keys=None, to_update_inplace=None):
         '''Evaluate the system of equations given input sol.
-        Specify keys to evaluate only a subset of the equations.'''
+        Specify keys to evaluate only a subset of the equations.
+        to_update_inplace is a dictionary mapping keys or self.keys()
+        to numpy arrays that we want to overwrite with ans0 values.'''
         if keys is None:
             keys = self.keys
         _sol = {k + '_': v.conj() for k, v in sol.items() if k.startswith('g')}


### PR DESCRIPTION
Despite some misleading results from %memit, it appears that omnical's memory usage is the root of some of the problems we've been having with RTP. 

This PR improves the memory efficiency of omnical. It does so by studiously avoiding copying data unnecessarily, as well as by updating dictionaries with for loops rather than dictionary comprehension, so that we don't have to make a whole new dictionary before deallocating the old one.

It also changes the default value of `wgt_func` from `lambda x: 1.` to `None` and adds special treatment of the `None` case so that it doesn't multiply by 1 and create new arrays.

It has a negligible effect on performance (and actually might be a tiny bit faster). In my tests on the file_calibration notebook with  `zen.2460280.48839.sum.uvh5` locally, runtime improved from 5.07 minutes to 4.63 minutes. It improves peak memory usage from 18.8 GB to 12.3 GB, although it should be noted that ~6.5 GB was the memory usage (mostly raw data) going into omnical.

Here's my memray results before:

![image](https://github.com/HERA-Team/hera_cal/assets/5281139/184bbc16-8405-4bb4-afaf-c782e46b7c00)

And after:

![image](https://github.com/HERA-Team/hera_cal/assets/5281139/f6db8cc6-0259-404d-b7d9-0c9d93b66193)

It's possible we can do even better if we use single precision, which I'll explore next.

This PR relies on https://github.com/HERA-Team/linsolve/pull/51