### PR TITLE
Remove an unused import that will break in pyuvdata v3

### DIFF
--- a/hera_cal/tests/test_utils.py
+++ b/hera_cal/tests/test_utils.py
@@ -14,7 +14,6 @@ import copy
 from contextlib import contextmanager
 from pyuvdata import UVData
 from pyuvdata import UVCal
-import pyuvdata.tests as uvtest
 from sklearn import gaussian_process as gp
 from ..redcal import filter_reds
 from ..redcal import get_pos_reds


### PR DESCRIPTION
This import isn't used, so there should be no affect to the code. Generally, it'd be a good idea to remove unused imports. There are linters that can help you find those.