### PR TITLE
make sure to copy attributes on subtraction

### DIFF
--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -218,6 +218,7 @@ class DataContainer:
     def __add__(self, D):
         '''
         Addition operator overload.
+        returns a copy of this container.
 
         Add the values of this DataContainer with
         the value of D. If D is another DataContainer, add
@@ -255,6 +256,8 @@ class DataContainer:
         Subtraction operator overload.
 
         Subtract D with the values of this DataContainer.
+        returns a copy of this container.
+
         If D is another DataContainer, subtract
         their values and form a new container,
         otherwise subtract D from each ndarray in self.
@@ -287,6 +290,7 @@ class DataContainer:
     def __mul__(self, D):
         '''
         Multiplication operator overload.
+        returns a copy of this container.
 
         Multiply D with the values of this DataContainer.
         If D is another DataContainer, multiply
@@ -321,6 +325,7 @@ class DataContainer:
     def __floordiv__(self, D):
         '''
         Floor division operator overload, i.e. //.
+        returns a copy of this container.
 
         Floor divide the values of this DataContainer by D.
         If D is another DataContainer, floor divide
@@ -365,6 +370,7 @@ class DataContainer:
     def __truediv__(self, D):
         '''
         True division operator overload, i.e. /.
+        returns a copy of this container.
 
         True divide the values of this DataContainer by D.
         If D is another DataContainer, true divide

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -259,6 +259,7 @@ class DataContainer:
         otherwise subtract D from each ndarray in self.
         '''
         # check type of D
+        newD = copy.deepcopy(self)
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
             if D[list(D.keys())[0]].shape[0] != self.__getitem__(list(self.keys())[0]).shape[0]:
@@ -266,15 +267,13 @@ class DataContainer:
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
 
-            # start new object
-            newD = odict()
 
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
                     newD[k] = self.__getitem__(k) - D[k]
 
-            return DataContainer(newD)
+            return newD
 
         else:
             newD = copy.deepcopy(self)

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -387,8 +387,6 @@ class DataContainer:
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
 
-            # start new object
-            newD = odict()
 
             # iterate over D keys
             for i, k in enumerate(D.keys()):

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -224,6 +224,8 @@ class DataContainer:
         their values together and form a new container,
         otherwise add D to each ndarray in self.
         '''
+        # make output datacontainer
+        newD = copy.deepcopy(self)
         # check type of D
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
@@ -233,14 +235,13 @@ class DataContainer:
                 raise ValueError("[1] axis of dictionary values don't match")
 
             # start new object
-            newD = odict()
 
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
                     newD[k] = self.__getitem__(k) + D[k]
 
-            return DataContainer(newD)
+            return newD
 
         else:
             newD = copy.deepcopy(self)
@@ -258,8 +259,9 @@ class DataContainer:
         their values and form a new container,
         otherwise subtract D from each ndarray in self.
         '''
-        # check type of D
+        # make output datacontainer
         newD = copy.deepcopy(self)
+        # check type of D
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
             if D[list(D.keys())[0]].shape[0] != self.__getitem__(list(self.keys())[0]).shape[0]:
@@ -291,6 +293,8 @@ class DataContainer:
         their values together and form a new container,
         otherwise multiply D with each ndarray in self.
         '''
+        # start a new output object
+        newD = copy.deepcopy(self)
         # check type of D
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
@@ -299,15 +303,13 @@ class DataContainer:
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
 
-            # start new object
-            newD = odict()
 
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
                     newD[k] = self.__getitem__(k) * D[k]
 
-            return DataContainer(newD)
+            return newD
 
         else:
             newD = copy.deepcopy(self)
@@ -325,6 +327,8 @@ class DataContainer:
         their values and form a new container,
         otherwise floor divide D from each ndarray in self.
         '''
+        # start a new output object
+        newD = copy.deepcopy(self)
         # check type of D
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
@@ -345,7 +349,7 @@ class DataContainer:
                         div = self.__getitem__(k) / D[k]
                         newD[k] = np.real(div).astype(int) + 1j * np.imag(div).astype(int)
 
-            return DataContainer(newD)
+            return newD
 
         else:
             newD = copy.deepcopy(self)
@@ -367,6 +371,8 @@ class DataContainer:
         their values and form a new container,
         otherwise true divide D from each ndarray in self.
         '''
+        # start a new output object
+        newD = copy.deepcopy(self)
         # check type of D
         if isinstance(D, DataContainer):
             # check time and frequency structure matches
@@ -383,7 +389,7 @@ class DataContainer:
                 if self.__contains__(k):
                     newD[k] = self.__getitem__(k) / D[k]
 
-            return DataContainer(newD)
+            return newD
 
         else:
             newD = copy.deepcopy(self)

--- a/hera_cal/datacontainer.py
+++ b/hera_cal/datacontainer.py
@@ -245,7 +245,6 @@ class DataContainer:
             return newD
 
         else:
-            newD = copy.deepcopy(self)
             for k in newD.keys():
                 newD[k] = newD[k] + D
 
@@ -271,7 +270,6 @@ class DataContainer:
                 raise ValueError("[0] axis of dictionary values don't match")
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
-
 
             # iterate over D keys
             for i, k in enumerate(D.keys()):
