### PR TITLE
Fix stats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: 'hera_cal/data/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -20,6 +20,6 @@ repos:
     args: ['--fix=no']
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1  # pick a git hash / tag to point to
+    rev: 7.0.0  # pick a git hash / tag to point to
     hooks:
     -   id: flake8

--- a/hera_cal/lst_stack/__init__.py
+++ b/hera_cal/lst_stack/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 from .wrappers import lst_bin_files
-from .binning import lst_bin_files_for_baselines, lst_align, lst_bin_files_from_config
+from .binning import lst_bin_files_for_baselines, lst_align, lst_bin_files_from_config, LSTStack
 from .config import LSTBinConfigurator, LSTConfig
 from .io import create_empty_uvd, create_lstbin_output_file, format_outfile_name
 from .averaging import reduce_lst_bins, lst_average

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -4,6 +4,8 @@ import numpy as np
 import logging
 import warnings
 from .binning import LSTStack
+from .. import vis_clean
+from hera_filters import dspec
 
 logger = logging.getLogger(__name__)
 

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -332,7 +332,9 @@ def average_and_inpaint_simultaneously(
                     wgts=wgts[band],
                     mode='dpss_solve',
                     max_contiguous_edge_flags=stack.Nfreqs,
-                    cache=cache
+                    cache=cache,
+                    filter_centers=filter_centers,
+                    filter_half_widths=filter_half_widths,
                     **kwargs,  # noqa: E225
                 )
 

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -75,6 +75,7 @@ def get_lst_median_and_mad(
 def compute_std(
     data: np.ndarray | np.ma.MaskedArray,
     nsamples: np.ndarray | np.ma.MaskedArray,
+    meandata: np.ndarray,
     flags: np.ndarray | None = None
 ):
     logger.info("Calculating std")
@@ -198,7 +199,7 @@ def lst_average(
     norm = np.sum(nsamples, axis=0)
 
     if get_std:
-        std, norm = compute_std(data, nsamples)
+        std, norm = compute_std(data, nsamples, meandata)
     else:
         std = None
 
@@ -242,7 +243,7 @@ def reduce_lst_bins(
     get_mad
         Whether to compute the median and median absolute deviation of the data in each
         LST bin, in addition to the mean and standard deviation.
-    compute_std
+    get_std
         Whether to compute the standard deviation of the data in each LST bin.
 
     Returns

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -431,7 +431,7 @@ def average_and_inpaint_simultaneously(
             # simply sum(n_i) for all i (originally flagged or not).
             inpainted_mean[:] = 0.0
             total_nsamples[:] = 0.0
-            for d, f, n in zip(data, flags, nsamples):
+            for d, f, n in zip(stackd, stackf, stackn):
                 # If an entire integration is flagged, don't use it at all
                 # in the averaging -- it doesn't contibute any knowledge.
                 if np.all(f):

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -196,7 +196,6 @@ def lst_average(
     # what we want for the mean, for the std and nsamples we want to treat flags as really
     # flagged.
     nsamples.mask = flags
-    norm = np.sum(nsamples, axis=0)
 
     if get_std:
         std, norm = compute_std(data, nsamples, meandata)

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -6,6 +6,8 @@ import warnings
 from .binning import LSTStack
 from .. import vis_clean
 from hera_filters import dspec
+from scipy import constants
+from typing import Sequence
 
 logger = logging.getLogger(__name__)
 

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -72,7 +72,7 @@ def get_lst_median_and_mad(
     return med, madrl + madim * 1j
 
 
-def get_std(
+def compute_std(
     data: np.ndarray | np.ma.MaskedArray,
     nsamples: np.ndarray | np.ma.MaskedArray,
     flags: np.ndarray | None = None
@@ -198,7 +198,7 @@ def lst_average(
     norm = np.sum(nsamples, axis=0)
 
     if get_std:
-        std, norm = get_std(data, nsamples)
+        std, norm = compute_std(data, nsamples)
     else:
         std = None
 
@@ -242,7 +242,7 @@ def reduce_lst_bins(
     get_mad
         Whether to compute the median and median absolute deviation of the data in each
         LST bin, in addition to the mean and standard deviation.
-    get_std
+    compute_std
         Whether to compute the standard deviation of the data in each LST bin.
 
     Returns

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -421,7 +421,7 @@ def average_and_inpaint_simultaneously(
 
                 # Update the flags. All successfully-inpainted data is unflagged.
                 # If in-painting is unsuccessful, we flag the data.
-                flgs[band] = (info['status']['axis_0'][0] == 'skipped')
+                flgs[band] = (info['status']['axis_1'][0] == 'skipped')
 
             if return_models:
                 all_models[(*antpair, pol)] = model.copy()

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -308,7 +308,7 @@ def average_and_inpaint_simultaneously(
     # Time axis is outer axis for all LSTStacks.
     uvws = stack.uvw_array.reshape((stack.Ntimes, stack.Nbls, 3))
 
-    newmean = np.ones_like(avg['data']) * np.nan
+    newmean = np.ones_like(lstavg['data']) * np.nan
     complete_flags = stack.flagged_or_inpainted()
 
     for iap, antpair in enumerate(stack.antpairs):

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -325,7 +325,7 @@ def average_and_inpaint_simultaneously(
             )
 
             flagged_mean = lstavg['data'][iap, :, polidx].copy()
-            wgts = lstavg['nsamples'][iap, :, polidx]
+            wgts = lstavg['nsamples'][iap, :, polidx].copy()
 
             # fourier_filter can't deal with nans, even if they're flagged
             nanmask = np.isnan(flagged_mean)

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -301,7 +301,7 @@ def average_and_inpaint_simultaneously(
         A dictionary of the inpainted models, keyed by (ant1, ant2, pol). If
         ``return_models`` is False, the dict is empty.
     """
-    model = np.zeros(stacks[0].Nfreqs, dtype=stacks[0].data_array.dtype)
+    model = np.zeros(stack.Nfreqs, dtype=stack.data_array.dtype)
 
     all_models = {}
 

--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -324,8 +324,13 @@ def average_and_inpaint_simultaneously(
                 **filter_properties,
             )
 
-            flagged_mean = lstavg['data'][iap, :, polidx]
+            flagged_mean = lstavg['data'][iap, :, polidx].copy()
             wgts = lstavg['nsamples'][iap, :, polidx]
+
+            # fourier_filter can't deal with nans, even if they're flagged
+            nanmask = np.isnan(flagged_mean)
+            flagged_mean[nanmask] = 0.0
+            wgts[nanmask] = 0.0
 
             for band in inpaint_bands:
                 model[band], _, info = dspec.fourier_filter(

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -662,6 +662,14 @@ class LSTStack:
             (self.Ntimes, self.Nbls, len(self.freq_array), len(self.polarization_array))
         )
 
+    def inpainted(self) -> np.ndarray:
+        """Flags representing data that is inpainted."""
+        return self.nsamples <= 0
+
+    def flagged_or_inpainted(self):
+        """Flags representing data that is flagged or inpainted."""
+        return self.flags | self.inpainted()
+
     @property
     def metrics(self) -> np.ndarray:
         """A view into the flags array, reshaped to (Nbls, Ntimes, Nfreqs, Npols)."""

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -709,7 +709,7 @@ def lst_bin_files_from_config(
     rephase: bool = True,
     freq_min: float | None = None,
     freq_max: float | None = None,
-) -> list[LSTStack] | None:
+) -> list[LSTStack | None] | None:
     """Read and LST-bin data from a configuration object.
 
     This function is the main entry point for binning (not averaging) data into LST
@@ -790,6 +790,10 @@ def lst_bin_files_from_config(
 
     out = []
     for (d, f, n, wf, bt) in zip(data, flags, nsamples, where_inpainted, binned_times):
+        if len(binned_times) == 0:
+            out.append(None)
+            continue
+
         # To enable inpaint-mode, set nsamples where things are flagged and inpainted
         # to zero, and set the flags to false.
         if wf is not None:

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -790,9 +790,6 @@ def lst_bin_files_from_config(
 
     out = []
     for (d, f, n, wf, bt) in zip(data, flags, nsamples, where_inpainted, binned_times):
-        if len(binned_times) == 0:
-            out.append(None)
-            continue
 
         # To enable inpaint-mode, set nsamples where things are flagged and inpainted
         # to zero, and set the flags to false.

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -135,9 +135,8 @@ def get_squared_zscores(
 
     # convert zstack to UVFlag object
     zstack = UVFlag(stack._uvd, mode='metric', use_future_array_shapes=True)
-    zstack.metric_array = zsq
+    zstack.metric_array = zsq.reshape(stack.data_array.shape)
 
-    out = LSTStack(zstack)
     return LSTStack(zstack)
 
 

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -7,7 +7,7 @@ import attrs
 import numpy as np
 from functools import partial
 from .. import utils
-from pyuvdata import UVData, UVFlag
+from pyuvdata import UVFlag
 from ..red_groups import RedundantGroups
 from .. import types as tp
 from .binning import LSTStack

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -201,7 +201,7 @@ def get_squared_zscores(
 def get_squared_zscores_flagged(
     stack: LSTStack,
     variance: np.ndarray | None = None,
-    auto_stats: lstbin.metrics.LSTBinStats | None = None,
+    auto_stats: LSTBinStats | None = None,
 ):
     zsq = np.zeros(stack.data.shape, dtype=np.float32)
 
@@ -229,7 +229,7 @@ def get_squared_zscores_flagged(
     # convert zstack to UVFlag object
     zstack = UVFlag(stack._uvd, mode='metric', use_future_array_shapes=True)
     zstack.metric_array = zsq.reshape(stack.data_array.shape)
-    return lstbin.averaging.LSTStack(zstack)
+    return LSTStack(zstack)
 
 
 def get_selected_bls(

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -37,6 +37,8 @@ class LSTBinStats:
         kls = partial(RedDataContainer, reds=reds) if reds is not None else DataContainer
 
         for k, v in rdc.items():
+            if v is None:
+                continue
             if k == 'data':
                 k = 'mean'
             dct = {antpair + (pol,): v[i, :, j] for i, antpair in enumerate(antpairs) for j, pol in enumerate(pols)}

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -65,9 +65,13 @@ def get_nightly_predicted_variance(
 
     dtdf = (stack.dt * stack.df).to_value("")
 
-    gf = stack.get_flags(bl)
-    per_day_expected_var = np.abs(auto / dtdf / stack.get_nsamples(bl))
-    per_day_expected_var[gf] = np.inf
+    with np.errstate(divide='ignore'):
+        # Some nsamples can be zero, so we ignore warnings from that.
+        # Also note that in the stack, inpainted samples have -nsamples, rather than
+        # zero. These will thus return a finite expected variance, even though they
+        # technically have no unflagged samples.
+        per_day_expected_var = np.abs(auto / dtdf / stack.get_nsamples(bl))
+
     return per_day_expected_var
 
 

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -372,7 +372,7 @@ def downselect_zscores(
         if not hasattr(nights, '__len__'):
             nights = [nights]
 
-        zsq = zsq[[zscores.nights.tolist().index(n) for n in nights]]
+        zsq = zsq[np.isin(zscores.nights, nights)]
 
     return zsq
 

--- a/hera_cal/lst_stack/stats.py
+++ b/hera_cal/lst_stack/stats.py
@@ -218,7 +218,7 @@ def mean_zsquare_mixture(
     absolute: bool = True,
     min_n: int = 1
 ) -> MixtureModel:
-    """The distribution of the mean Z^2 of n iid visibilities for a collection of such means.
+    """The distribution of the mean Z^2 over the redundant set of n iid visibilities for a collection of such means.
 
     This is the distribution of a *collection* of mean Z-square values, each of which may
     be the mean of a different number of z^2.
@@ -244,7 +244,7 @@ def mean_zsquare_mixture(
     unique_n = unique_n[indx]
     counts = counts[indx]
 
-    return MixtureModel([mean_zsquare(nn, absolute=absolute) for nn in unique_n], weights=counts)
+    return MixtureModel([mean_zsquare_over_redundant_set(nn, absolute=absolute) for nn in unique_n], weights=counts)
 
 
 def excess_variance_mixture(

--- a/hera_cal/lst_stack/tests/test_averaging.py
+++ b/hera_cal/lst_stack/tests/test_averaging.py
@@ -306,11 +306,9 @@ def test_get_std():
 
     mean = np.mean(_d, axis=0)
 
-    std = avg.compute_std(_d, _n, meandata=mean)[0]
-    std2 = avg.compute_std(data, nsamples, meandata=mean, flags=flags)[0]
-    std3 = avg.compute_std(_d, _n, meandata=mean, flags=flags)[0]
+    std = avg.compute_std(_d, _n, mean=mean)[0]
+    std2 = avg.compute_std(_d, _n)[0]
     assert np.all(std == std2)
-    assert np.all(std == std3)
 
 
 class TestReduceLSTBins:

--- a/hera_cal/lst_stack/tests/test_averaging.py
+++ b/hera_cal/lst_stack/tests/test_averaging.py
@@ -296,6 +296,23 @@ class TestLSTAverage:
         assert dbf[0, 0, 0] == 0
 
 
+def test_get_std():
+    data = np.linspace(0, 10, 3 * 4 * 5).reshape(3, 4, 5)
+    nsamples = np.ones_like(data)
+    flags = np.zeros_like(data, dtype=bool)
+    flags[0, 0, 0] = True
+
+    _d, _f, _n = avg.get_masked_data(data, flags, nsamples, inpainted_mode=False)
+
+    mean = np.mean(_d, axis=0)
+
+    std = avg.compute_std(_d, _n, meandata=mean)[0]
+    std2 = avg.compute_std(data, nsamples, meandata=mean, flags=flags)[0]
+    std3 = avg.compute_std(_d, _n, meandata=mean, flags=flags)[0]
+    assert np.all(std == std2)
+    assert np.all(std == std3)
+
+
 class TestReduceLSTBins:
     @classmethod
     def get_input_data(

--- a/hera_cal/lst_stack/tests/test_metrics.py
+++ b/hera_cal/lst_stack/tests/test_metrics.py
@@ -116,7 +116,7 @@ class TestGetZSquared:
         assert isinstance(zsq, LSTStack)
         assert zsq.metrics.shape == cross_stack.data.shape
 
-        dist = stats.zsquare(n=len(zsq.nights), absolute=True)
+        dist = stats.zsquare(absolute=True)
 
         # Check if the mean lines up. The variance on the mean is equal to
         # the variance of chi2(df=2nnights)/nnights^2 == 4*nnights/nnights^2.
@@ -168,7 +168,7 @@ class TestGetSelectedBls:
 class TestDownSelectZscores:
     def setup_class(self):
         uvd = mockuvd.create_mock_hera_obs(
-            integration_time=1.0, ntimes=20, jd_start=2459844.0, ants=[0, 1, 2, 3],
+            integration_time=24 * 3600, ntimes=20, jd_start=2459844.0, ants=[0, 1, 2, 3],
             time_axis_faster_than_bls=False
         )
         uvf = UVFlag(uvd, mode='metric', use_future_array_shapes=True)

--- a/hera_cal/lst_stack/tests/test_metrics.py
+++ b/hera_cal/lst_stack/tests/test_metrics.py
@@ -57,7 +57,7 @@ def cross_stack(lstconfig) -> LSTStack:
 
 @pytest.fixture(scope='module')
 def auto_rdc(auto_stack) -> dict[str, np.ndarray]:
-    return reduce_lst_bins(auto_stack, get_mad=True)
+    return reduce_lst_bins(auto_stack, get_mad=False)
 
 
 @pytest.fixture(scope='module')
@@ -106,6 +106,14 @@ class TestGetNightlyPredictedVariance:
                 np.testing.assert_allclose(predicted_var[0] / 2, std.real**2, atol=0, rtol=0.5)
                 np.testing.assert_allclose(predicted_var[0] / 2, std.imag**2, atol=0, rtol=0.5)
 
+    def test_as_stack(self, cross_stack, auto_stats):
+        v = mt.get_nightly_predicted_variance_stack(
+            stack=cross_stack,
+            auto_stats=auto_stats,
+        )
+        assert v.shape == cross_stack.data.shape
+        assert np.all(v >= 0)
+
 
 class TestGetZSquared:
     @pytest.mark.parametrize("central", ['mean', 'median'])
@@ -136,6 +144,17 @@ class TestGetZSquared:
     def test_wrong_std(self, auto_stats, cross_stats, cross_stack):
         with pytest.raises(ValueError, match="std must be 'autos', 'std' or 'mad'"):
             mt.get_squared_zscores(auto_stats, cross_stats, cross_stack, std='bad')
+
+    def test_get_flagged_z(self, auto_stats, cross_stats, cross_stack):
+        zsq = mt.get_squared_zscores_flagged(
+            cross_stack, auto_stats=auto_stats
+        )
+        v = mt.get_nightly_predicted_variance_stack(
+            cross_stack, auto_stats=auto_stats, flag_if_inpainted=True
+        ) / 2
+        zsq2 = mt.get_squared_zscores_flagged(cross_stack, variance=v)
+
+        assert np.all(zsq.metrics == zsq2.metrics)
 
 
 class TestGetSelectedBls:

--- a/hera_cal/lst_stack/tests/test_stats.py
+++ b/hera_cal/lst_stack/tests/test_stats.py
@@ -166,7 +166,7 @@ def test_excess_var(absolute, ndays, weighted):
 def test_mean_zsquare_mixture(absolute):
     zsq, navg = get_samples(
         absolute=absolute, mean_over_days=True,
-        ndays=10, nvars=10000, weighted=True, allow_zeros=True
+        ndays=10, nvars=1000, weighted=True, allow_zeros=True
     )
     dist = stats.mean_zsquare_mixture(absolute=absolute, n=navg)
 

--- a/hera_cal/lst_stack/tests/test_stats.py
+++ b/hera_cal/lst_stack/tests/test_stats.py
@@ -7,57 +7,76 @@ from scipy.stats import gamma, chi2, norm
 
 def get_vis(
     ndays: int = 10,
+    ninds: int = 1,
     nvars: int = 200000,
     weighted: bool = False,
     allow_zeros: bool = False,
-    absolute: bool = True
 ):
-    rng = np.random.default_rng(1)
+    rng = np.random.default_rng()
 
     if weighted:
-        weights = rng.integers(low=0 if allow_zeros else 1, high=10, size=(ndays, nvars))
+        weights = rng.integers(low=0 if allow_zeros else 1, high=10, size=(ndays, ninds))
         weights[0] = 1  # Ensure at least one day is included
+        weights = weights[:, :, None] * np.ones((ndays, ninds, nvars))
     else:
-        weights = np.ones((ndays, nvars))
+        weights = np.ones((ndays, ninds, nvars))
 
-    scale = np.ones_like(weights).astype(float)
+    scale = np.ones_like(weights).astype(float)  # *np.nan
     scale[weights > 0] = 1 / np.sqrt(weights[weights > 0])
 
-    x = rng.normal(scale=scale)
-    if absolute:
-        x = x + 1j * rng.normal(scale=scale)
+    x = rng.normal(scale=scale) + 1j * rng.normal(scale=scale)
 
     return x, weights
 
 
 def get_samples(
     ndays: int = 10,
+    ninds: int = 1,
     nvars: int = 200000,
     absolute: bool = True,
-    mean: bool = False,
-    weighted: bool = False,
+    mean_over_days: bool = False,
+    mean_over_ind: bool = False,
+    weighted: bool = True,
     allow_zeros: bool = False
 ):
-    x, weights = get_vis(ndays, nvars, weighted, allow_zeros, absolute)
+    x, weights = get_vis(ndays, ninds, nvars, weighted, allow_zeros)
+
     avg = np.average(x, axis=0, weights=weights)
+    m = np.sum(weights, axis=0)
+    prefac = weights * m / (m - weights)
+    if absolute:
+        zsq = prefac * np.abs(x - avg)**2
+    else:
+        zsq = prefac * np.abs(x.real - avg.real)**2
 
-    zsq = weights * np.abs(x - avg)**2
-    if mean:
-        zsq = np.mean(zsq, axis=0)
+    if mean_over_days:
+        zsq = np.mean(zsq * (m - weights) / m, axis=0)
 
-    n_averaged = np.sum(weights > 0, axis=0)
+    n_averaged = np.sum(weights[:, :, 0] > 0, axis=0)
 
-    return zsq, n_averaged
+    if mean_over_ind:
+        if not mean_over_days:
+            zsq = np.mean(zsq, axis=1)[0]
+        else:
+            zsq = np.mean(zsq, axis=0)
+            n_averaged = np.sum(n_averaged, axis=0)
+    else:
+        if ninds > 1:
+            raise ValueError("only use ninds>1 if averaging over ind")
+        n_averaged = n_averaged[0]
+
+    return zsq.flatten(), n_averaged
 
 
 def get_excess_variance(
     ndays: int = 10,
+    ninds: int = 1,
     nvars: int = 200000,
     absolute: bool = True,
-    weighted: bool = False,
-    allow_zeros: bool = False
+    weighted: bool = True,
+    allow_zeros: bool = True
 ):
-    x, weights = get_vis(ndays, nvars, weighted, allow_zeros, absolute)
+    x, weights = get_vis(ndays, ninds, nvars, weighted, allow_zeros)
     avg = np.average(x, axis=0, weights=weights)
 
     var = np.average((x.real - avg.real)**2, axis=0, weights=weights)
@@ -66,12 +85,12 @@ def get_excess_variance(
         yvar = np.average((x.imag - avg.imag)**2, axis=0, weights=weights)
         var += yvar
 
-    excess_var = var * np.sum(weights, axis=0) / (ndays - 1)  # Bessel's correction, true var is 1
+    n_averaged = np.sum(weights > 0, axis=0)
+
+    excess_var = var * np.sum(weights, axis=0) / (n_averaged - 1)  # Bessel's correction, true var is 1
 
     if absolute:
         excess_var /= 2
-
-    n_averaged = np.sum(weights > 0, axis=0)
 
     return excess_var, n_averaged
 
@@ -80,8 +99,8 @@ def get_excess_variance(
 @pytest.mark.parametrize("ndays", [2, 3, 10, 50])
 @pytest.mark.parametrize("weighted", [True, False])
 def test_zsquare(absolute, ndays, weighted):
-    zsq, _ = get_samples(absolute=absolute, mean=False, ndays=ndays, weighted=weighted)
-    dist = stats.zsquare(absolute=absolute, n=ndays)
+    zsq, _ = get_samples(absolute=absolute, ndays=ndays, weighted=weighted)
+    dist = stats.zsquare(absolute=absolute)
 
     # Test statistics...
     np.testing.assert_allclose(dist.mean(), np.mean(zsq), atol=1e-2)
@@ -91,9 +110,40 @@ def test_zsquare(absolute, ndays, weighted):
 @pytest.mark.parametrize("absolute", [True, False])
 @pytest.mark.parametrize("ndays", [2, 3, 10, 50])
 @pytest.mark.parametrize("weighted", [True, False])
-def test_zsquare_mean(absolute, ndays, weighted):
-    zsq, _ = get_samples(absolute=absolute, mean=True, ndays=ndays, weighted=weighted)
-    dist = stats.mean_zsquare(absolute=absolute, n=ndays)
+def test_zsquare_mean_over_redundant(absolute, ndays, weighted):
+    zsq, _ = get_samples(absolute=absolute, mean_over_days=True, ndays=ndays, weighted=weighted)
+    dist = stats.mean_zsquare_over_redundant_set(absolute=absolute, n=ndays)
+
+    # Test statistics...
+    np.testing.assert_allclose(dist.mean(), np.mean(zsq), atol=1e-2)
+    np.testing.assert_allclose(dist.var(), np.var(zsq), rtol=0.1)
+
+
+@pytest.mark.parametrize("absolute", [True, False])
+@pytest.mark.parametrize("ndays", [2, 3, 8])
+@pytest.mark.parametrize("ninds", [4, 8])
+@pytest.mark.parametrize("weighted", [True, False])
+def test_zsquare_mean_over_ind(absolute, ndays, ninds, weighted):
+    zsq, _ = get_samples(absolute=absolute, mean_over_ind=True, ndays=ndays, ninds=ninds, weighted=weighted)
+    dist = stats.mean_zsquare_over_independent_set(absolute=absolute, q=ninds)
+
+    # Test statistics...
+    np.testing.assert_allclose(dist.mean(), np.mean(zsq), atol=1e-2)
+    np.testing.assert_allclose(dist.var(), np.var(zsq), rtol=0.1)
+
+
+@pytest.mark.parametrize("absolute", [True, False])
+@pytest.mark.parametrize("ndays", [2, 3, 8])
+@pytest.mark.parametrize("ninds", [4, 8])
+@pytest.mark.parametrize("weighted", [True, False])
+def test_zsquare_mean_over_both(absolute, ndays, ninds, weighted):
+    zsq, n = get_samples(
+        absolute=absolute, mean_over_ind=True, mean_over_days=True, ndays=ndays,
+        ninds=ninds, weighted=weighted
+    )
+    dist = stats.mean_zsquare_over_redundant_and_independent_sets(
+        absolute=absolute, nsets=ninds, ntot=n
+    )
 
     # Test statistics...
     np.testing.assert_allclose(dist.mean(), np.mean(zsq), atol=1e-2)
@@ -104,7 +154,7 @@ def test_zsquare_mean(absolute, ndays, weighted):
 @pytest.mark.parametrize("ndays", [2, 3, 10, 50])
 @pytest.mark.parametrize("weighted", [True, False])
 def test_excess_var(absolute, ndays, weighted):
-    zsq, _ = get_excess_variance(absolute=absolute, ndays=ndays, weighted=weighted)
+    zsq, _ = get_excess_variance(absolute=absolute, ndays=ndays, weighted=weighted, allow_zeros=False)
     dist = stats.excess_variance(absolute=absolute, n=ndays)
 
     # Test statistics...
@@ -114,7 +164,10 @@ def test_excess_var(absolute, ndays, weighted):
 
 @pytest.mark.parametrize("absolute", [True, False])
 def test_mean_zsquare_mixture(absolute):
-    zsq, navg = get_samples(absolute=absolute, mean=True, ndays=10, nvars=10000, weighted=True, allow_zeros=True)
+    zsq, navg = get_samples(
+        absolute=absolute, mean_over_days=True,
+        ndays=10, nvars=10000, weighted=True, allow_zeros=True
+    )
     dist = stats.mean_zsquare_mixture(absolute=absolute, n=navg)
 
     # Test statistics...
@@ -124,7 +177,9 @@ def test_mean_zsquare_mixture(absolute):
 
 @pytest.mark.parametrize("absolute", [True, False])
 def test_excess_variance_mixture(absolute):
-    zsq, navg = get_excess_variance(absolute=absolute, ndays=10, weighted=True, nvars=10000, allow_zeros=True)
+    zsq, navg = get_excess_variance(
+        absolute=absolute, ndays=10, weighted=True, nvars=10000, allow_zeros=True
+    )
     dist = stats.excess_variance_mixture(absolute=absolute, n=navg)
 
     # Test statistics...

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -56,7 +56,7 @@ def create_mock_hera_obs(
         if jd_start < 2000000:
             jd_start += jdint
         times = np.arange(jd_start, ntimes * tint + jd_start, tint)[:ntimes]
-
+        print(times)
     if ants is None:
         ants = list(HERA_ANTPOS.keys())
 

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -56,7 +56,7 @@ def create_mock_hera_obs(
         if jd_start < 2000000:
             jd_start += jdint
         times = np.arange(jd_start, ntimes * tint + jd_start, tint)[:ntimes]
-        print(times)
+
     if ants is None:
         ants = list(HERA_ANTPOS.keys())
 


### PR DESCRIPTION
This fixes the stats module so that the distributions align with the new memo (not published as yet... in Danny's todo log). It also adds much more complete docstrings to those distributions.

It also adds a new function to do simultaneous inpainting and LST-binning, as well as a new function to get z^2 scores in a faster way on a whole stack. 

