### PR TITLE
Count phase flips in smooth_cal

### DIFF
--- a/hera_cal/smooth_cal.py
+++ b/hera_cal/smooth_cal.py
@@ -891,7 +891,7 @@ class CalibrationSmoother():
         '''
         all_time_indices = np.array([i for indices in self.time_indices.values() for i in indices])
         assert len(all_time_indices) == len(np.unique(all_time_indices)), \
-                'Multiple calibration integrations map to the same time index.'
+            'Multiple calibration integrations map to the same time index.'
         for cal in self.cals:
             assert np.all(
                 np.abs(self.cal_freqs[cal] - self.freqs) < 1e-4
@@ -901,10 +901,10 @@ class CalibrationSmoother():
             unq_flag = np.unique(all_flag_time_indices)
             unq_time = np.unique(all_time_indices)
             assert len(unq_flag) == len(unq_time) and np.all(unq_flag == unq_time), \
-                    'The number of unique indices for the flag files does not match the calibration files.'
+                'The number of unique indices for the flag files does not match the calibration files.'
             for ff in self.flag_files:
                 assert np.all(np.abs(self.flag_freqs[ff] - self.freqs) < 1e-4), \
-                        '{} and {} have different frequencies.'.format(ff, self.cals[0])
+                    '{} and {} have different frequencies.'.format(ff, self.cals[0])
 
     def rephase_to_refant(self, warn=True, propagate_refant_flags=False):
         '''If the CalibrationSmoother object has a refant attribute, this function rephases the
@@ -1062,7 +1062,9 @@ class CalibrationSmoother():
                                                      skip_flagged_edges=skip_flagged_edges, fix_phase_flips=fix_phase_flips, **win_kwargs)
                 flipped = (info['phase_flips'] == -1)
                 if np.any(flipped):
-                    print(f'{np.sum(flipped)} phase-flipped integrations detected on antenna {ant} between {self.time_grid[flipped][0]} and {self.time_grid[flipped][-1]}.')
+                    print(f'{np.sum(np.diff(flipped))} phase flips detected on antenna {ant}. '
+                          f'A total of {np.sum(flipped)} integrations were phase-flipped relative to the 0th '
+                          f'integration between {self.time_grid[flipped][0]} and {self.time_grid[flipped][-1]}.')
                     if flag_phase_flip_ants:
                         self.flag_grids[ant][:, :] = True
                     # apply flags before and after phase flips


### PR DESCRIPTION
When an antenna experiences a spontaneous phase flip, we now print out how many times that flip happens, not just the number of flips. 

Also some pep8 stuff.