@@ -307,7 +305,6 @@ class DataContainer:
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
 
-
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
@@ -316,7 +313,6 @@ class DataContainer:
             return newD
 
         else:
-            newD = copy.deepcopy(self)
             for k in newD.keys():
                 newD[k] = newD[k] * D
 
@@ -357,7 +353,6 @@ class DataContainer:
             return newD
 
         else:
-            newD = copy.deepcopy(self)
             for k in newD.keys():
                 if not (np.iscomplexobj(newD[k]) or np.iscomplexobj(D)):
                     newD[k] = newD[k] // D
@@ -387,7 +382,6 @@ class DataContainer:
             if D[list(D.keys())[0]].shape[1] != self.__getitem__(list(self.keys())[0]).shape[1]:
                 raise ValueError("[1] axis of dictionary values don't match")
 
-
             # iterate over D keys
             for i, k in enumerate(D.keys()):
                 if self.__contains__(k):
@@ -396,7 +390,6 @@ class DataContainer:
             return newD
 
         else:
-            newD = copy.deepcopy(self)
             for k in newD.keys():
                 newD[k] = newD[k] / D
 

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -19,6 +19,8 @@ class TestDataContainer(object):
         self.antpairs = [(1, 2), (2, 3), (3, 4), (1, 3), (2, 4)]  # not (1,4)
         self.pols = ['xx', 'yy']
         self.blpol = {}
+        self.lsts = np.array([1.1])
+        self.freqs = np.array([101.1])#the edge
         for bl in self.antpairs:
             self.blpol[bl] = {}
             for pol in self.pols:
@@ -33,7 +35,7 @@ class TestDataContainer(object):
             for bl in self.antpairs:
                 self.both[bl + (pol,)] = 1j
         self.bools = {}
-        for pol in self.pols:
+        for pol in self.pols:   
             for bl in self.antpairs:
                 self.bools[bl + (pol,)] = np.array([True])
         self.blpolarr = {}
@@ -359,6 +361,8 @@ class TestDataContainerWithRealData:
         pytest.raises(ValueError, d.__add__, d2)
         d2 = d + 1
         assert np.isclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] + 1)
+        assert np.isclose(d2.freqs,d.freqs)
+        assert np.isclose(d2.lsts,d.lsts)
 
     def test_sub(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -346,6 +346,10 @@ class TestDataContainerWithRealData:
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d + d
+        assert type(d2.freqs)==type(d.freqs)
+        assert type(d2.lsts)==type(d.lsts)
+        assert np.allclose(d2.freqs,d.freqs)
+        assert np.allclose(d2.lsts,d.lsts)
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] * 2)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
@@ -361,6 +365,10 @@ class TestDataContainerWithRealData:
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d - d
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], 0.0)
+        assert type(d2.freqs)==type(d.freqs)
+        assert type(d2.lsts)==type(d.lsts)
+        assert np.allclose(d2.freqs,d.freqs)
+        assert np.allclose(d2.lsts,d.lsts)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]
@@ -376,6 +384,10 @@ class TestDataContainerWithRealData:
         f[(24, 25, 'ee')][:, 0] = False
         f2 = f * f
         assert not np.any(f2[(24, 25, 'ee')][0, 0])
+        assert type(f2.freqs)==type(f.freqs)
+        assert type(f2.lsts)==type(f.lsts)
+        assert np.allclose(f2.freqs,f.freqs)
+        assert np.allclose(f2.lsts,f.lsts)
         # test exception
         d2, f2 = io.load_vis(test_file, pop_autos=True)
         d2[list(d2.keys())[0]] = d2[list(d2.keys())[0]][:, :10]
@@ -394,6 +406,10 @@ class TestDataContainerWithRealData:
         d, f = io.load_vis(test_file, pop_autos=True)
         d2 = d / d
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], 1.0)
+        assert type(d2.freqs)==type(d.freqs)
+        assert type(d2.lsts)==type(d.lsts)
+        assert np.allclose(d2.freqs,d.freqs)
+        assert np.allclose(d2.lsts,d.lsts)
         d2 = d / 2.0
         assert np.allclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] / 2.0)
         d2 = d // d

--- a/hera_cal/tests/test_datacontainer.py
+++ b/hera_cal/tests/test_datacontainer.py
@@ -361,8 +361,8 @@ class TestDataContainerWithRealData:
         pytest.raises(ValueError, d.__add__, d2)
         d2 = d + 1
         assert np.isclose(d2[(24, 25, 'ee')][30, 30], d[(24, 25, 'ee')][30, 30] + 1)
-        assert np.isclose(d2.freqs,d.freqs)
-        assert np.isclose(d2.lsts,d.lsts)
+        assert np.allclose(d2.freqs,d.freqs)
+        assert np.allclose(d2.lsts,d.lsts)
 
     def test_sub(self):
         test_file = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")


### PR DESCRIPTION
Subtracting two datacontainers returned a new datacontainer shorn of all attributes. This fixes the problem by always returning the difference with all the attributes of the A, where the difference being computed is A - B.