### PR TITLE
explicitly test paths generated by build_visfile_to_calfile_map

### DIFF
--- a/hera_cal/lst_stack/config.py
+++ b/hera_cal/lst_stack/config.py
@@ -781,7 +781,7 @@ class LSTBinConfiguratorSingleBaseline():
                 matches = re.findall(r"\d{7}", visfile)[0]  # find the JD in the filename
                 if len(matches) < 1:
                     raise ValueError(f"Could not find a unique night in {visfile}.")
-                cal_file_path = cal_file_template.format(night=matches[0])
+                cal_file_path = cal_file_template.format(night=matches)
                 self.visfile_to_calfile_map[visfile] = cal_file_path
 
         return self.visfile_to_calfile_map

--- a/hera_cal/lst_stack/tests/test_config.py
+++ b/hera_cal/lst_stack/tests/test_config.py
@@ -313,9 +313,15 @@ class TestLSTBinConfiguratorSingleBaseline():
         for night in nights:
             night_dir = tmp_path / night
             night_dir.mkdir(parents=True, exist_ok=True)
+            cal_dir = tmp_path / "cals"
+            cal_dir.mkdir(parents=True, exist_ok=True)
+            calfl = cal_dir / f"cal_{night}.h5"
+            calfl.touch()
+
             for bl in baselines:
                 fl = night_dir / f"{bl}.uvh5"
                 fl.touch()
+
 
     def test_build_bl_to_file_map(self, tmp_path):
         nights = ["2458001", "2458002"]
@@ -347,6 +353,7 @@ class TestLSTBinConfiguratorSingleBaseline():
         for bl in cfg.bl_to_file_map:
             for visfile in cfg.bl_to_file_map[bl]:
                 assert visfile in out
+                assert Path(out[visfile]).exists()
 
     def test_from_toml(self, tmp_path):
         nights = ["2458001", "2458002"]

--- a/hera_cal/lst_stack/tests/test_config.py
+++ b/hera_cal/lst_stack/tests/test_config.py
@@ -322,7 +322,6 @@ class TestLSTBinConfiguratorSingleBaseline():
                 fl = night_dir / f"{bl}.uvh5"
                 fl.touch()
 
-
     def test_build_bl_to_file_map(self, tmp_path):
         nights = ["2458001", "2458002"]
         baselines = ["0_1", "1_2"]


### PR DESCRIPTION
This PR fixes a small bug in the `build_visfile_to_calfile_map` function that was not previously tested.