### PR TITLE
Apply flag to N-sample before delay filtering

### DIFF
--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -20,6 +20,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class DelayFilter(VisClean):
     """
     DelayFilter object.
@@ -98,7 +99,8 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
                                 res_outfilename=None, CLEAN_outfilename=None, filled_outfilename=None,
                                 clobber=False, add_to_history='', polarizations=None,
                                 skip_flagged_edges=False, overwrite_flags=False,
-                                flag_yaml=None, read_axis=None, **filter_kwargs):
+                                flag_yaml=None, read_axis=None, apply_flag_to_nsample=False,
+                                **filter_kwargs):
     '''
     Uses partial data loading and writing to perform delay filtering.
     While this function reads from multiple files (in datafile_list)
@@ -136,6 +138,8 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
         flag_yaml: path to manual flagging text file.
         read_axis: str
             str to pass to axis arg for io.HERAData.read(). Default is None
+        apply_flag_to_nsample: bool, optional
+            apply flag to nsample before performing delay filtering, default is False
         filter_kwargs: additional keyword arguments to be passed to DelayFilter.run_delay_filter()
     '''
     if baseline_list is not None and Nbls_per_load is not None:
@@ -177,9 +181,9 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
             logger.info(f"Delay-Filtering baseline group {i+1}/{nbl_groups}")
 
             df = DelayFilter(hd, input_cal=cals)
-            
+
             df.read(
-                bls=baseline_list[i*Nbls_per_load:min((i+1)*Nbls_per_load, len(baseline_list))],
+                bls=baseline_list[i * Nbls_per_load:min((i + 1) * Nbls_per_load, len(baseline_list))],
                 frequencies=freqs, polarizations=polarizations, axis=read_axis
             )
             if avg_red_bllens:
@@ -194,6 +198,14 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
             if factorize_flags:
                 logger.info("  Factorizing flags")
                 df.factorize_flags(time_thresh=time_thresh, inplace=True)
+            if apply_flag_to_nsample:
+                logger.info("  Applying flags to nsample arrays")
+                for bl in baseline_list[i:i + Nbls_per_load]:
+                    _nsample = np.copy(df.hd.get_nsamples(bl))
+                    _nsample[df.hd.get_flags(bl)] = 0
+                    if _nsample.ndim == 2:
+                        _nsample = _nsample[:, :, np.newaxis]
+                    df.hd.set_nsamples(_nsample, bl)
 
             logger.info("  Running Delay Filter")
             df.run_delay_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache,
@@ -201,12 +213,12 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
             logger.info("  Writing filtered data")
             df.write_filtered_data(
                 res_outfilename=res_outfilename, CLEAN_outfilename=CLEAN_outfilename,
-                filled_outfilename=filled_outfilename, 
+                filled_outfilename=filled_outfilename,
                 partial_write=Nbls_per_load < len(baseline_list),
                 clobber=clobber, add_to_history=add_to_history,
                 extra_attrs={
-                    'Nfreqs': df.Nfreqs, 
-                    'freq_array': df.hd.freq_array, 
+                    'Nfreqs': df.Nfreqs,
+                    'freq_array': df.hd.freq_array,
                     'channel_width': df.hd.channel_width,
                     'flex_spw_id_array': df.hd.flex_spw_id_array,
                 }

--- a/hera_cal/delay_filter.py
+++ b/hera_cal/delay_filter.py
@@ -200,12 +200,18 @@ def load_delay_filter_and_write(datafile_list, baseline_list=None, calfile_list=
                 df.factorize_flags(time_thresh=time_thresh, inplace=True)
             if apply_flag_to_nsample:
                 logger.info("  Applying flags to nsample arrays")
+                # Modify self.hd.nsamples
                 for bl in baseline_list[i:i + Nbls_per_load]:
                     _nsample = np.copy(df.hd.get_nsamples(bl))
                     _nsample[df.hd.get_flags(bl)] = 0
                     if _nsample.ndim == 2:
                         _nsample = _nsample[:, :, np.newaxis]
                     df.hd.set_nsamples(_nsample, bl)
+                # Modify self.nsamples
+                for blk in df.nsamples:
+                    _nsample = np.copy(df.nsamples[blk])
+                    _nsample[df.flags[blk]] = 0
+                    df.nsamples[blk] = _nsample
 
             logger.info("  Running Delay Filter")
             df.run_delay_filter(cache_dir=cache_dir, read_cache=read_cache, write_cache=write_cache,

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -138,7 +138,7 @@ class Test_DelayFilter(object):
         input_file = os.path.join(tmp_path, 'temp_special_flags.h5')
         shutil.copy(uvh5, input_file)
         hd = io.HERAData(input_file)
-        _, flags, _ = hd.read()
+        _, flags, nsamples = hd.read()
         ntimes_before = hd.Ntimes
         nfreqs_before = hd.Nfreqs
         freqs_before = hd.freqs
@@ -180,6 +180,16 @@ class Test_DelayFilter(object):
             # check that flags were broadcasted.
             assert np.all(f[bl][0, :])
             assert np.all(f[bl][:, -1])
+
+        # test apply flag to nsample
+        df.load_delay_filter_and_write(input_file, res_outfilename=outfilename, tol=1e-4, Nbls_per_load=1, avg_red_bllens=avg_bl,
+                                       apply_flag_to_nsample=True, time_thresh=time_thresh, clobber=True)
+        hd = io.HERAData(outfilename)
+        d, f, n = hd.read(bls=[(53, 54, 'ee')])
+        for bl in f:
+            # check nsample is the same as input nsample applied with flag
+            nsamples[bl][flags[bl]] = 0
+            assert np.all(nsamples[bl] == n[bl])
 
     def test_load_delay_filter_and_write_baseline_list(self, tmpdir):
         tmp_path = tmpdir.strpath

--- a/hera_cal/tests/test_delay_filter.py
+++ b/hera_cal/tests/test_delay_filter.py
@@ -189,6 +189,7 @@ class Test_DelayFilter(object):
         for bl in f:
             # check nsample is the same as input nsample applied with flag
             nsamples[bl][flags[bl]] = 0
+            assert np.any(n[bl] == 0)
             assert np.all(nsamples[bl] == n[bl])
 
     def test_load_delay_filter_and_write_baseline_list(self, tmpdir):

--- a/hera_cal/vis_clean.py
+++ b/hera_cal/vis_clean.py
@@ -21,7 +21,6 @@ from .utils import echo
 from .flag_utils import factorize_flags
 
 
-
 def discard_autocorr_imag(data_container, keys=None):
     """
     Helper function to discard all imaginary components in autocorrs in a datacontainer.
