### PR TITLE
Graduate distance_to_nearest_nonzero() from notebook to hera_cal

### DIFF
--- a/hera_cal/tests/test_flag_utils.py
+++ b/hera_cal/tests/test_flag_utils.py
@@ -213,6 +213,17 @@ def test_get_minimal_slices_band_without_false():
             np.array([[1, 0, 1],
                       [0, 1, 2]], dtype=float),
         ),
+        # 3-D case
+        (
+            np.array([[[0, 1, 0],      # first row, first “plane”
+                       [0, 0, 2]],
+                      [[3, 0, 0],      # second “plane”
+                       [0, 0, 0]]]),
+            np.array([[[1, 0, 1],
+                       [2, 1, 0]],
+                      [[0, 1, 2],
+                       [np.inf, np.inf, np.inf]]], dtype=float),
+        ),
     ],
 )
 def test_expected_values(arr, expected):


### PR DESCRIPTION
This function is currently in https://github.com/HERA-Team/hera_notebook_templates/blob/master/notebooks/single_baseline_2D_informed_inpaint.ipynb as `distance_to_nearest_nonzero_vectorized()`. I'd like to use it for my single-baseline LST-binner and re-inpainter that I'm working on. Even if that doesn't pan out, it's good to graduate code from notebooks.

This PR generalizes it to higher dimensions (the distance is always computed over the last dimension and usually all you care about is distance in frequency when the first axis is time). It also improves the documentation and adds unit tests (thanks chat-gpt!) 

