### PR TITLE
feat: add option to sigma-clip sub-bands homogeneously

### DIFF
--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -590,10 +590,10 @@ def sigma_clip(
 
     if scale is None:
         scale = np.expand_dims(np.ma.median(np.abs(array - location), axis=median_axis) * 1.482579, axis=median_axis)
-    elif scale.shape != array.shape:
+    elif scale.ndim == array.ndim - 1:
         scale = np.expand_dims(scale, axis=median_axis)
 
-    if scale.shape != array.shape and scale.shape[median_axis] != 1:
+    if (scale.shape != array.shape and scale.shape[median_axis] != 1) or scale.ndim != array.ndim:
         raise ValueError(
             "scale must have same shape as array or array with median_axis removed."
             f"Got {scale.shape}, needed {array.shape}"

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -311,6 +311,23 @@ def reduce_lst_bins(
         per baseline, frequency, and polarization.
     sigma_clip_min_N
         The minimum number of unflagged samples required to perform sigma clipping.
+    sigma_clip_type
+        The type of sigma clipping to perform. If ``direct``, each datum is flagged
+        individually. If ``mean`` or ``median``, an entire sub-band of the data is
+        flagged if its mean (absolute) zscore is beyond the threshold.
+    sigma_clip_subbands
+        A list of tuples specifying the start and end indices of the threshold axis
+        over which to perform sigma clipping. They are used in a ``slice`` object,
+        so that the end is exclusive but the start is inclusive. If None, the entire
+        threshold axis is used at once.
+    sigma_clip_scale
+        If given, interpreted as the expected standard deviation of the data
+        (over nights). If not given, estimated from the data using the median
+        absolute deviation. If given, must be an array with either the same
+        shape as ``array`` OR the same shape as ``array`` with the ``median_axis``
+        removed. If the former, each variate over the ``median_axis`` is scaled
+        independently. If the latter, the same scale is applied to all variates
+        (generally nights).
     flag_below_min_N
         Whether to flag data that has fewer than ``sigma_clip_min_N`` unflagged samples.
     flag_thresh
@@ -320,6 +337,7 @@ def reduce_lst_bins(
     get_mad
         Whether to compute the median and median absolute deviation of the data in each
         LST bin, in addition to the mean and standard deviation.
+
 
     Returns
     -------
@@ -686,6 +704,14 @@ def lst_average(
         The type of sigma clipping to perform. If ``direct``, each datum is flagged
         individually. If ``mean`` or ``median``, an entire sub-band of the data is
         flagged if its mean (absolute) zscore is beyond the threshold.
+    sigma_clip_scale
+        If given, interpreted as the expected standard deviation of the data
+        (over nights). If not given, estimated from the data using the median
+        absolute deviation. If given, must be an array with either the same
+        shape as ``array`` OR the same shape as ``array`` with the ``median_axis``
+        removed. If the former, each variate over the ``median_axis`` is scaled
+        independently. If the latter, the same scale is applied to all variates
+        (generally nights).
 
     Returns
     -------

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -594,9 +594,11 @@ def sigma_clip(
         elif clip_type in ['mean', 'median']:
             # In this mode, an entire sub-band of the data is flagged if its mean
             # (absolute) zscore is beyond the threshold.
-            mean_abs_dev = getattr(np.ma, clip_type)(subz, axis=threshold_axis)
-            print(mean_abs_dev.min(), mean_abs_dev.max(), subz.min(), subz.max())
-            subflags[:] = np.expand_dims(mean_abs_dev > threshold, axis=threshold_axis)
+            thisf = getattr(np.ma, clip_type)(subz, axis=threshold_axis) > threshold
+            for day_idx, bl_idx, pol_idx in thisf.nonzero():
+                print(f"Sigma-clipping (day,bl,pol)={day_idx},{bl_idx},{pol_idx}")
+
+            subflags[:] = np.expand_dims(thisf, axis=threshold_axis)
         else:
             raise ValueError(
                 f"clip_type must be 'direct', 'mean' or 'median', got {clip_type}"
@@ -2516,7 +2518,7 @@ def lst_bin_arg_parser():
     )
     a.add_argument(
         "--sigma-clip-type",
-        type='str',
+        type=str,
         default='direct',
         choices=['direct', 'mean', 'median'],
         help="How to threshold the absolute zscores for sigma clipping."

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -599,8 +599,9 @@ def sigma_clip(
             # In this mode, an entire sub-band of the data is flagged if its mean
             # (absolute) zscore is beyond the threshold.
             thisf = getattr(np.ma, clip_type)(subz, axis=threshold_axis) > threshold
-            for day_idx, bl_idx, pol_idx in thisf.nonzero():
-                print(f"Sigma-clipping (day,bl,pol)={day_idx},{bl_idx},{pol_idx}")
+            if np.any(thisf):
+                for day_idx, bl_idx, pol_idx in zip(*thisf.nonzero()):
+                    print(f"Sigma-clipping (day,bl,pol)={day_idx},{bl_idx},{pol_idx}")
 
             subflags[:] = np.expand_dims(thisf, axis=threshold_axis)
         else:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -269,6 +269,8 @@ def reduce_lst_bins(
     mutable: bool = False,
     sigma_clip_thresh: float | None = None,
     sigma_clip_min_N: int = 4,
+    sigma_clip_type: str = 'direct',
+    sigma_clip_subbands: list[int] | None = None,
     flag_below_min_N: bool = False,
     flag_thresh: float = 0.7,
     get_mad: bool = False,
@@ -375,6 +377,8 @@ def reduce_lst_bins(
                 inpainted_mode=inpainted_mode,
                 sigma_clip_thresh=sigma_clip_thresh,
                 sigma_clip_min_N=sigma_clip_min_N,
+                sigma_clip_subbands=sigma_clip_subbands,
+                sigma_clip_type=sigma_clip_type,
                 flag_below_min_N=flag_below_min_N,
             )
 

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -724,7 +724,7 @@ def lst_average(
             'median_axis': 0,
             'threshold_axis': 0 if sigma_clip_type == 'direct' else -2,
             'flag_bands': list(zip(sigma_clip_subbands[:-1], sigma_clip_subbands[1:])) if sigma_clip_subbands else None,
-            "sigma_clip_scale": sigma_clip_scale,
+            "scale": sigma_clip_scale,
         }
         clip_flags = sigma_clip(data.real, **kw)
         clip_flags |= sigma_clip(data.imag, **kw)
@@ -2583,7 +2583,7 @@ def lst_bin_arg_parser():
     )
     a.add_argument(
         "--sigma-clip-use-autos",
-        type="store_true",
+        action="store_true",
         help="whether to use the autos to predict the variance for sigma-clipping"
     )
     a.add_argument(

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -1268,7 +1268,6 @@ def lst_bin_files_single_outfile(
     sigma_clip_min_N: int = 4,
     sigma_clip_subbands: list[int] | None = None,
     sigma_clip_type: Literal['direct', 'mean', 'median'] = 'direct',
-    sigma_clip_expected_variance: np.ndarray | None = None,
     flag_below_min_N: bool = False,
     flag_thresh: float = 0.7,
     freq_min: float | None = None,
@@ -1395,9 +1394,6 @@ def lst_bin_files_single_outfile(
         The type of sigma clipping to perform. If ``direct``, each datum is flagged
         individually. If ``mean`` or ``median``, an entire sub-band of the data is
         flagged if its mean (absolute) zscore is beyond the threshold.
-    sigma_clip_expected_variance
-        Expected variance of the data over the sigma_clip_subbands. If None, it is
-        estimated from the data.
     flag_below_min_N
         If True, flag all (antpair, pol,channel) combinations  for an LST-bin that
         contiain fewer than `flag_below_min_N` unflagged integrations within the bin.
@@ -1772,7 +1768,6 @@ def lst_bin_files_single_outfile(
                 get_mad=write_med_mad,
                 sigma_clip_subbands=sigma_clip_subbands,
                 sigma_clip_type=sigma_clip_type,
-                sigma_clip_expected_variance=sigma_clip_expected_variance,
             )
 
             write_baseline_slc_to_file(

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -593,8 +593,11 @@ def sigma_clip(
     elif scale.shape != array.shape:
         scale = np.expand_dims(scale, axis=median_axis)
 
-    if scale.shape != array.shape:
-        raise ValueError("scale must have same shape as array or array with median_axis removed")
+    if scale.shape != array.shape and scale.shape[median_axis] != 1:
+        raise ValueError(
+            "scale must have same shape as array or array with median_axis removed."
+            f"Got {scale.shape}, needed {array.shape}"
+        )
 
     if flag_bands is None:
         # Use entire threshold axis together
@@ -621,11 +624,6 @@ def sigma_clip(
             # In this mode, an entire sub-band of the data is flagged if its mean
             # (absolute) zscore is beyond the threshold.
             thisf = getattr(np.ma, clip_type)(subz, axis=threshold_axis) > threshold
-            if np.any(thisf):
-                for day_idx, bl_idx, pol_idx in zip(*thisf.nonzero()):
-                    if not np.all(subz.mask[day_idx, bl_idx, :, pol_idx]):
-                        print(f"Sigma-clipping (band,day,bl,pol)={band},{day_idx},{bl_idx},{pol_idx}")
-
             subflags[:] = np.expand_dims(thisf, axis=threshold_axis)
         else:
             raise ValueError(

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -601,7 +601,8 @@ def sigma_clip(
             thisf = getattr(np.ma, clip_type)(subz, axis=threshold_axis) > threshold
             if np.any(thisf):
                 for day_idx, bl_idx, pol_idx in zip(*thisf.nonzero()):
-                    print(f"Sigma-clipping (day,bl,pol)={day_idx},{bl_idx},{pol_idx}")
+                    if not np.all(subz.mask[day_idx, bl_idx, :, pol_idx]):
+                        print(f"Sigma-clipping (band,day,bl,pol)={band},{day_idx},{bl_idx},{pol_idx}")
 
             subflags[:] = np.expand_dims(thisf, axis=threshold_axis)
         else:

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -559,7 +559,8 @@ def sigma_clip(
         with clipped values set to True.
     """
     # ensure array is an array
-    array = np.asarray(array)
+    if not isinstance(array, np.ndarray):  # this covers np.ma.MaskedArray as well
+        array = np.asarray(array)
 
     if np.iscomplexobj(array):
         raise ValueError("array must be real")

--- a/hera_cal/lstbin_simple.py
+++ b/hera_cal/lstbin_simple.py
@@ -270,7 +270,7 @@ def reduce_lst_bins(
     sigma_clip_thresh: float | None = None,
     sigma_clip_min_N: int = 4,
     sigma_clip_type: str = 'direct',
-    sigma_clip_subbands: list[int] | None = None,
+    sigma_clip_subbands: list[tuple[int, int]] | None = None,
     sigma_clip_scale: list[np.ndarray] | None = None,
     flag_below_min_N: bool = False,
     flag_thresh: float = 0.7,
@@ -660,7 +660,7 @@ def lst_average(
     sigma_clip_thresh: float | None = None,
     sigma_clip_min_N: int = 4,
     flag_below_min_N: bool = False,
-    sigma_clip_subbands: list[int] | None = None,
+    sigma_clip_subbands: list[tuple[int, int]] | None = None,
     sigma_clip_type: Literal['direct', 'mean', 'median'] = 'direct',
     sigma_clip_scale: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -695,11 +695,9 @@ def lst_average(
     flag_below_min_N
         Whether to flag data that has fewer than ``sigma_clip_min_N`` unflagged samples.
     sigma_clip_subbands
-        A list of integers specifying the start and end indices of the frequency axis
-        to perform sigma clipping over. If None, the entire frequency axis is used at
-        once. Given a list of integers e.g. ``[0, 10, 20]``, the sub-bands will be
-        defined as [(0, 10), (10, 20)], where each 2-tuple defines a standard Python
-        slice object (i.e. end is exclusive, start is inclusive).
+        A list of 2-tuples of integers specifying the start and end indices of the
+        frequency axis to perform sigma clipping over. If None, the entire frequency
+        axis is used at once.
     sigma_clip_type
         The type of sigma clipping to perform. If ``direct``, each datum is flagged
         individually. If ``mean`` or ``median``, an entire sub-band of the data is
@@ -747,7 +745,7 @@ def lst_average(
             'clip_type': sigma_clip_type,
             'median_axis': 0,
             'threshold_axis': 0 if sigma_clip_type == 'direct' else -2,
-            'flag_bands': list(zip(sigma_clip_subbands[:-1], sigma_clip_subbands[1:])) if sigma_clip_subbands else None,
+            'flag_bands': sigma_clip_subbands,
             "scale": sigma_clip_scale,
         }
         clip_flags = sigma_clip(data.real, **kw)
@@ -1316,7 +1314,7 @@ def lst_bin_files_single_outfile(
     golden_lsts: tuple[float] = (),
     sigma_clip_thresh: float | None = None,
     sigma_clip_min_N: int = 4,
-    sigma_clip_subbands: list[int] | None = None,
+    sigma_clip_subbands: list[tuple[int, int]] | None = None,
     sigma_clip_type: Literal['direct', 'mean', 'median'] = 'direct',
     sigma_clip_use_autos: bool = False,
     flag_below_min_N: bool = False,
@@ -1438,9 +1436,9 @@ def lst_bin_files_single_outfile(
         is False, these (antpair,pol,channel) combinations are not flagged by
         sigma-clipping (otherwise they are).
     sigma_clip_subbands
-        A list of integers specifying the start and end indices of the frequency axis
-        to perform sigma clipping over. If None, the entire frequency axis is used at
-        once.
+        A list of 2-tuples of integers, specifying the start and end indices of the
+        frequency axis to perform sigma clipping over. If None, the entire frequency
+        axis is used at once.
     sigma_clip_type
         The type of sigma clipping to perform. If ``direct``, each datum is flagged
         individually. If ``mean`` or ``median``, an entire sub-band of the data is
@@ -2595,7 +2593,7 @@ def lst_bin_arg_parser():
     a.add_argument(
         "--sigma-clip-subbands",
         type=str,
-        help="Channels at which bands are separated for homogeneous sigma clipping. Separated by commas.",
+        help="Band-edges (as channel number) at which bands are separated for homogeneous sigma clipping, e.g. '0~10,100~500'",
         default=None,
     )
     a.add_argument(

--- a/hera_cal/tests/test_lstbin_simple.py
+++ b/hera_cal/tests/test_lstbin_simple.py
@@ -1739,3 +1739,156 @@ class TestThresholdFlags:
 
         assert not np.all(flags[:, 0])
         assert np.all(new[:, 0])
+
+
+# Define a fixture for common array shapes used in the tests
+@pytest.fixture(params=[(10, 5, 5, 2), (8, 10, 10, 4), (15, 3, 7, 1)])
+def array_shape(request):
+    return request.param
+
+
+class TestSigmaClip:
+    # Happy path tests with various realistic test values
+    @pytest.mark.parametrize(
+        "threshold, min_N, median_axis, threshold_axis, clip_type, flag_bands",
+        [
+            (4.0, 4, 0, 0, 'direct', None),
+            (3.0, 4, 1, 1, 'mean', [(1, 3), (4, 5)]),
+            (5.0, 4, 2, 2, 'median', [(2, 4)]),
+        ]
+    )
+    def test_sigma_clip_happy_path(
+        self, array_shape, threshold, min_N, median_axis, threshold_axis, clip_type, flag_bands
+    ):
+        # Arrange
+        np.random.seed(42)
+        array = np.random.normal(size=array_shape)
+
+        print(
+            f"threshold={threshold}, min_N={min_N}, median_axis={median_axis}, "
+            f"threshold_axis={threshold_axis}, array_shape={array_shape}, "
+            f"clip_type={clip_type}, flag_bands={flag_bands}"
+        )
+        # Act
+        clip_flags = lstbin_simple.sigma_clip(
+            array=array,
+            threshold=threshold,
+            min_N=min_N,
+            median_axis=median_axis,
+            threshold_axis=threshold_axis,
+            clip_type=clip_type,
+            flag_bands=flag_bands
+        )
+
+        # Assert
+        assert isinstance(clip_flags, np.ndarray), "The output should be an ndarray."
+        assert clip_flags.dtype == bool, "The output array should be of boolean type."
+        assert clip_flags.shape == array.shape, "The output flags should have the same shape as the input array."
+
+    # Edge cases
+    @pytest.mark.parametrize("array, threshold, min_N, median_axis, threshold_axis, clip_type, flag_bands, test_id", [
+        (np.array([]), 4.0, 4, 0, 0, 'direct', None, 'edge_empty_array'),
+        (np.array([np.nan, np.nan]), 4.0, 4, 0, 0, 'direct', None, 'edge_all_nan'),
+        (np.random.normal(size=(5, 5)), 4.0, 6, 0, 0, 'direct', None, 'edge_below_min_N'),
+    ])
+    def test_sigma_clip_edge_cases(self, array, threshold, min_N, median_axis, threshold_axis, clip_type, flag_bands, test_id):
+        # Act
+        clip_flags = lstbin_simple.sigma_clip(
+            array, threshold, min_N, median_axis, threshold_axis, clip_type, flag_bands
+        )
+
+        # Assert
+        assert isinstance(clip_flags, np.ndarray), f"Test ID: {test_id} - The output should be an ndarray."
+        assert clip_flags.dtype == bool, f"Test ID: {test_id} - The output array should be of boolean type."
+        assert clip_flags.shape == array.shape, f"Test ID: {test_id} - The output flags should have the same shape as the input array."
+
+    # Error cases
+    def test_sigma_clip_error_cases(self):
+        # Act / Assert
+        array = np.array([1 + 1j, 2 + 2j])
+        with pytest.raises(ValueError, match=".*must be real.*"):
+            lstbin_simple.sigma_clip(array)
+
+        array = np.array([1, 2])
+        with pytest.raises(ValueError, match=".*clip_type.*"):
+            lstbin_simple.sigma_clip(array, min_N=0, clip_type='wrong_clip_type')
+
+    @pytest.mark.parametrize(
+        "clip_type", ['direct', 'mean', 'median']
+    )
+    @pytest.mark.parametrize(
+        "flag_bands", [None, [(0, 12)], [(0, 1), (1, 12)]]
+    )
+    def test_constant_data_no_flags(self, clip_type, flag_bands):
+        """Test an array with a reasonable expected shape, but constant values.
+
+        Expect that nothing is flagged in this case.
+        """
+        array = np.ones((10, 8, 12, 4))  # nnights, nbls, nfreqs, npols
+        clip_flags = lstbin_simple.sigma_clip(
+            array,
+            clip_type=clip_type,
+            flag_bands=flag_bands,
+            median_axis=0,
+            threshold_axis=2,
+            min_N=0,
+            threshold=3.0,
+        )
+        assert not np.any(clip_flags)
+
+    def test_spiky_data_direct_clip(self):
+        """Test an array with a reasonable expected shape with spiky outliers.
+
+        We expect that JUST the outliers are flagged.
+        """
+        array = np.random.normal(size=(100, 8, 12, 4))  # nnights, nbls, nfreqs, npols
+
+        array[1, 0, 0, 0] = 1000
+        array[0, 1, 0, 0] = 1000
+        array[0, 0, 1, 0] = 1000
+        array[0, 0, 0, 1] = 1000
+
+        clip_flags = lstbin_simple.sigma_clip(
+            array,
+            clip_type='direct',
+            median_axis=0,
+            threshold_axis=2,
+            min_N=0,
+            threshold=10.0,
+        )
+
+        assert np.sum(clip_flags) == 4
+        assert clip_flags[1, 0, 0, 0]
+        assert clip_flags[0, 1, 0, 0]
+        assert clip_flags[0, 0, 1, 0]
+        assert clip_flags[0, 0, 0, 1]
+
+    @pytest.mark.parametrize(
+        "flag_bands", [[(0, 12)], [(0, 2), (2, 12)]]
+    )
+    @pytest.mark.parametrize(
+        "clip_type", ['mean', 'median']
+    )
+    def test_spiky_data_mean_clip(self, flag_bands, clip_type):
+        """Test an array with a reasonable expected shape with spiky outliers.
+
+        In this case, we aggregate over the frequency axis by taking the mean,
+        and we also flag in particular bands.
+        """
+        array = np.random.normal(size=(100, 8, 12, 4))
+
+        array[0, 0, flag_bands[0][0]:flag_bands[0][1], 0] = 1000
+
+        clip_flags = lstbin_simple.sigma_clip(
+            array,
+            clip_type=clip_type,
+            median_axis=0,
+            threshold_axis=2,
+            min_N=0,
+            threshold=6.0,
+            flag_bands=flag_bands,
+        )
+
+        # The entire first band should be clipped, but nothing else.
+        assert np.sum(clip_flags) == flag_bands[0][1] - flag_bands[0][0]
+        assert np.all(clip_flags[0, 0, flag_bands[0][0]:flag_bands[0][1], 0])

--- a/hera_cal/tests/test_lstbin_simple.py
+++ b/hera_cal/tests/test_lstbin_simple.py
@@ -655,7 +655,7 @@ class Test_LSTAverage:
         nsamples = np.ones(_data.shape, dtype=float)
         flags = np.zeros(_data.shape, dtype=bool)
 
-        with pytest.warns(UserWarning, match="Sigma-clipping in in-painted mode"):
+        with pytest.warns(UserWarning, match="Direct-mode sigma-clipping in in-painted mode"):
             lstbin_simple.lst_average(
                 data=_data,
                 nsamples=nsamples,

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -60,7 +60,7 @@ kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(
 
 kwargs['output_flagged'] = not kwargs.pop('no_flagged_mode')
 kwargs['output_inpainted'] = kwargs.pop("do_inpaint_mode")
-kwargs['sigma_clip_subbands'] = [int(b) for b in kwargs.pop["sigma_clip_subbands"].split(",")]
+kwargs['sigma_clip_subbands'] = [int(b) for b in kwargs["sigma_clip_subbands"].split(",")]
 
 run_with_profiling(
     lstbin.lst_bin_files,

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -60,7 +60,7 @@ kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(
 
 kwargs['output_flagged'] = not kwargs.pop('no_flagged_mode')
 kwargs['output_inpainted'] = kwargs.pop("do_inpaint_mode")
-kwargs['sigma_clip_subbands'] = [int(b) for b in kwargs["sigma_clip_subbands"].split(",")]
+kwargs['sigma_clip_subbands'] = [(int(low), int(high)) for b in kwargs["sigma_clip_subbands"].split(",") for low, high in b.split("~")]
 
 run_with_profiling(
     lstbin.lst_bin_files,

--- a/scripts/lstbin_simple.py
+++ b/scripts/lstbin_simple.py
@@ -60,6 +60,8 @@ kwargs['golden_lsts'] = tuple(float(lst) for lst in kwargs['golden_lsts'].split(
 
 kwargs['output_flagged'] = not kwargs.pop('no_flagged_mode')
 kwargs['output_inpainted'] = kwargs.pop("do_inpaint_mode")
+kwargs['sigma_clip_subbands'] = [int(b) for b in kwargs.pop["sigma_clip_subbands"].split(",")]
+
 run_with_profiling(
     lstbin.lst_bin_files,
     args,


### PR DESCRIPTION
This adds several options to a new `sigma_clip()` function, including `clip_type` which specifies whether data should be directly clipped or accumulated over some axis before assessing the threshold. A placeholder for allowing the expected variance to be passed has also been added, but not piped through (i.e. you can't specify this on the CLI yet).

The reason that the expected variance can't be piped through easily is that there's no obvious way of getting the auto spectra that works for both redundantly averaged and non-averaged data input. 