### PR TITLE
fix: force flagged averaged data to be inf

### DIFF
--- a/hera_cal/lst_stack/averaging.py
+++ b/hera_cal/lst_stack/averaging.py
@@ -708,8 +708,12 @@ def average_and_inpaint_simultaneously(
         data=auto_stack.data.transpose((1, 0, 2, 3)),
         flags=auto_stack.flags.transpose((1, 0, 2, 3)),
         nsamples=auto_stack.nsamples.transpose((1, 0, 2, 3)),
-        get_std=False, get_mad=False, inpainted_mode=False, mean_fill_value=0.0
+        get_std=False, get_mad=False, inpainted_mode=False, mean_fill_value=np.inf
     )
+
+    # Something weird happens in reduce_lst_bins due to MaskedArrays, and the flagged
+    # values don't actually get set to inf properly. We just force it here to be sure.
+    auto_redavg['data'][auto_redavg['flags']] = np.inf + 0j
 
     # Map antenna polarizations to visibility pol indices for correct noise variance computation
     # even for cross-polarized visibilities, which use the auto-polarized autocorrelations.


### PR DESCRIPTION
Fixes a weird bug where flagged values in the mean turned out to be 0 regardless of the value of `mean_fill_value`, and this was causing nans in the variance in simultaneous inpainting. This fix is a patch-up; we should investigate the root cause (something to do with MaskedArray behaviour that I don't understand). 