### PR TITLE
Drop support for 3.8, add 3.11 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV_NAME: publish
-      PYTHON: 3.8
+      PYTHON: 3.9
     steps:
       - uses: actions/checkout@main
         with:


### PR DESCRIPTION
This PR drops support for Python 3.8, which will reach end of life by [October 2024](https://devguide.python.org/versions/), and adds support for Python versions 3.11 and 3.12. 