### PR TITLE
Future pyuvdata compatibility

### DIFF
--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1872,9 +1872,9 @@ def partial_time_io(hd, times=None, time_range=None, lsts=None, lst_range=None, 
                          return_data=False, **kwargs)
         except ValueError as err:
             # check to see if the read failed because of the time range or lst range
-            if 'No elements in time range between ' in str(err) or 'No elements in time_array between ' in str(err):
+            if 'No elements in time range between ' in str(err) or 'No elements in time_array between ' in str(err) or 'No data matching this time selection present in object' in str(err):
                 continue  # no matching times, skip this file
-            elif 'No elements in LST range between ' in str(err) or 'No elements in lst_array between ' in str(err):
+            elif 'No elements in LST range between ' in str(err) or 'No elements in lst_array between ' in str(err) or 'No data matching this lst selection present in object' in str(err):
                 continue  # no matchings lsts, skip this file
             else:
                 raise

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -1268,10 +1268,10 @@ class Test_Visibility_IO_Legacy:
             shutil.rmtree('ex.uv')
 
     @pytest.mark.filterwarnings("ignore:writing default values for restfreq")
-    def test_update_vis(self):
+    def test_update_vis(self, tmpdir):
         # load in cal
         fname = os.path.join(DATA_PATH, "zen.2458043.12552.xx.HH.uvORA")
-        outname = os.path.join(DATA_PATH, "test_output/zen.2458043.12552.xx.HH.modified.uvORA")
+        outname = os.path.join(tmpdir, "zen.2458043.12552.xx.HH.modified.uvORA")
         uvd = UVData()
         uvd.read_miriad(fname)
         data, flags, antpos, ants, freqs, times, lsts, pols = io.load_vis(fname, return_meta=True)


### PR DESCRIPTION
Fix error handling to account for slight upcoming changes to error messages when no data matches a selection.

Note that the new changes in pyuvdata make it so that no error is raised if some of the criteria are not met, but we still issue an error if none of the criteria are met. I'm not really sure why you want to allow for that...

I also fixed a test that fails for me locally because it tries to write to a non-existent directory, which I presume you all create. I changed it to use the pytest fixture to write to a temporary directory as I consider that much better behavior for tests.

I'll also note that I had some trouble getting a consistent environment set up to be able to test hera_cal. Apparently the aipy conda package is not compatible with numpy 2.0 (https://github.com/conda-forge/aipy-feedstock/pull/30). If hera_cal really needs to depend on aipy that needs to be fixed. Although I note that at least some of the errors seem to be related to using aipy to interface with miriad files which pyuvdata can do. I **strongly** suggest that at least one CI job uses conda to set up the test environment so you can catch this kind of problem.