### PR TITLE
Allow LST-cal to work with inpainted data

### DIFF
--- a/hera_cal/lst_stack/calibration.py
+++ b/hera_cal/lst_stack/calibration.py
@@ -219,7 +219,7 @@ def _lstbin_amplitude_calibration(
 
             # Compute the weights for the baseline from the number of samples and flags
             # Here, we use the absolute value of the number of samples to ensure we have a positive weight
-            # when the data has been flagged and inpainted.  
+            # when the data has been flagged and inpainted.
             wgts_here[blpol] = np.abs(stack.nsamples[:, apidx, :, polidx]) * (
                 ~flags[:, apidx, :, polidx]
             ).astype(float)

--- a/hera_cal/lst_stack/tests/test_calibration.py
+++ b/hera_cal/lst_stack/tests/test_calibration.py
@@ -352,7 +352,7 @@ class TestLSTBinCalibration:
         auto_stack_copy.data *= gains[:, None, :, :] ** 2
         model = np.mean(self.stack.data, axis=0)
         auto_model = np.mean(self.auto_stack.data, axis=0)
-        
+
         # Calculate parameters with positive nsamples
         cal_params, gains = calibration.lstbin_absolute_calibration(
             stack_copy,


### PR DESCRIPTION
This PR modifies the LST-cal code to work with data that have already been inpainted. In particular, this PR uses the proper flags and nsamples to fit for the degenerate parameters.