### PR TITLE
Fix creation of UVData object in LSTStack to use proper antenna positions

### DIFF
--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -800,7 +800,7 @@ def lst_bin_files_from_config(
         uv = UVData.new(
             freq_array=freqs,
             polarization_array=utils.polstr2num([_comply_vispol(p) for p in config.pols], x_orientation=meta.x_orientation),
-            antenna_positions=meta.antpos_enu,
+            antenna_positions=meta.antenna_positions,
             telescope_location=EarthLocation.from_geocentric(*meta.telescope_location, unit="m"),
             telescope_name=meta.telescope_name,
             times=bt,

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ..config import LSTBinConfigurator
 import shutil
 from hera_cal.lst_stack.io import apply_filename_rules
-from pyuvdata import UVFlag
+from pyuvdata import UVFlag, UVData
 
 
 class TestAdjustLSTBinEdges:
@@ -368,6 +368,10 @@ class TestLSTBinFilesFromConfig:
         assert uvd.Nbls == uvd1.Nbls == len(cfg.antpairs)
         assert uvd.Nfreqs == uvd1.Nfreqs == len(cfg.config.datameta.freq_array)
         assert uvd.Npols == uvd1.Npols == len(cfg.config.datameta.pols)
+
+        # test that exposes bug fixed in 3a3ead0fd13400578b50b5fe05af39be61717206
+        uvd0 = UVData.from_file(cfg.matched_files[0])
+        assert np.allclose(uvd.get_ENU_antpos()[0], uvd0.get_ENU_antpos()[0])
 
     def test_redavg_with_where_inpainted(self, request, tmp_path_factory):
         # This is kind of a dodgy way to test that if the inpainted files don't have


### PR DESCRIPTION
This follows from a bug @tyler-a-cox found in the lststack notebook where baseline vectors were not actually ENU coordinates, leading to underestimates of baseline vector lengths when only using E and N (but ignoring U). I think the transformation involving telescope location was being performed twice. 