### PR TITLE
fix: mount_type doesn't always exist

### DIFF
--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -805,7 +805,7 @@ def lst_bin_files_from_config(
             antenna_numbers=meta.antenna_numbers,
             antenna_positions=meta.antenna_positions,
             instrument=meta.instrument,
-            mount_type=meta.mount_type,
+            mount_type=getattr(meta, "mount_type", None),
             antenna_diameters=meta.antenna_diameters
         )
         telescope.set_feeds_from_x_orientation(meta.x_orientation, feeds=['x', 'y'])  # assumes linear polarization


### PR DESCRIPTION
`mount_type` doesn't always exist in the HDF5 files, so when it doesn't just it to None.