### PR TITLE
Fix flagging issue in expand degeneracies function LST-Cal

### DIFF
--- a/hera_cal/lst_stack/calibration.py
+++ b/hera_cal/lst_stack/calibration.py
@@ -127,7 +127,7 @@ def _expand_degeneracies_to_ant_gains(
                     tau, _ = utils.fft_dly(
                         raw_ant_gain[:, band],
                         np.diff(stack.freq_array[band])[0],
-                        wgts=np.logical_not(stack.flags[:, 0, band, polidx]),
+                        wgts=np.logical_not(flags[:, band, polidx]),
                     )
                     rephasor = np.exp(-2.0j * np.pi * tau * stack.freq_array[band])
                     raw_ant_gain[:, band] *= rephasor


### PR DESCRIPTION
This PR fixes an issue in `_expand_degeneracies_to_ant_gains` where the array averaged flagging pattern was not used when computing the delay of the gains when smoothing.