### PR TITLE
Update to reflect pyuvdata 3.2 changes to x_orientation handling

### DIFF
--- a/hera_cal/abscal.py
+++ b/hera_cal/abscal.py
@@ -4186,8 +4186,10 @@ def post_redcal_abscal_run(data_file, redcal_file, model_files, raw_auto_file=No
             warnings.warn(f"Warning: Overwriting redcal gain_scale of {hc.gain_scale} with model gain_scale of {hdm.vis_units}", RuntimeWarning)
         hc.gain_scale = hdm.vis_units  # set vis_units of hera_cal based on model files.
         hd_autos = io.HERAData(raw_auto_file)
-        assert hdm.telescope.x_orientation.lower() == hd.telescope.x_orientation.lower(), 'Data x_orientation, {}, does not match model x_orientation, {}'.format(hd.telescope.x_orientation.lower(), hdm.telescope.x_orientation.lower())
-        assert hc.telescope.x_orientation.lower() == hd.telescope.x_orientation.lower(), 'Data x_orientation, {}, does not match redcal x_orientation, {}'.format(hd.telescope.x_orientation.lower(), hc.telescope.x_orientation.lower())
+        assert hdm.telescope.get_x_orientation_from_feeds().lower() == hd.telescope.get_x_orientation_from_feeds().lower(), \
+            f'Data x_orientation, {hd.telescope.x_orientation.lower()}, does not match model x_orientation, {hdm.telescope.x_orientation.lower()}'
+        assert hc.telescope.get_x_orientation_from_feeds().lower() == hd.telescope.get_x_orientation_from_feeds().lower(), \
+            f'Data x_orientation, {hd.telescope.get_x_orientation_from_feeds().lower()}, does not match redcal x_orientation, {hc.telescope.get_x_orientation_from_feeds().lower()}'
         pol_load_list = [pol for pol in hd.pols if split_pol(pol)[0] == split_pol(pol)[1]]
 
         # get model bls and antpos to use later in baseline matching

--- a/hera_cal/chunker.py
+++ b/hera_cal/chunker.py
@@ -81,7 +81,7 @@ def chunk_files(filenames, inputfile, outputfile, chunk_size, type="data",  # no
         if spw_range is None:
             spw_range = (0, chunked_files.Nfreqs)
         # convert polarizations to jones integers.
-        jones = [uvutils.polstr2num(pol, x_orientation=chunked_files.telescope.x_orientation) for pol in polarizations]
+        jones = [uvutils.polstr2num(pol, x_orientation=chunked_files.telescope.get_x_orientation_from_feeds()) for pol in polarizations]
         chunked_files.select(freq_chans=np.arange(spw_range[0], spw_range[1]).astype(int), jones=jones)
     # throw away fully flagged baselines.
     if throw_away_flagged_ants:

--- a/hera_cal/frf.py
+++ b/hera_cal/frf.py
@@ -471,7 +471,7 @@ def build_fringe_rate_profiles(uvd, uvb, keys=None, normed=True, combine_pols=Tr
         echo(f"Generating FR-Profile of {bl} at {str(datetime.datetime.now())}", verbose=verbose)
         # sum beams from all frequencies
         # get polarization index
-        polindex = np.where(uvutils.polstr2num(bl[-1], x_orientation=uvb.x_orientation) == uvb.polarization_array)[0][0]
+        polindex = np.where(uvutils.polstr2num(bl[-1], x_orientation=uvb.get_x_orientation_from_feeds()) == uvb.polarization_array)[0][0]
         # get baseline vector in equitorial coordinates.
         blvec = antpos_trf[antnums == bl[1]] - antpos_trf[antnums == bl[0]]
         # initialize binned power.

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -345,7 +345,15 @@ def read_hera_calfits(filenames, ants=None, pols=None,
             jones_array = _gethduaxis(fname[0], 2)
             _jhash = hash(jones_array.tobytes())
             if _jhash not in inds:
-                info['x_orientation'] = x_orient = hdr['XORIENT']
+                if 'XORIENT' in hdr:
+                    # using old standard for x_orientation (prior to pyuvdata 3.2)
+                    info['x_orientation'] = x_orient = hdr['XORIENT']
+                else:
+                    # using new standard for x_orientation
+                    feed_array = np.array([[item.strip().lower() for item in antdata["POLTYA"]],
+                                           [item.strip().lower() for item in antdata["POLTYB"]]]).T
+                    feed_angle = np.radians([antdata["POLAA"], antdata["POLAB"]]).T
+                    info['x_orientation'] = uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle)
                 _pols = [uvutils.parse_jpolstr(uvutils.JONES_NUM2STR_DICT[num], x_orientation=x_orient)
                          for num in jones_array]
                 if 'pols' in info:

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -2212,7 +2212,6 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
                 antenna_names=antenna_names,
                 antenna_positions=antenna_positions,
                 instrument=instrument,
-                x_orientation=x_orientation,
             )
         }
     else:
@@ -2223,7 +2222,6 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
             "antenna_names": antenna_names,
             "antenna_positions": antenna_positions,
             "instrument": instrument,
-            "x_orientation": x_orientation,
         }
     uvd = UVData.new(
         freq_array=freq_array,
@@ -2236,6 +2234,7 @@ def write_vis(fname, data, lst_array, freq_array, antpos, time_array=None, flags
         history=history,
         **tel_params,
     )
+    uvd.telescope.set_feeds_from_x_orientation(x_orientation, feeds=['x', 'y'])  # assumes linear polarization
 
     # set data
     for antpair in antpairs:
@@ -2560,7 +2559,6 @@ def write_cal(fname, gains, freqs, times, antpos=None, lsts=None, flags=None, qu
     if hasattr(UVCal(), "telescope"):
         if antpos is None:
             tel_use = Telescope.from_known_telescopes(telescope_name)
-            tel_use.x_orientation = x_orientation
         else:
             tel_use = Telescope.new(
                 name=telescope_name,
@@ -2568,8 +2566,8 @@ def write_cal(fname, gains, freqs, times, antpos=None, lsts=None, flags=None, qu
                 antenna_numbers=antenna_numbers,
                 antenna_names=antenna_names,
                 antenna_positions=antenna_positions,
-                x_orientation=x_orientation,
             )
+        tel_use.set_feeds_from_x_orientation(x_orientation, feeds=['x', 'y'])  # assumes linear polarization
         tel_params = {"telescope": tel_use}
     else:
         if antpos is None:

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1298,10 +1298,10 @@ def read_hera_hdf5(filenames, bls=None, pols=None, full_read_thresh=0.002,
                 npols = pol_array.size
                 # the following errors if x_orientation not set in this hdf5
                 if 'x_orientation' in h:
-                    x_orient = str(h['x_orientation'][()], encoding='utf-8')
+                    info['x_orientation'] = str(h['x_orientation'][()], encoding='utf-8')
                 else:
-                    x_orient = uvutils.pol.get_x_orientation_from_feeds(np.char.decode(h['feed_array'][()], encoding='utf-8'), h['feed_angle'][()])
-                pol_indices = {uvutils.parse_polstr(POL_NUM2STR_DICT[n], x_orientation=x_orient): cnt
+                    info['x_orientation'] = uvutils.pol.get_x_orientation_from_feeds(np.char.decode(h['feed_array'][()], encoding='utf-8'), h['feed_angle'][()])
+                pol_indices = {uvutils.parse_polstr(POL_NUM2STR_DICT[n], x_orientation=info['x_orientation']): cnt
                                for cnt, n in enumerate(pol_array)}
                 info['pols'] = list(pol_indices.keys())
                 info['ants'] = antenna_numbers = h['antenna_numbers'][()]
@@ -1474,7 +1474,7 @@ class HERADataFastReader():
 
         # update metadata internally
         self.info = rv['info']
-        for meta in HERAData.HERAData_metas:
+        for meta in HERAData.HERAData_metas + ['x_orientation',]:
             if meta in rv['info']:
                 setattr(self, meta, rv['info'][meta])
             else:

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -347,14 +347,16 @@ def read_hera_calfits(filenames, ants=None, pols=None,
             if _jhash not in inds:
                 if 'XORIENT' in hdr:
                     # using old standard for x_orientation (prior to pyuvdata 3.2)
-                    info['x_orientation'] = x_orient = hdr['XORIENT']
+                    info['x_orientation'] = hdr['XORIENT']
                 else:
                     # using new standard for x_orientation
                     feed_array = np.array([[item.strip().lower() for item in antdata["POLTYA"]],
                                            [item.strip().lower() for item in antdata["POLTYB"]]]).T
                     feed_angle = np.radians([antdata["POLAA"], antdata["POLAB"]]).T
-                    info['x_orientation'] = uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle)
-                _pols = [uvutils.parse_jpolstr(uvutils.JONES_NUM2STR_DICT[num], x_orientation=x_orient)
+                    print(feed_array, feed_angle)
+                    print(uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle))
+                    info['x_orientation'] = uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle, tols=[1e-6, 0])
+                _pols = [uvutils.parse_jpolstr(uvutils.JONES_NUM2STR_DICT[num], x_orientation=info['x_orientation'])
                          for num in jones_array]
                 if 'pols' in info:
                     info['pols'] = info['pols'].union(set(_pols))

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -1295,7 +1295,10 @@ def read_hera_hdf5(filenames, bls=None, pols=None, full_read_thresh=0.002,
                 pol_array = h['polarization_array'][()]
                 npols = pol_array.size
                 # the following errors if x_orientation not set in this hdf5
-                x_orient = str(h['x_orientation'][()], encoding='utf-8')
+                if 'x_orientation' in h:
+                    x_orient = str(h['x_orientation'][()], encoding='utf-8')
+                else:
+                    x_orient = uvutils.pol.get_x_orientation_from_feeds(np.char.decode(h['feed_array'][()], encoding='utf-8'), h['feed_angle'][()])
                 pol_indices = {uvutils.parse_polstr(POL_NUM2STR_DICT[n], x_orientation=x_orient): cnt
                                for cnt, n in enumerate(pol_array)}
                 info['pols'] = list(pol_indices.keys())

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -353,8 +353,6 @@ def read_hera_calfits(filenames, ants=None, pols=None,
                     feed_array = np.array([[item.strip().lower() for item in antdata["POLTYA"]],
                                            [item.strip().lower() for item in antdata["POLTYB"]]]).T
                     feed_angle = np.radians([antdata["POLAA"], antdata["POLAB"]]).T
-                    print(feed_array, feed_angle)
-                    print(uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle))
                     info['x_orientation'] = uvutils.pol.get_x_orientation_from_feeds(feed_array, feed_angle, tols=[1e-6, 0])
                 _pols = [uvutils.parse_jpolstr(uvutils.JONES_NUM2STR_DICT[num], x_orientation=info['x_orientation'])
                          for num in jones_array]

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -804,9 +804,11 @@ def lst_bin_files_from_config(
             antenna_names=meta.antenna_names,
             antenna_numbers=meta.antenna_numbers,
             antenna_positions=meta.antenna_positions,
-            x_orientation=meta.x_orientation,
             instrument=meta.instrument,
+            mount_type=meta.mount_type,
+            antenna_diameters=meta.antenna_diameters
         )
+        telescope.set_feeds_from_x_orientation(meta.x_orientation, feeds=['x', 'y'])  # assumes linear polarization
         uv = UVData.new(
             freq_array=freqs,
             polarization_array=utils.polstr2num([_comply_vispol(p) for p in config.pols], x_orientation=meta.x_orientation),

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -696,7 +696,7 @@ class LSTStack:
     @property
     def pols(self) -> list[str]:
         """The polarizations in the data."""
-        return utils.polnum2str(self.polarization_array, x_orientation=self.telescope.x_orientation)
+        return utils.polnum2str(self.polarization_array, x_orientation=self.telescope.get_x_orientation_from_feeds())
 
     def copy(self, *args, **kwargs):
         """Return a copy of the LSTStack object."""

--- a/hera_cal/lst_stack/io.py
+++ b/hera_cal/lst_stack/io.py
@@ -237,7 +237,7 @@ def create_empty_uvd(
     # Need to set the polarization array manually because even though the select
     # operation does the down-select, it doesn't re-order the pols.
     uvd_template.polarization_array = np.array(
-        uvutils.polstr2num(pols, x_orientation=uvd_template.telescope.x_orientation)
+        uvutils.polstr2num(pols, x_orientation=uvd_template.telescope.get_x_orientation_from_feeds())
     )
     return uvd_template
 

--- a/hera_cal/lst_stack/metrics.py
+++ b/hera_cal/lst_stack/metrics.py
@@ -350,7 +350,7 @@ def downselect_zscores(
     """
     nbls = zscores.Nbls
     datapols = utils.polnum2str(
-        zscores.polarization_array, x_orientation=zscores.telescope.x_orientation
+        zscores.polarization_array, x_orientation=zscores.telescope.get_x_orientation_from_feeds()
     )
     datapairs = list(
         zip(zscores.ant_1_array[:nbls], zscores.ant_2_array[:nbls])

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -320,7 +320,7 @@ class TestLSTBinFilesForBaselines:
                 reds=RedundantGroups.from_antpos(
                     dict(zip(uvd.telescope.antenna_numbers, uvd.telescope.antenna_positions)),
                     pols=uvutils.polnum2str(
-                        uvd.polarization_array, x_orientation=uvd.telescope.x_orientation
+                        uvd.polarization_array, x_orientation=uvd.telescope.get_x_orientation_from_feeds()
                     ),
                 ),
                 antpairs=uvd.get_antpairs(),

--- a/hera_cal/lstbin.py
+++ b/hera_cal/lstbin.py
@@ -741,7 +741,7 @@ def lst_bin_files(data_files, input_cals=None, dlst=None, verbose=True, ntimes_p
     last_day_index = np.argmax([np.min([time for tarr in tarrs for time in tarr]) for tarrs in time_arrs])
     zeroth_file_on_last_day_index = np.argmin([np.min(tarr) for tarr in time_arrs[last_day_index]])
     hd = io.HERAData(data_files[last_day_index][zeroth_file_on_last_day_index])
-    x_orientation = hd.telescope.x_orientation
+    x_orientation = hd.telescope.get_x_orientation_from_feeds()
 
     # get metadata
     freq_array = hd.freqs

--- a/hera_cal/reflections.py
+++ b/hera_cal/reflections.py
@@ -476,7 +476,7 @@ class ReflectionFitter(FRFilter):
             if cal.Nfreqs > Nfreqs:
                 freq_array = cal.freq_array
             kwargs = {
-                'x_orientation': cal.telescope.x_orientation,
+                'x_orientation': cal.telescope.get_x_orientation_from_feeds(),
                 'telescope_name': cal.telescope.name,
                 'cal_style': cal.cal_style,
                 'gain_convention': cal.gain_convention,
@@ -484,7 +484,7 @@ class ReflectionFitter(FRFilter):
             }
             add_to_history += "\nMerged-in calibration {}".format(input_calfits)
         else:
-            kwargs = {'x_orientation': self.hd.telescope.x_orientation, }
+            kwargs = {'x_orientation': self.hd.telescope.get_x_orientation_from_feeds()}
 
             if self.hd.integration_time is not None:
                 unique_intg = np.unique(self.hd.integration_time)

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -62,7 +62,7 @@ def create_mock_hera_obs(
 
     hera = Telescope.from_known_telescopes('HERA')
     hera.instrument = 'hera'
-    hera.x_orientation = x_orientation
+    hera.set_feed_from_x_orientation(x_orientation)
 
     if ants is None:
         ants = hera.antenna_numbers

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -62,7 +62,7 @@ def create_mock_hera_obs(
 
     hera = Telescope.from_known_telescopes('HERA')
     hera.instrument = 'hera'
-    hera.set_feed_from_x_orientation(x_orientation)
+    hera.set_feeds_from_x_orientation(x_orientation)
 
     if ants is None:
         ants = hera.antenna_numbers

--- a/hera_cal/tests/mock_uvdata.py
+++ b/hera_cal/tests/mock_uvdata.py
@@ -62,7 +62,7 @@ def create_mock_hera_obs(
 
     hera = Telescope.from_known_telescopes('HERA')
     hera.instrument = 'hera'
-    hera.set_feeds_from_x_orientation(x_orientation)
+    hera.set_feeds_from_x_orientation(x_orientation, feeds=['x', 'y'])  # this assumes linear polarization
 
     if ants is None:
         ants = hera.antenna_numbers

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -1015,6 +1015,29 @@ class Test_HERADataFastReader:
         for ap in hd1.lsts_by_bl:
             np.testing.assert_allclose(hd1.lsts_by_bl[ap], hd2.lsts_by_bl[ap])
 
+    @pytest.mark.filterwarnings("ignore:Combined frequencies are separated by more than their channel width")
+    def test_roundtrip_hd_x_orientation(self, tmp_path):
+        # Read original with HERAData
+        hd = io.HERAData(self.uvh5_1)
+        # ensure metadata is loaded
+        hd.read()
+
+        # Write out via HERAData
+        out_file = tmp_path / "roundtrip.uvh5"
+        hd.write_uvh5(str(out_file), clobber=True)
+
+        # Initialize fast reader on the written file
+        fr = io.HERADataFastReader(str(out_file))
+        # Load only metadata to get x_orientation
+        fr.read(read_flags=False, read_nsamples=False, check=True)
+
+        # Compare x_orientation matches original
+        orig_x_orient = hd.telescope.get_x_orientation_from_feeds()
+        fr_x_orient = fr.x_orientation
+        assert fr_x_orient == orig_x_orient, (
+            f"FastReader x_orientation '{fr_x_orient}' != original '{orig_x_orient}'"
+        )
+
     def test_errors(self):
         hd = io.HERADataFastReader([self.uvh5_1, self.uvh5_2])
         with pytest.raises(NotImplementedError):

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -1119,6 +1119,25 @@ class Test_ReadHeraCalfits(object):
             assert k in rv1['gains']
             np.testing.assert_array_equal(rv1['gains'][k], rv2['gains'][k])
 
+    def test_heracal_roundtrip_with_read_hera_calfits(self, tmp_path):
+        # Load with HERACal
+        hc = io.HERACal(self.fname_2pol)
+        gains, flags, quals, total_qual = hc.read()
+        print(hc.telescope.get_x_orientation_from_feeds())
+
+        # Write out a new calfits file
+        out = tmp_path / "roundtrip.calfits"
+        hc.write_calfits(str(out), clobber=True)
+
+        # Now load it via read_hera_calfits
+        rv = io.read_hera_calfits(str(out), read_gains=True, read_flags=True, read_quality=True,
+                                  read_tot_quality=False, check=True, verbose=True)
+
+        # Check x_orientation round-trips correctly
+        assert rv["info"]["x_orientation"] == hc.telescope.get_x_orientation_from_feeds()
+
+        # And clean up (tmp_path gets auto-deleted)
+
 
 @pytest.mark.filterwarnings("ignore:The default for the `center` keyword has changed")
 class Test_Visibility_IO_Legacy:

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -61,13 +61,13 @@ class Test_HERACal:
         gains, flags, quals, total_qual = hc.read()
         uvc = UVCal()
         uvc.read_calfits(self.fname)
-        np.testing.assert_array_equal(uvc.gain_array[0, :, :, 0].T, gains[9, parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation)])
-        np.testing.assert_array_equal(uvc.flag_array[0, :, :, 0].T, flags[9, parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation)])
-        np.testing.assert_array_equal(uvc.quality_array[0, :, :, 0].T, quals[9, parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation)])
-        np.testing.assert_array_equal(uvc.total_quality_array[:, :, 0].T, total_qual[parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation)])
+        np.testing.assert_array_equal(uvc.gain_array[0, :, :, 0].T, gains[9, parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds())])
+        np.testing.assert_array_equal(uvc.flag_array[0, :, :, 0].T, flags[9, parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds())])
+        np.testing.assert_array_equal(uvc.quality_array[0, :, :, 0].T, quals[9, parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds())])
+        np.testing.assert_array_equal(uvc.total_quality_array[:, :, 0].T, total_qual[parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds())])
         np.testing.assert_array_equal(np.unique(uvc.freq_array), hc.freqs)
         np.testing.assert_array_equal(np.unique(uvc.time_array), hc.times)
-        assert hc.pols == [parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation), parse_jpolstr('jyy', x_orientation=hc.telescope.x_orientation)]
+        assert hc.pols == [parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds()), parse_jpolstr('jyy', x_orientation=hc.telescope.get_x_orientation_from_feeds())]
         assert set([ant[0] for ant in hc.ants]) == set(uvc.ant_array)
 
         # test list loading
@@ -78,7 +78,7 @@ class Test_HERACal:
         assert len(quals.keys()) == 36
         assert hc.freqs.shape == (1024,)
         assert hc.times.shape == (3,)
-        assert sorted(hc.pols) == [parse_jpolstr('jxx', x_orientation=hc.telescope.x_orientation), parse_jpolstr('jyy', x_orientation=hc.telescope.x_orientation)]
+        assert sorted(hc.pols) == [parse_jpolstr('jxx', x_orientation=hc.telescope.get_x_orientation_from_feeds()), parse_jpolstr('jyy', x_orientation=hc.telescope.get_x_orientation_from_feeds())]
 
     def test_read_select(self):
         # test read multiple files and select times
@@ -353,7 +353,7 @@ class Test_HERAData(object):
             np.testing.assert_array_equal(hd._get_slice(hd.data_array, bl), hd.get_data(bl))
         np.testing.assert_array_equal(hd._get_slice(hd.data_array, (54, 53, 'EE')),
                                       hd.get_data((54, 53, 'EE')))
-        np.testing.assert_array_equal(hd._get_slice(hd.data_array, (53, 54))[parse_polstr('XX', x_orientation=hd.telescope.x_orientation)],
+        np.testing.assert_array_equal(hd._get_slice(hd.data_array, (53, 54))[parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds())],
                                       hd.get_data((53, 54, 'EE')))
         np.testing.assert_array_equal(hd._get_slice(hd.data_array, 'EE')[(53, 54)],
                                       hd.get_data((53, 54, 'EE')))
@@ -447,7 +447,7 @@ class Test_HERAData(object):
         assert hd.last_read_kwargs['polarizations'] is None
         for dc in [d, f, n]:
             assert len(dc) == 1
-            assert list(dc.keys()) == [(53, 54, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))]
+            assert list(dc.keys()) == [(53, 54, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))]
             assert dc[53, 54, 'ee'].shape == (10, 100)
         with pytest.raises(ValueError):
             d, f, n = hd.read(polarizations=['xy'])
@@ -493,7 +493,7 @@ class Test_HERAData(object):
         assert hd.last_read_kwargs['polarizations'] == ['XX']
         for dc in [d, f, n]:
             assert len(dc) == 1
-            assert list(dc.keys()) == [(52, 53, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))]
+            assert list(dc.keys()) == [(52, 53, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))]
             assert dc[52, 53, 'ee'].shape == (10, 30)
         with pytest.raises(NotImplementedError):
             d, f, n = hd.read(read_data=False)
@@ -507,7 +507,7 @@ class Test_HERAData(object):
         for dc in [d, f, n]:
             assert len(dc) == 1
             assert list(dc.keys()) == [
-                (ant_pairs[0][0], ant_pairs[0][1], parse_polstr('XX', x_orientation=hd.telescope.x_orientation))
+                (ant_pairs[0][0], ant_pairs[0][1], parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))
             ]
             assert dc[ant_pairs[0][0], ant_pairs[0][1], 'ee'].shape == (60, 10)
 
@@ -609,7 +609,7 @@ class Test_HERAData(object):
         hd = HERAData(self.uvh5_1)
         assert hd._writers == {}
         d, f, n = hd.read(bls=hd.bls[0])
-        assert hd.last_read_kwargs['bls'] == (53, 53, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))
+        assert hd.last_read_kwargs['bls'] == (53, 53, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))
         d[(53, 53, 'EE')] *= 2.0
         hd.partial_write('out.h5', data=d, clobber=True)
         assert 'out.h5' in hd._writers
@@ -622,12 +622,12 @@ class Test_HERAData(object):
                     assert np.all(getattr(hd, meta)[k] == getattr(hd._writers['out.h5'], meta)[k])
 
         d, f, n = hd.read(bls=hd.bls[1])
-        assert hd.last_read_kwargs['bls'] == (53, 54, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))
+        assert hd.last_read_kwargs['bls'] == (53, 54, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))
         d[(53, 54, 'EE')] *= 2.0
         hd.partial_write('out.h5', data=d, clobber=True)
 
         d, f, n = hd.read(bls=hd.bls[2])
-        assert hd.last_read_kwargs['bls'] == (54, 54, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))
+        assert hd.last_read_kwargs['bls'] == (54, 54, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))
         d[(54, 54, 'EE')] *= 2.0
         hd.partial_write('out.h5', data=d, clobber=True, inplace=True)
         d_after, _, _ = hd.build_datacontainers()
@@ -677,7 +677,7 @@ class Test_HERAData(object):
 
         hd = HERAData(self.miriad_1, filetype='miriad')
         d, f, n = next(hd.iterate_over_bls(bls=[(52, 53, 'xx')]))
-        assert list(d.keys()) == [(52, 53, parse_polstr('XX', x_orientation=hd.telescope.x_orientation))]
+        assert list(d.keys()) == [(52, 53, parse_polstr('XX', x_orientation=hd.telescope.get_x_orientation_from_feeds()))]
         with pytest.raises(NotImplementedError):
             next(hd.iterate_over_bls())
 
@@ -1051,7 +1051,7 @@ class Test_ReadHeraCalfits(object):
                                   verbose=True)
         assert np.allclose(hc.times, rv['info']['times'])
         assert np.allclose(hc.freqs, rv['info']['freqs'])
-        assert hc.telescope.x_orientation == rv['info']['x_orientation']
+        assert hc.telescope.get_x_orientation_from_feeds() == rv['info']['x_orientation']
         assert hc.gain_convention == rv['info']['gain_convention']
         for key, gain in g.items():
             assert np.allclose(gain, rv['gains'][key])
@@ -1138,13 +1138,13 @@ class Test_Visibility_IO_Legacy:
         data, flags = io.load_vis(fname, pop_autos=False)
         assert data[(24, 25, 'ee')].shape == (60, 64)
         assert flags[(24, 25, 'ee')].shape == (60, 64)
-        assert (24, 24, parse_polstr('EE', x_orientation=self.uvd.telescope.x_orientation)) in data
+        assert (24, 24, parse_polstr('EE', x_orientation=self.uvd.telescope.get_x_orientation_from_feeds())) in data
         data, flags = io.load_vis([fname])
         assert data[(24, 25, 'ee')].shape == (60, 64)
 
         # test pop autos
         data, flags = io.load_vis(fname, pop_autos=True)
-        assert (24, 24, parse_polstr('EE', x_orientation=self.uvd.telescope.x_orientation)) not in data
+        assert (24, 24, parse_polstr('EE', x_orientation=self.uvd.telescope.get_x_orientation_from_feeds())) not in data
 
         # test uvd object
         uvd = UVData()
@@ -1198,7 +1198,7 @@ class Test_Visibility_IO_Legacy:
         d, f = io.load_vis([uvd1, uvd2], nested_dict=True)
         for i, j in d:
             for pol in d[i, j]:
-                uvpol = list(uvd1.polarization_array).index(polstr2num(pol, x_orientation=uvd1.telescope.x_orientation))
+                uvpol = list(uvd1.polarization_array).index(polstr2num(pol, x_orientation=uvd1.telescope.get_x_orientation_from_feeds()))
                 uvmask = np.all(
                     np.array(list(zip(uvd.ant_1_array, uvd.ant_2_array))) == [i, j], axis=1)
                 np.testing.assert_equal(d[i, j][pol], np.resize(
@@ -1209,7 +1209,7 @@ class Test_Visibility_IO_Legacy:
         d, f = io.load_vis([filename1, filename2], nested_dict=True)
         for i, j in d:
             for pol in d[i, j]:
-                uvpol = list(uvd.polarization_array).index(polstr2num(pol, x_orientation=uvd.telescope.x_orientation))
+                uvpol = list(uvd.polarization_array).index(polstr2num(pol, x_orientation=uvd.telescope.get_x_orientation_from_feeds()))
                 uvmask = np.all(
                     np.array(list(zip(uvd.ant_1_array, uvd.ant_2_array))) == [i, j], axis=1)
                 np.testing.assert_equal(d[i, j][pol], np.resize(
@@ -1247,7 +1247,7 @@ class Test_Visibility_IO_Legacy:
         assert hd.data_array.shape == (1680, 64, 1)
         assert np.allclose(data[(24, 25, 'ee')][30, 32], uvd.get_data(24, 25, 'ee')[30, 32])
         assert np.allclose(data[(24, 25, 'ee')][30, 32], hd.get_data(24, 25, 'ee')[30, 32])
-        assert hd.telescope.x_orientation.lower() == 'east'
+        assert hd.telescope.get_x_orientation_from_feeds().lower() == 'east'
         for ant in ap:
             np.testing.assert_array_almost_equal(hd.antpos[ant], ap[ant])
         os.remove("ex.uvh5")
@@ -1259,7 +1259,7 @@ class Test_Visibility_IO_Legacy:
         assert uvd.flag_array.shape == (1680, 64, 1)
         assert np.allclose(nsample[(24, 25, 'ee')][30, 32], uvd.get_nsamples(24, 25, 'ee')[30, 32])
         assert np.allclose(flgs[(24, 25, 'ee')][30, 32], uvd.get_flags(24, 25, 'ee')[30, 32])
-        assert uvd.telescope.x_orientation.lower() == 'east'
+        assert uvd.telescope.get_x_orientation_from_feeds().lower() == 'east'
 
         # test exceptions
         pytest.raises(AttributeError, io.write_vis, "ex.uv", data, lst, f, ap)
@@ -1349,7 +1349,7 @@ class Test_Calibration_IO_Legacy:
         assert len(quals.keys()) == 36
         assert freqs.shape == (1024,)
         assert times.shape == (3,)
-        assert sorted(pols) == [parse_jpolstr('jxx', x_orientation=cal.telescope.x_orientation), parse_jpolstr('jyy', x_orientation=cal.telescope.x_orientation)]
+        assert sorted(pols) == [parse_jpolstr('jxx', x_orientation=cal.telescope.get_x_orientation_from_feeds()), parse_jpolstr('jyy', x_orientation=cal.telescope.get_x_orientation_from_feeds())]
 
         cal_xx, cal_yy = UVCal(), UVCal()
         cal_xx.read_calfits(fname_xx)
@@ -1360,7 +1360,7 @@ class Test_Calibration_IO_Legacy:
         assert len(quals.keys()) == 36
         assert freqs.shape == (1024,)
         assert times.shape == (3,)
-        assert sorted(pols) == [parse_jpolstr('jxx', x_orientation=cal_xx.telescope.x_orientation), parse_jpolstr('jyy', x_orientation=cal_yy.telescope.x_orientation)]
+        assert sorted(pols) == [parse_jpolstr('jxx', x_orientation=cal_xx.telescope.get_x_orientation_from_feeds()), parse_jpolstr('jyy', x_orientation=cal_yy.telescope.get_x_orientation_from_feeds())]
 
     def test_write_cal(self):
         # create fake data

--- a/hera_cal/utils.py
+++ b/hera_cal/utils.py
@@ -1373,7 +1373,7 @@ def red_average(data, reds=None, bl_tol=1.0, inplace=False,
     if fed_container:
         pols = sorted(data.pols())
     else:
-        pols = [polnum2str(pol, x_orientation=data.telescope.x_orientation) for pol in data.polarization_array]
+        pols = [polnum2str(pol, x_orientation=data.telescope.get_x_orientation_from_feeds()) for pol in data.polarization_array]
 
     # get redundant groups
     if reds is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "hdf5plugin",
     "astropy",
     "astropy-healpix",
-    "pyuvdata>=3.1.3",
+    "pyuvdata>=3.2",
     "linsolve",
     "hera_qm>=2.2.0",
     "scikit-learn",


### PR DESCRIPTION
This PR updates to use `.telescope.get_x_orientation_from_feeds()`, rather than `.telescope.x_orientation` which will eventually be deprecated in pyuvdata. The goal is to remove the various deprecation warnings. This cuts down the warnings significantly, though there's still several (not all our fault!) 

When writing data to disk with a given x_orientation, we need to assume that the feed is linearly polarized "x y" (and not circularly polarized "l r"). This should be fine for any HERA application.

This PR had to update some of the fast readers, since the underlying metadata in calfits and uvh5 is changing. Right now, if you use pyuvdata 3.2.0+ and you write a file with .write_uvh5 and then try to read it with HERADataFastReader, it will error (which turns out to be a problem in the new part of the H6C IDR3 pipeline I'm working on). This fixes this and adds new unit tests to cover the problem.