@@ -1153,7 +1152,7 @@ class VisClean(object):
                     win = flag_rows_with_flags_within_edge_distance(xp, win, skip_if_flag_within_edge_distance, ax=ax)
 
                 mdl, res = np.zeros_like(d), np.zeros_like(d)
-                
+
                 if 0 not in din.shape:
                     mdl, res, info = dspec.fourier_filter(x=xp, data=din, wgts=win, filter_centers=filter_centers,
                                                           filter_half_widths=filter_half_widths,
@@ -1251,7 +1250,7 @@ class VisClean(object):
                     resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice]) | skipped
                 else:
                     resid_flags[k][:, spw_slice] = copy.deepcopy(flags[k][:, spw_slice])
-        
+
         # loop through resids, model, and data and make sure everything is real.
         discard_autocorr_imag(filtered_model, keys=keys)
         discard_autocorr_imag(filtered_resid, keys=keys)
@@ -1890,6 +1889,7 @@ def _trim_status(info_dict, axis, zeropad):
     for i in range(nints):
         statuses[i] = statuses.pop(i + zeropad)
 
+
 def _adjust_info_indices(x, info_dict, edges, freq_baseind):
     """Adjust indices in info dict to reflect rows inserted by restore_flagged_edges
 
@@ -1923,7 +1923,7 @@ def _adjust_info_indices(x, info_dict, edges, freq_baseind):
                 statuses[ind + offset + baseinds[axind]] = statuses.pop(ind)
             offset -= edge[0]
 
-            
+
 # ------------------------------------------
 # Here is an argparser with core arguments
 # needed for all types of xtalk and delay
@@ -1986,6 +1986,7 @@ def _filter_argparser():
     flag_options.add_argument("--dont_flag_model_rms_outliers", default=False, action="store_true", help="Do not flag integrations or channels where the rms of the filter model exceeds the rms of the unflagged data.")
     flag_options.add_argument("--model_rms_threshold", type=float, default=1.1, help="Factor that rms of model in a channel or integration needs to exceed the rms of unflagged data to be flagged.")
     flag_options.add_argument("--clean_flags_not_in_resid_flags", default=False, action="store_true", help="Do not include flags from times/channels skipped in the resid flags.")
+    flag_options.add_argument("--apply_flag_to_nsample", default=False, action="store_true", help="Set nsample to 0 where flag is True before filtering.")
 
     # Arguments for CLEAN. Not used in linear filtering methods.
     clean_options = ap.add_argument_group(title='Options for CLEAN (arguments only used if mode=="clean"!)')
@@ -2073,9 +2074,9 @@ def time_chunk_from_baseline_chunks(time_chunk_template, baseline_chunk_files, o
     else:
         dt_time_chunk = np.median(np.diff(hd_time_chunk.times)) / 2.
         tmax = hd_time_chunk.times.max() + dt_time_chunk
-        
+
         tmin = hd_time_chunk.times.min() - dt_time_chunk
-        
+
         hd_combined = io.HERAData(baseline_chunk_files)
         # we only compare centers of baseline files to time limits of time-file.
         # this is to prevent integrations that straddle file boundaries from being dropped.

--- a/scripts/delay_filter_run.py
+++ b/scripts/delay_filter_run.py
@@ -45,7 +45,7 @@ run_with_profiling(
     cache_dir=ap.cache_dir, res_outfilename=ap.res_outfilename,
     clobber=ap.clobber, write_cache=ap.write_cache, external_flags=ap.external_flags,
     read_cache=ap.read_cache, mode=ap.mode, overwrite_flags=ap.overwrite_flags,
-    factorize_flags=ap.factorize_flags, time_thresh=ap.time_thresh,
+    factorize_flags=ap.factorize_flags, apply_flag_to_nsample=ap.apply_flag_to_nsample, time_thresh=ap.time_thresh,
     add_to_history=' '.join(sys.argv), polarizations=ap.polarizations,
     verbose=ap.verbose, skip_if_flag_within_edge_distance=ap.skip_if_flag_within_edge_distance,
     flag_yaml=ap.flag_yaml, Nbls_per_load=ap.Nbls_per_load,


### PR DESCRIPTION
Add an option in `load_delay_filter_and_write` so that we can add the flags to the N-sample array before delay filtering (i.e., setting `nsample[flag == True] = 0`). Write a new test to support this new option. Also modify the run script.