### PR TITLE
Add option to load files in parallel when LST stacking

### DIFF
--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -316,10 +316,14 @@ def _read_one_file(
         inpainted   DataContainer or None
         bls_loaded  list of antpairs that were actually loaded
     """
+    # Inspect file metadata (cheap; no I/O on the data arrays)
     meta = FastUVH5Meta(meta_path, blts_are_rectangular=blts_are_rectangular)
     data_antpairs = meta.get_transactional("antpairs")
     ntimes = len(tind)
 
+    # Determine which baselines to actually read
+    # For redundantly-averaged files we must map the requested unique-baseline
+    # keys back to whichever physical baseline is stored in this file.
     if redundantly_averaged:
         bls_to_load = [
             bl for bl in data_antpairs
@@ -342,6 +346,7 @@ def _read_one_file(
                 "data": None, "flags": None, "nsamples": None,
                 "inpainted": None, "bls_loaded": []}
 
+    # Read visibility data
     logger.info(f"Reading {meta_path}")
 
     # TODO: use Fast readers here instead, and select times directly on read.
@@ -351,11 +356,12 @@ def _read_one_file(
         polarizations=pols,
     )
 
-    # Now select the relevant times from the data.
+    # Trim to only the time indices that fall within an LST bin.
     _data.select_or_expand_times(indices=tind, skip_bda_check=True)
     _flags.select_or_expand_times(indices=tind, skip_bda_check=True)
     _nsamples.select_or_expand_times(indices=tind, skip_bda_check=True)
 
+    # Load inpainting flags (optional)
     inpainted = None
     if inpfile is not None:
         # This returns a DataContainer (unless something went wrong) since it should
@@ -364,12 +370,12 @@ def _read_one_file(
         if not isinstance(inpainted, DataContainer):
             raise ValueError(f"Expected {inpfile} to be a DataContainer")
 
-        # We need to down-selecton times/freqs (bls and pols will be sub-selected
+        # We need to down-select on times/freqs (bls and pols will be sub-selected
         # based on those in the data through the next loop)
         inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
         inpainted.select_freqs(channels=freq_chans)
 
-    # load calibration files if given, and apply calibration
+    # Load and apply calibration (optional)
     if calfl is not None:
         logger.info(f"Opening and applying {calfl}")
         if cal_file_loader is not None:
@@ -651,7 +657,23 @@ def lst_bin_files_for_baselines(
 
     # ── helper: write one file's result into the master arrays ───────────────
     def _fill_master_arrays(res: dict, slc: slice) -> None:
+        """Copy a single file's result dict into the pre-allocated master arrays.
+
+        ``slc`` is the row slice in the time axis of the master arrays that
+        corresponds to this file.  Results can therefore be written in any
+        order, which is what allows the parallel path to fill as each future
+        completes rather than waiting for all files to finish first.
+
+        Parameters
+        ----------
+        res
+            The dict returned by :func:`_read_one_file`.
+        slc
+            The slice into the time axis of the master arrays for this file,
+            pre-computed from each file's ``time_idx`` length.
+        """
         if res["skip"]:
+            # File had no usable data; fill its time rows with flagged nans.
             data[slc] = np.nan
             flags[slc] = True
             nsamples[slc] = 0
@@ -665,6 +687,8 @@ def lst_bin_files_for_baselines(
         for i, bl in enumerate(antpairs):
             _bl = bl  # may be remapped below for redundantly_averaged
 
+            # For redundantly-averaged data, find which stored physical baseline
+            # represents this unique-baseline group in the current file.
             if redundantly_averaged:
                 bls = reds.get_reds_in_bl_set(bl, _data.antpairs(), include_conj=True)
                 if len(bls) > 1:
@@ -680,6 +704,7 @@ def lst_bin_files_for_baselines(
                 blpol = _bl + (pol,)
 
                 if blpol in _data:
+                    # Baseline found: copy data, flags, nsamples into master arrays.
                     data[slc, i, :, j] = _data[blpol]
                     flags[slc, i, :, j] = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
@@ -713,7 +738,7 @@ def lst_bin_files_for_baselines(
         for i in range(len(file_args))
     ]
 
-    # ── dispatch: serial (n_workers==1) or parallel ───────────────────────────
+    # dispatch: serial (n_workers==1) or parallel
     if n_workers == 1:
         # Call worker directly and fill immediately -- no results list needed.
         for i, args in enumerate(file_args):

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -782,6 +782,7 @@ class SingleBaselineStacker:
             to_keep_slice: slice | None = None,
             cal_file_loader: callable | None = None,
             cal_file_loader_kwargs: dict | None = None,
+            n_workers: int = 1,
         ) -> SingleBaselineStacker:
         """Creates a SingleBaselineStacker object that loads data for a single baseline, optionally rolls to start after a branch cut,
         and removes any times at the beginning or end of the data set that have no data.
@@ -858,6 +859,7 @@ class SingleBaselineStacker:
             cal_files=cal_files,
             cal_file_loader=cal_file_loader,
             cal_file_loader_kwargs=cal_file_loader_kwargs,
+            n_workers=n_workers,
          )
 
         # Cut out baseline dimension

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -25,6 +25,7 @@ from hera_qm.time_series_metrics import true_stretches
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
 def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
     """
     Adjust the LST bin edges so that they start in the range [0, 2pi) and increase.
@@ -493,7 +494,7 @@ def lst_bin_files_for_baselines(
     n_workers : int, optional
         Number of parallel workers to use when reading files.  ``1`` (the default)
         reproduces the original serial behaviour exactly.  Values greater than 1
-        submit each file read to a thread pool so that multiple nights 
+        submit each file read to a thread pool so that multiple nights
         can be read concurrently.
 
         A sensible upper bound is ``min(n_workers, len(data_files))``.
@@ -622,8 +623,8 @@ def lst_bin_files_for_baselines(
             nsamples[slc] = 0
             return
 
-        _data     = res["data"]
-        _flags    = res["flags"]
+        _data = res["data"]
+        _flags = res["flags"]
         _nsamples = res["nsamples"]
         inpainted = res["inpainted"]
 
@@ -643,8 +644,8 @@ def lst_bin_files_for_baselines(
                 blpol = _bl + (pol,)
 
                 if blpol in _data:
-                    data[slc, i, :, j]     = _data[blpol]
-                    flags[slc, i, :, j]    = _flags[blpol]
+                    data[slc, i, :, j] = _data[blpol]
+                    flags[slc, i, :, j] = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
 
                     if inpainted is not None and where_inpainted is not None:
@@ -661,8 +662,8 @@ def lst_bin_files_for_baselines(
                                 )
                         where_inpainted[slc, i, :, j] = inpainted[inpblpol]
                 else:
-                    data[slc, i, :, j]     = np.nan
-                    flags[slc, i, :, j]    = True
+                    data[slc, i, :, j] = np.nan
+                    flags[slc, i, :, j] = True
                     nsamples[slc, i, :, j] = 0
 
     # Precompute each file's time slice so results can be filled in any order.

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -287,12 +287,12 @@ def _get_freqs_chans(freqs, freq_min: float | None = None, freq_max: float | Non
 
 def _read_one_file(
     meta_path: str,
-    calfl,
+    calfl: str | None,
     tind: np.ndarray,
-    inpfile,
+    inpfile: str | None,
     antpairs: list[tuple],
     pols: list[str],
-    freq_chans,
+    freq_chans: np.ndarray | None,
     redundantly_averaged: bool,
     reds: RedundantGroups | None,
     cal_file_loader: callable | None,
@@ -483,6 +483,15 @@ def lst_bin_files_for_baselines(
     lsts
         A list of LST arrays for each file. If not provided, will be read from the
         files. If provided, must be the same length as ``data_files``.
+    redundantly_averaged
+        If True, the data files are assumed to have already been averaged in time and
+        redundant baseline groups, so that each row in the data corresponds to a unique
+        redundant baseline group, rather than a unique baseline. In this case, the
+        ``antpairs`` argument is interpreted as a list of redundant baseline groups to
+        read, rather than a list of actual antenna pairs. If True, the ``reds`` argument
+        must be provided, and the function will automatically map the redundant baseline
+        groups in ``antpairs`` to the actual baselines in the data files using the
+        redundant groups information in ``reds``.
     freq_min, freq_max
         Minimum and maximum frequencies to include in the data. If not provided,
         all frequencies will be included.

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -361,7 +361,7 @@ def _read_one_file(
         inpainted = io.load_flags(inpfile)
         if not isinstance(inpainted, DataContainer):
             raise ValueError(f"Expected {inpfile} to be a DataContainer")
-        
+
         # We need to down-selecton times/freqs (bls and pols will be sub-selected
         # based on those in the data through the next loop)
         inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
@@ -664,7 +664,7 @@ def lst_bin_files_for_baselines(
                 if bls:
                     # if there are no bls, just keep bl the same, and it won't be found,
                     # triggering the data to be filled with nans anyway
-                    _bl = next(iter(bls)) # use next(iter) since bls is a set
+                    _bl = next(iter(bls))  # use next(iter) since bls is a set
 
             for j, pol in enumerate(pols):
                 blpol = _bl + (pol,)

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -613,7 +613,8 @@ def lst_bin_files_for_baselines(
             redundantly_averaged,
             reds,
             cal_file_loader,
-            cal_file_loader_kwargs,
+            # make per-task copy so worker threads don't share mutable kwargs
+            dict(cal_file_loader_kwargs) if cal_file_loader_kwargs is not None else None,
         )
         for meta, calfl, tind, inpfile in zip(
             metas, cal_files, time_idx, where_inpainted_files

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -611,25 +611,24 @@ def lst_bin_files_for_baselines(
         raise ValueError("Cannot apply calibration if redundantly_averaged is True")
 
     # ── build per-file argument tuples (shared by serial and parallel paths) ─
-    file_args = [
-        (
-            str(meta.path),
-            calfl,
-            tind,
-            inpfile,
-            list(antpairs),       # plain list for picklability
-            list(pols),
-            freq_chans,
-            redundantly_averaged,
-            reds,
-            cal_file_loader,
-            # make per-task copy so worker threads don't share mutable kwargs
-            dict(cal_file_loader_kwargs) if cal_file_loader_kwargs is not None else None,
+    file_args = []
+    for meta, calfl, tind, inpfile in zip(metas, cal_files, time_idx, where_inpainted_files):
+        file_args.append(
+            (
+                str(meta.path),
+                calfl,
+                tind,
+                inpfile,
+                list(antpairs),       # plain list for picklability
+                list(pols),
+                freq_chans,
+                redundantly_averaged,
+                reds,
+                cal_file_loader,
+                # make per-task copy so worker threads don't share mutable kwargs
+                dict(cal_file_loader_kwargs) if cal_file_loader_kwargs is not None else None,
+            )
         )
-        for meta, calfl, tind, inpfile in zip(
-            metas, cal_files, time_idx, where_inpainted_files
-        )
-    ]
 
     # ── helper: write one file's result into the master arrays ───────────────
     def _fill_master_arrays(res: dict, slc: slice) -> None:

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -332,6 +332,8 @@ def _read_one_file(
         ]
 
     if not bls_to_load or ntimes == 0:
+        # If none of the requested baselines are in this file, then just
+        # set stuff as nan and go to next file.
         logger.warning(
             f"None of the baseline-times are in {meta_path}. Skipping."
         )
@@ -341,6 +343,7 @@ def _read_one_file(
 
     logger.info(f"Reading {meta_path}")
 
+    # TODO: use Fast readers here instead, and select times directly on read.
     _data, _flags, _nsamples = io.HERAData(meta_path).read(
         bls=bls_to_load,
         freq_chans=freq_chans,
@@ -351,16 +354,20 @@ def _read_one_file(
     _flags.select_or_expand_times(indices=tind, skip_bda_check=True)
     _nsamples.select_or_expand_times(indices=tind, skip_bda_check=True)
 
-    # ── inpaint flags ────────────────────────────────────────────────────────
     inpainted = None
     if inpfile is not None:
+        # This returns a DataContainer (unless something went wrong) since it should
+        # always be a 'baseline' type of UVFlag.
         inpainted = io.load_flags(inpfile)
         if not isinstance(inpainted, DataContainer):
             raise ValueError(f"Expected {inpfile} to be a DataContainer")
+        
+        # We need to down-selecton times/freqs (bls and pols will be sub-selected
+        # based on those in the data through the next loop)
         inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
         inpainted.select_freqs(channels=freq_chans)
 
-    # ── calibration ──────────────────────────────────────────────────────────
+    # load calibration
     if calfl is not None:
         logger.info(f"Opening and applying {calfl}")
         if cal_file_loader is not None:
@@ -528,6 +535,7 @@ def lst_bin_files_for_baselines(
         for fl in data_files
     ]
 
+    # Make sure n_workers is a positive integer
     if n_workers < 1 or not isinstance(n_workers, int):
         raise ValueError(f"n_workers must be a positive integer, got {n_workers}")
 
@@ -555,9 +563,11 @@ def lst_bin_files_for_baselines(
         if cal_file_loader_kwargs is None:
             cal_file_loader_kwargs = {}
 
+        # Add LST bin edges if not already present
         if 'lst_bin_edges' not in cal_file_loader_kwargs:
             cal_file_loader_kwargs['lst_bin_edges'] = lst_bin_edges
 
+        # Add telescope location if not already present
         if 'telescope_location_lat_lon_alt_degrees' not in cal_file_loader_kwargs:
             cal_file_loader_kwargs['telescope_location_lat_lon_alt_degrees'] = metas[0].telescope_location_lat_lon_alt_degrees
 
@@ -644,7 +654,9 @@ def lst_bin_files_for_baselines(
                         f"Expected only one baseline in group for {bl}, got {bls}"
                     )
                 if bls:
-                    _bl = next(iter(bls))
+                    # if there are no bls, just keep bl the same, and it won't be found,
+                    # triggering the data to be filled with nans anyway
+                    _bl = next(iter(bls)) # use next(iter) since bls is a set
 
             for j, pol in enumerate(pols):
                 blpol = _bl + (pol,)
@@ -655,6 +667,8 @@ def lst_bin_files_for_baselines(
                     nsamples[slc, i, :, j] = _nsamples[blpol]
 
                     if inpainted is not None and where_inpainted is not None:
+                        # Get the representative baseline key from this bl group that
+                        # exists in the where_inpainted data.
                         inpblpol = blpol
                         if redundantly_averaged:
                             for inpbl in reds[bl]:
@@ -668,6 +682,8 @@ def lst_bin_files_for_baselines(
                                 )
                         where_inpainted[slc, i, :, j] = inpainted[inpblpol]
                 else:
+                    # This baseline+pol doesn't exist in this file. That's
+                    # OK, we don't assume all baselines are in every file.
                     data[slc, i, :, j] = np.nan
                     flags[slc, i, :, j] = True
                     nsamples[slc, i, :, j] = 0
@@ -699,6 +715,9 @@ def lst_bin_files_for_baselines(
                 _fill_master_arrays(fut.result(), file_slices[i])
 
     logger.info("About to run LST binning...")
+    # LST bin edges are the actual edges of the bins, so should have length
+    # +1 of the LST centres. We use +dlst instead of +dlst/2 on the top edge
+    # so that np.arange definitely gets the last edge.
     bin_lst, data, flags, nsamples, where_inpainted = lst_align(
         data=data,
         flags=None if ignore_flags else flags,

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -497,7 +497,7 @@ def lst_bin_files_for_baselines(
         positive integer (``>= 1``); passing ``0`` or a negative value is invalid and
         will result in a ``ValueError``. Values greater than 1 submit each file read
         to a thread pool so that multiple nights can be read concurrently.
-        
+
         A sensible effective upper bound is ``min(n_workers, len(data_files))``,
         which is applied internally.
 

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -305,6 +305,48 @@ def _read_one_file(
     arguments must therefore be picklable (paths as strings, arrays as numpy,
     etc.) when used with ProcessPoolExecutor.
 
+    Parameters
+    ----------
+    meta_path
+        Path to the UVH5 file to read, as a plain string (not a Path object,
+        for picklability with ProcessPoolExecutor).
+    calfl
+        Path to a calibration file to apply to the data, or ``None`` to skip
+        calibration.
+    tind
+        Indices into the time axis of the file that fall within at least one
+        LST bin.  Only these rows are read into memory.
+    inpfile
+        Path to a UVFlag file recording where the data have
+        been inpainted, or ``None`` if no inpainting information is available.
+    antpairs
+        The antenna pairs (baselines) to load.  Pairs absent from this file
+        are silently skipped; conjugate pairs are handled automatically.
+    pols
+        Polarization strings to read.
+    freq_chans
+        Channel indices to read, or ``None`` to read all channels.
+    redundantly_averaged
+        If ``True``, the file stores one row per unique-baseline group rather
+        than one row per physical baseline.  The ``antpairs`` argument is then
+        interpreted as unique-baseline keys, and ``reds`` is used to map them
+        to whatever physical baseline is stored in the file.
+    reds
+        Redundant-baseline group information.  Required when
+        ``redundantly_averaged`` is ``True``; ignored otherwise.
+    cal_file_loader
+        Optional callable for reading calibration solutions in a non-standard
+        format.  Must accept ``(calfl, antpairs=..., polarizations=..., **kwargs)``
+        and return ``(gains, cal_flags)``.  If ``None``, the default
+        HERAData/HERACal readers are used.
+    cal_file_loader_kwargs
+        Extra keyword arguments forwarded to ``cal_file_loader``.  Pass
+        ``None`` (or omit) when using the default loader.
+    blts_are_rectangular
+        Passed through to :class:`~pyuvdata.uvdata.FastUVH5Meta`; set to
+        ``False`` only for files where baselines and times are not on a
+        regular grid.
+
     Returns
     -------
     dict with keys:

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -492,12 +492,14 @@ def lst_bin_files_for_baselines(
     cal_file_loader_kwargs
         A dictionary of keyword arguments to pass to ``cal_file_loader``.
     n_workers : int, optional
-        Number of parallel workers to use when reading files.  ``1`` (the default)
-        reproduces the original serial behaviour exactly.  Values greater than 1
-        submit each file read to a thread pool so that multiple nights
-        can be read concurrently.
-
-        A sensible upper bound is ``min(n_workers, len(data_files))``.
+        Number of parallel workers to use when reading files. ``1`` (the default)
+        reproduces the original serial behaviour exactly. ``n_workers`` must be a
+        positive integer (``>= 1``); passing ``0`` or a negative value is invalid and
+        will result in a ``ValueError``. Values greater than 1 submit each file read
+        to a thread pool so that multiple nights can be read concurrently.
+        
+        A sensible effective upper bound is ``min(n_workers, len(data_files))``,
+        which is applied internally.
 
     Returns
     -------
@@ -525,6 +527,9 @@ def lst_bin_files_for_baselines(
         )
         for fl in data_files
     ]
+
+    if n_workers < 1 or not isinstance(n_workers, int):
+        raise ValueError(f"n_workers must be a positive integer, got {n_workers}")
 
     lst_bin_edges = np.array(lst_bin_edges)
 

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -826,6 +826,10 @@ class SingleBaselineStacker:
             format than HERACal files.
         cal_file_loader_kwargs : dict | None
             A dictionary of keyword arguments to pass to ``cal_file_loader``.
+        n_workers : int
+            Number of parallel workers to use when reading files. ``1`` (the default) reproduces the original serial behaviour exactly. ``n_workers`` must be a
+            positive integer (``>= 1``); passing ``0`` or a negative value is invalid and will result in a ``ValueError``. Values greater than 1 submit each file read to a thread pool so
+            that multiple nights can be read concurrently.
         """
         # Load the data
         files_here = configurator.bl_to_file_map[bl_str]

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -25,6 +25,7 @@ from hera_qm.time_series_metrics import true_stretches
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
 def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
     """
     Adjust the LST bin edges so that they start in the range [0, 2pi) and increase.
@@ -493,7 +494,7 @@ def lst_bin_files_for_baselines(
     n_workers : int, optional
         Number of parallel workers to use when reading files.  ``1`` (the default)
         reproduces the original serial behaviour exactly.  Values greater than 1
-        submit each file read to a thread pool so that multiple nights 
+        submit each file read to a thread pool so that multiple nights
         can be read concurrently.
 
         A sensible upper bound is ``min(n_workers, len(data_files))``.
@@ -643,10 +644,10 @@ def lst_bin_files_for_baselines(
             nsamples[slc] = 0
             continue
 
-        _data      = res["data"]
-        _flags     = res["flags"]
-        _nsamples  = res["nsamples"]
-        inpainted  = res["inpainted"]
+        _data = res["data"]
+        _flags = res["flags"]
+        _nsamples = res["nsamples"]
+        inpainted = res["inpainted"]
 
         for i, bl in enumerate(antpairs):
             _bl = bl  # may be remapped below for redundantly_averaged
@@ -664,8 +665,8 @@ def lst_bin_files_for_baselines(
                 blpol = _bl + (pol,)
 
                 if blpol in _data:
-                    data[slc, i, :, j]     = _data[blpol]
-                    flags[slc, i, :, j]    = _flags[blpol]
+                    data[slc, i, :, j] = _data[blpol]
+                    flags[slc, i, :, j] = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
 
                     if inpainted is not None and where_inpainted is not None:
@@ -682,8 +683,8 @@ def lst_bin_files_for_baselines(
                                 )
                         where_inpainted[slc, i, :, j] = inpainted[inpblpol]
                 else:
-                    data[slc, i, :, j]     = np.nan
-                    flags[slc, i, :, j]    = True
+                    data[slc, i, :, j] = np.nan
+                    flags[slc, i, :, j] = True
                     nsamples[slc, i, :, j] = 0
 
     logger.info("About to run LST binning...")

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -23,6 +23,7 @@ from astropy.coordinates import EarthLocation
 from ..utils import _comply_vispol
 from hera_qm.time_series_metrics import true_stretches
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
     """
@@ -283,6 +284,119 @@ def _get_freqs_chans(freqs, freq_min: float | None = None, freq_max: float | Non
     return freqs, freq_chans
 
 
+def _read_one_file(
+    meta_path: str,
+    calfl,
+    tind: np.ndarray,
+    inpfile,
+    antpairs: list[tuple],
+    pols: list[str],
+    freq_chans,
+    redundantly_averaged: bool,
+    reds: RedundantGroups | None,
+    cal_file_loader: callable | None,
+    cal_file_loader_kwargs: dict | None,
+) -> dict:
+    """Read visibility data from a single file and return it as a plain dict.
+
+    Designed to be called from either a thread or a process pool.  All
+    arguments must therefore be picklable (paths as strings, arrays as numpy,
+    etc.) when used with ProcessPoolExecutor.
+
+    Returns
+    -------
+    dict with keys:
+        skip        bool: True when there is nothing useful in this file
+        ntimes      int: number of time integrations in tind
+        data        DataContainer or None
+        flags       DataContainer or None
+        nsamples    DataContainer or None
+        inpainted   DataContainer or None
+        bls_loaded  list of antpairs that were actually loaded
+    """
+    meta = FastUVH5Meta(meta_path, blts_are_rectangular=True)
+    data_antpairs = meta.get_transactional("antpairs")
+    ntimes = len(tind)
+
+    if redundantly_averaged:
+        bls_to_load = [
+            bl for bl in data_antpairs
+            if reds.get_ubl_key(bl) in antpairs
+            or reds.get_ubl_key(bl[::-1]) in antpairs
+        ]
+    else:
+        bls_to_load = [
+            bl for bl in antpairs
+            if bl in data_antpairs or bl[::-1] in data_antpairs
+        ]
+
+    if not bls_to_load or ntimes == 0:
+        logger.warning(
+            f"None of the baseline-times are in {meta_path}. Skipping."
+        )
+        return {"skip": True, "ntimes": ntimes,
+                "data": None, "flags": None, "nsamples": None,
+                "inpainted": None, "bls_loaded": []}
+
+    logger.info(f"Reading {meta_path}")
+
+    _data, _flags, _nsamples = io.HERAData(meta_path).read(
+        bls=bls_to_load,
+        freq_chans=freq_chans,
+        polarizations=pols,
+    )
+
+    _data.select_or_expand_times(indices=tind, skip_bda_check=True)
+    _flags.select_or_expand_times(indices=tind, skip_bda_check=True)
+    _nsamples.select_or_expand_times(indices=tind, skip_bda_check=True)
+
+    # ── inpaint flags ────────────────────────────────────────────────────────
+    inpainted = None
+    if inpfile is not None:
+        inpainted = io.load_flags(inpfile)
+        if not isinstance(inpainted, DataContainer):
+            raise ValueError(f"Expected {inpfile} to be a DataContainer")
+        inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
+        inpainted.select_freqs(channels=freq_chans)
+
+    # ── calibration ──────────────────────────────────────────────────────────
+    if calfl is not None:
+        logger.info(f"Opening and applying {calfl}")
+        if cal_file_loader is not None:
+            gains, cal_flags = cal_file_loader(
+                calfl,
+                antpairs=bls_to_load,
+                polarizations=pols,
+                **(cal_file_loader_kwargs or {}),
+            )
+            gain_convention = "divide"
+        else:
+            uvc = io.to_HERACal(calfl)
+            gains, cal_flags, _, _ = uvc.read(freq_chans=freq_chans)
+            if len(tind) < uvc.Ntimes and uvc.Ntimes > 1:
+                uvc.select(times=uvc.time_array[tind])
+                gains, cal_flags, _, _ = uvc.build_calcontainers()
+            gain_convention = uvc.gain_convention
+
+        apply_cal.calibrate_in_place(
+            _data,
+            gains,
+            data_flags=_flags,
+            cal_flags=cal_flags,
+            gain_convention=gain_convention,
+        )
+
+    return {
+        "skip": False,
+        "ntimes": ntimes,
+        "data": _data,
+        "flags": _flags,
+        "nsamples": _nsamples,
+        "inpainted": inpainted,
+        "bls_loaded": bls_to_load,
+    }
+
+
 def lst_bin_files_for_baselines(
     data_files: list[Path | FastUVH5Meta],
     lst_bin_edges: np.ndarray,
@@ -302,6 +416,7 @@ def lst_bin_files_for_baselines(
     where_inpainted_files: list[list[str | Path | None]] | None = None,
     cal_file_loader: callable | None = None,
     cal_file_loader_kwargs: dict | None = None,
+    n_workers: int = 1,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[np.ndarray]]:
     """Produce a set of LST-binned (but not averaged) data for a set of baselines.
 
@@ -375,6 +490,13 @@ def lst_bin_files_for_baselines(
         format than HERACal files.
     cal_file_loader_kwargs
         A dictionary of keyword arguments to pass to ``cal_file_loader``.
+    n_workers : int, optional
+        Number of parallel workers to use when reading files.  ``1`` (the default)
+        reproduces the original serial behaviour exactly.  Values greater than 1
+        submit each file read to a thread pool so that multiple nights 
+        can be read concurrently.
+
+        A sensible upper bound is ``min(n_workers, len(data_files))``.
 
     Returns
     -------
@@ -427,11 +549,9 @@ def lst_bin_files_for_baselines(
         if cal_file_loader_kwargs is None:
             cal_file_loader_kwargs = {}
 
-        # Add LST bin edges if not already present
         if 'lst_bin_edges' not in cal_file_loader_kwargs:
             cal_file_loader_kwargs['lst_bin_edges'] = lst_bin_edges
 
-        # Add telescope location if not already present
         if 'telescope_location_lat_lon_alt_degrees' not in cal_file_loader_kwargs:
             cal_file_loader_kwargs['telescope_location_lat_lon_alt_degrees'] = metas[0].telescope_location_lat_lon_alt_degrees
 
@@ -474,96 +594,63 @@ def lst_bin_files_for_baselines(
     if redundantly_averaged and any(c is not None for c in cal_files):
         raise ValueError("Cannot apply calibration if redundantly_averaged is True")
 
-    # This loop actually reads the associated data in this LST bin.
+    # ── build per-file argument tuples (shared by serial and parallel paths) ─
+    file_args = [
+        (
+            str(meta.path),
+            calfl,
+            tind,
+            inpfile,
+            list(antpairs),       # plain list for picklability
+            list(pols),
+            freq_chans,
+            redundantly_averaged,
+            reds,
+            cal_file_loader,
+            cal_file_loader_kwargs,
+        )
+        for meta, calfl, tind, inpfile in zip(
+            metas, cal_files, time_idx, where_inpainted_files
+        )
+    ]
+
+    # ── dispatch: serial (n_workers==1) or parallel ───────────────────────────
+    if n_workers == 1:
+        # call worker directly, no executor overhead.
+        results = [_read_one_file(*args) for args in file_args]
+    else:
+        n_workers = min(n_workers, len(metas))   # never spin up more than needed
+        results = [None] * len(metas)
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            future_to_idx = {
+                pool.submit(_read_one_file, *args): i
+                for i, args in enumerate(file_args)
+            }
+            for fut in as_completed(future_to_idx):
+                i = future_to_idx[fut]
+                results[i] = fut.result()   # re-raises exceptions from workers
+
+    # ── fill master arrays from results ───────────────────────────────────────
     ntimes_so_far = 0
-    for meta, calfl, tind, inpfile in zip(
-        metas, cal_files, time_idx, where_inpainted_files
-    ):
-        logger.info(f"Reading {meta.path}")
-        slc = slice(ntimes_so_far, ntimes_so_far + len(tind))
-        ntimes_so_far += len(tind)
+    for res in results:
+        ntimes = res["ntimes"]
+        slc = slice(ntimes_so_far, ntimes_so_far + ntimes)
+        ntimes_so_far += ntimes
 
-        # hd = io.HERAData(str(fl.path), filetype='uvh5')
-        data_antpairs = meta.get_transactional("antpairs")
-
-        if redundantly_averaged:
-            bls_to_load = [
-                bl
-                for bl in data_antpairs
-                if reds.get_ubl_key(bl) in antpairs
-                or reds.get_ubl_key(bl[::-1]) in antpairs
-            ]
-        else:
-            bls_to_load = [
-                bl
-                for bl in antpairs
-                if bl in data_antpairs or bl[::-1] in data_antpairs
-            ]
-
-        if not bls_to_load or len(tind) == 0:
-            # If none of the requested baselines are in this file, then just
-            # set stuff as nan and go to next file.
-            logger.warning(f"None of the baseline-times are in {meta.path}. Skipping.")
+        if res["skip"]:
             data[slc] = np.nan
             flags[slc] = True
             nsamples[slc] = 0
             continue
 
-        # TODO: use Fast readers here instead, and select times directly on read.
-        _data, _flags, _nsamples = io.HERAData(meta.path).read(
-            bls=bls_to_load,
-            freq_chans=freq_chans,
-            polarizations=pols,
-        )
-
-        _data.select_or_expand_times(indices=tind, skip_bda_check=True)
-        _flags.select_or_expand_times(indices=tind, skip_bda_check=True)
-        _nsamples.select_or_expand_times(indices=tind, skip_bda_check=True)
-
-        if inpfile is not None:
-            # This returns a DataContainer (unless something went wrong) since it should
-            # always be a 'baseline' type of UVFlag.
-            inpainted = io.load_flags(inpfile)
-            if not isinstance(inpainted, DataContainer):
-                raise ValueError(f"Expected {inpfile} to be a DataContainer")
-
-            # We need to down-selecton times/freqs (bls and pols will be sub-selected
-            # based on those in the data through the next loop)
-            inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
-            inpainted.select_freqs(channels=freq_chans)
-        else:
-            inpainted = None
-
-        # load calibration
-        if calfl is not None:
-            logger.info(f"Opening and applying {calfl}")
-            if cal_file_loader is not None:
-                gains, cal_flags = cal_file_loader(
-                    calfl,
-                    antpairs=bls_to_load,
-                    polarizations=pols,
-                    **(cal_file_loader_kwargs or {})
-                )
-                gain_convention = "divide"
-            else:
-                uvc = io.to_HERACal(calfl)
-                gains, cal_flags, _, _ = uvc.read(freq_chans=freq_chans)
-                # down select times if necessary
-                if len(tind) < uvc.Ntimes and uvc.Ntimes > 1:
-                    # If uvc has Ntimes == 1, then broadcast across time will work automatically
-                    uvc.select(times=uvc.time_array[tind])
-                    gains, cal_flags, _, _ = uvc.build_calcontainers()
-                gain_convention = uvc.gain_convention
-
-            apply_cal.calibrate_in_place(
-                _data,
-                gains,
-                data_flags=_flags,
-                cal_flags=cal_flags,
-                gain_convention=gain_convention,
-            )
+        _data      = res["data"]
+        _flags     = res["flags"]
+        _nsamples  = res["nsamples"]
+        inpainted  = res["inpainted"]
 
         for i, bl in enumerate(antpairs):
+            _bl = bl  # may be remapped below for redundantly_averaged
+
             if redundantly_averaged:
                 bls = reds.get_reds_in_bl_set(bl, _data.antpairs(), include_conj=True)
                 if len(bls) > 1:
@@ -571,44 +658,35 @@ def lst_bin_files_for_baselines(
                         f"Expected only one baseline in group for {bl}, got {bls}"
                     )
                 if bls:
-                    # if there are no bls, just keep bl the same, and it won't be found,
-                    # triggering the data to be filled with nans anyway.
-                    bl = next(iter(bls))  # use next(iter) since bls is a set
+                    _bl = next(iter(bls))
 
             for j, pol in enumerate(pols):
-                blpol = bl + (pol,)
+                blpol = _bl + (pol,)
 
-                if blpol in _data:  # DataContainer takes care of conjugates.
-                    data[slc, i, :, j] = _data[blpol]
-                    flags[slc, i, :, j] = _flags[blpol]
+                if blpol in _data:
+                    data[slc, i, :, j]     = _data[blpol]
+                    flags[slc, i, :, j]    = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
 
-                    if inpainted is not None:
-                        # Get the representative baseline key from this bl group that
-                        # exists in the where_inpainted data.
+                    if inpainted is not None and where_inpainted is not None:
+                        inpblpol = blpol
                         if redundantly_averaged:
                             for inpbl in reds[bl]:
                                 if inpbl + (pol,) in inpainted:
-                                    blpol = inpbl + (pol,)
+                                    inpblpol = inpbl + (pol,)
                                     break
                             else:
                                 raise ValueError(
-                                    f"Could not find any baseline from group {bl} in "
-                                    "inpainted file"
+                                    f"Could not find any baseline from group {bl} "
+                                    "in inpainted file"
                                 )
-
-                        where_inpainted[slc, i, :, j] = inpainted[blpol]
+                        where_inpainted[slc, i, :, j] = inpainted[inpblpol]
                 else:
-                    # This baseline+pol doesn't exist in this file. That's
-                    # OK, we don't assume all baselines are in every file.
-                    data[slc, i, :, j] = np.nan
-                    flags[slc, i, :, j] = True
+                    data[slc, i, :, j]     = np.nan
+                    flags[slc, i, :, j]    = True
                     nsamples[slc, i, :, j] = 0
 
     logger.info("About to run LST binning...")
-    # LST bin edges are the actual edges of the bins, so should have length
-    # +1 of the LST centres. We use +dlst instead of +dlst/2 on the top edge
-    # so that np.arange definitely gets the last edge.
     bin_lst, data, flags, nsamples, where_inpainted = lst_align(
         data=data,
         flags=None if ignore_flags else flags,
@@ -990,6 +1068,7 @@ def lst_bin_files_from_config(
     rephase: bool = True,
     freq_min: float | None = None,
     freq_max: float | None = None,
+    n_workers: int = 1,
 ) -> list[LSTStack | None] | None:
     """Read and LST-bin data from a configuration object.
 
@@ -1014,6 +1093,9 @@ def lst_bin_files_from_config(
         The minimum frequency to include in the data (Hz). Default is all frequencies.
     freq_max : float, optional
         The maximum frequency to include in the data (Hz). Default is all frequencies.
+    n_workers : int, optional
+        Number of parallel workers for concurrent file reads. Default is 1 (serial).
+        Passed through to :func:`lst_bin_files_for_baselines`.
 
     Returns
     -------
@@ -1064,7 +1146,8 @@ def lst_bin_files_from_config(
         reds=config.config.reds,
         freq_min=freq_min,
         freq_max=freq_max,
-        where_inpainted_files=config.inpaint_files
+        where_inpainted_files=config.inpaint_files,
+        n_workers=n_workers,
     )
 
     freqs, _ = _get_freqs_chans(meta.freq_array, freq_min, freq_max)

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -297,6 +297,7 @@ def _read_one_file(
     reds: RedundantGroups | None,
     cal_file_loader: callable | None,
     cal_file_loader_kwargs: dict | None,
+    blts_are_rectangular: bool = True,
 ) -> dict:
     """Read visibility data from a single file and return it as a plain dict.
 
@@ -315,7 +316,7 @@ def _read_one_file(
         inpainted   DataContainer or None
         bls_loaded  list of antpairs that were actually loaded
     """
-    meta = FastUVH5Meta(meta_path, blts_are_rectangular=True)
+    meta = FastUVH5Meta(meta_path, blts_are_rectangular=blts_are_rectangular)
     data_antpairs = meta.get_transactional("antpairs")
     ntimes = len(tind)
 
@@ -350,6 +351,7 @@ def _read_one_file(
         polarizations=pols,
     )
 
+    # Now select the relevant times from the data.
     _data.select_or_expand_times(indices=tind, skip_bda_check=True)
     _flags.select_or_expand_times(indices=tind, skip_bda_check=True)
     _nsamples.select_or_expand_times(indices=tind, skip_bda_check=True)
@@ -367,10 +369,13 @@ def _read_one_file(
         inpainted.select_or_expand_times(indices=tind, skip_bda_check=True)
         inpainted.select_freqs(channels=freq_chans)
 
-    # load calibration
+    # load calibration files if given, and apply calibration
     if calfl is not None:
         logger.info(f"Opening and applying {calfl}")
         if cal_file_loader is not None:
+            # Use the custom loader to read the calibration solutions. This is useful if the
+            # calibration files are in a different format than HERACal files, or if the user wants
+            # to apply some custom pre-processing to the calibration solutions as they are read in.
             gains, cal_flags = cal_file_loader(
                 calfl,
                 antpairs=bls_to_load,
@@ -424,6 +429,7 @@ def lst_bin_files_for_baselines(
     where_inpainted_files: list[list[str | Path | None]] | None = None,
     cal_file_loader: callable | None = None,
     cal_file_loader_kwargs: dict | None = None,
+    blts_are_rectangular: bool = True,
     n_workers: int = 1,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[np.ndarray]]:
     """Produce a set of LST-binned (but not averaged) data for a set of baselines.
@@ -507,6 +513,9 @@ def lst_bin_files_for_baselines(
         format than HERACal files.
     cal_file_loader_kwargs
         A dictionary of keyword arguments to pass to ``cal_file_loader``.
+    blts_are_rectangular: bool
+        Whether to assume that the blt axis of the input files is rectangular (i.e. that
+        all baselines have the same time samples).
     n_workers : int, optional
         Number of parallel workers to use when reading files. ``1`` (the default)
         reproduces the original serial behaviour exactly. ``n_workers`` must be a
@@ -539,7 +548,7 @@ def lst_bin_files_for_baselines(
         (
             fl
             if isinstance(fl, FastUVH5Meta)
-            else FastUVH5Meta(fl, blts_are_rectangular=True)
+            else FastUVH5Meta(fl, blts_are_rectangular=blts_are_rectangular)
         )
         for fl in data_files
     ]
@@ -636,6 +645,7 @@ def lst_bin_files_for_baselines(
                 cal_file_loader,
                 # make per-task copy so worker threads don't share mutable kwargs
                 dict(cal_file_loader_kwargs) if cal_file_loader_kwargs is not None else None,
+                blts_are_rectangular,
             )
         )
 

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -25,7 +25,6 @@ from hera_qm.time_series_metrics import true_stretches
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-
 def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
     """
     Adjust the LST bin edges so that they start in the range [0, 2pi) and increase.
@@ -494,7 +493,7 @@ def lst_bin_files_for_baselines(
     n_workers : int, optional
         Number of parallel workers to use when reading files.  ``1`` (the default)
         reproduces the original serial behaviour exactly.  Values greater than 1
-        submit each file read to a thread pool so that multiple nights
+        submit each file read to a thread pool so that multiple nights 
         can be read concurrently.
 
         A sensible upper bound is ``min(n_workers, len(data_files))``.
@@ -615,37 +614,16 @@ def lst_bin_files_for_baselines(
         )
     ]
 
-    # ── dispatch: serial (n_workers==1) or parallel ───────────────────────────
-    if n_workers == 1:
-        # call worker directly, no executor overhead.
-        results = [_read_one_file(*args) for args in file_args]
-    else:
-        n_workers = min(n_workers, len(metas))   # never spin up more than needed
-        results = [None] * len(metas)
-        with ThreadPoolExecutor(max_workers=n_workers) as pool:
-            future_to_idx = {
-                pool.submit(_read_one_file, *args): i
-                for i, args in enumerate(file_args)
-            }
-            for fut in as_completed(future_to_idx):
-                i = future_to_idx[fut]
-                results[i] = fut.result()   # re-raises exceptions from workers
-
-    # ── fill master arrays from results ───────────────────────────────────────
-    ntimes_so_far = 0
-    for res in results:
-        ntimes = res["ntimes"]
-        slc = slice(ntimes_so_far, ntimes_so_far + ntimes)
-        ntimes_so_far += ntimes
-
+    # ── helper: write one file's result into the master arrays ───────────────
+    def _fill_master_arrays(res: dict, slc: slice) -> None:
         if res["skip"]:
             data[slc] = np.nan
             flags[slc] = True
             nsamples[slc] = 0
-            continue
+            return
 
-        _data = res["data"]
-        _flags = res["flags"]
+        _data     = res["data"]
+        _flags    = res["flags"]
         _nsamples = res["nsamples"]
         inpainted = res["inpainted"]
 
@@ -665,8 +643,8 @@ def lst_bin_files_for_baselines(
                 blpol = _bl + (pol,)
 
                 if blpol in _data:
-                    data[slc, i, :, j] = _data[blpol]
-                    flags[slc, i, :, j] = _flags[blpol]
+                    data[slc, i, :, j]     = _data[blpol]
+                    flags[slc, i, :, j]    = _flags[blpol]
                     nsamples[slc, i, :, j] = _nsamples[blpol]
 
                     if inpainted is not None and where_inpainted is not None:
@@ -683,9 +661,35 @@ def lst_bin_files_for_baselines(
                                 )
                         where_inpainted[slc, i, :, j] = inpainted[inpblpol]
                 else:
-                    data[slc, i, :, j] = np.nan
-                    flags[slc, i, :, j] = True
+                    data[slc, i, :, j]     = np.nan
+                    flags[slc, i, :, j]    = True
                     nsamples[slc, i, :, j] = 0
+
+    # Precompute each file's time slice so results can be filled in any order.
+    ntimes_offsets = np.cumsum([0] + [len(t) for t in time_idx])
+    file_slices = [
+        slice(int(ntimes_offsets[i]), int(ntimes_offsets[i + 1]))
+        for i in range(len(file_args))
+    ]
+
+    # ── dispatch: serial (n_workers==1) or parallel ───────────────────────────
+    if n_workers == 1:
+        # Call worker directly and fill immediately -- no results list needed.
+        for i, args in enumerate(file_args):
+            _fill_master_arrays(_read_one_file(*args), file_slices[i])
+    else:
+        n_workers = min(n_workers, len(metas))   # never spin up more than needed
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            future_to_idx = {
+                pool.submit(_read_one_file, *args): i
+                for i, args in enumerate(file_args)
+            }
+            for fut in as_completed(future_to_idx):
+                i = future_to_idx[fut]
+                # Fill immediately and let res go out of scope so the GC can
+                # reclaim each file's DataContainers as soon as they are consumed,
+                # rather than holding all results in memory until the loop ends.
+                _fill_master_arrays(fut.result(), file_slices[i])
 
     logger.info("About to run LST binning...")
     bin_lst, data, flags, nsamples, where_inpainted = lst_align(

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -388,6 +388,19 @@ class TestLSTBinFilesForBaselines:
         for d, _d in zip(data, data_mp):
             np.testing.assert_allclose(d, _d)
 
+    def test_bad_nworkers(self, uvd, uvd_file, uvc_file):
+        """Test that providing freq_range works."""
+        with pytest.raises(ValueError, match="n_workers must be a positive integer"):
+            _ = binning.lst_bin_files_for_baselines(
+                data_files=[uvd_file],
+                lst_bin_edges=[uvd.lst_array.min(), uvd.lst_array.max()],
+                cal_files=[uvc_file],
+                freq_min=153e6,
+                freq_max=158e6,
+                antpairs=uvd.get_antpairs(),
+                n_workers=0,
+            )
+
 
 class TestLSTBinFilesFromConfig:
     def get_config(self, season, request, outfile_index=0):

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -353,6 +353,42 @@ class TestLSTBinFilesForBaselines:
             uvd_redavg.Npols,
         )
 
+    def test_multiprocessed_load(self, uvd_redavg, uvd_redavg_file):
+        # Test that we can load the same file in multiple processes without error.
+        data = binning.lst_bin_files_for_baselines(
+            data_files=[uvd_redavg_file],
+            lst_bin_edges=[
+                uvd_redavg.lst_array.min() - 0.1,
+                uvd_redavg.lst_array.max() + 0.1,
+            ],
+            redundantly_averaged=True,
+            rephase=False,
+            antpairs=uvd_redavg.get_antpairs(),
+            reds=RedundantGroups.from_antpos(
+                dict(zip(uvd_redavg.telescope.antenna_numbers, uvd_redavg.telescope.antenna_positions)),
+            ),
+        )[1]
+
+        data_mp = binning.lst_bin_files_for_baselines(
+            data_files=[uvd_redavg_file],
+            lst_bin_edges=[
+                uvd_redavg.lst_array.min() - 0.1,
+                uvd_redavg.lst_array.max() + 0.1,
+            ],
+            redundantly_averaged=True,
+            rephase=False,
+            antpairs=uvd_redavg.get_antpairs(),
+            reds=RedundantGroups.from_antpos(
+                dict(zip(uvd_redavg.telescope.antenna_numbers, uvd_redavg.telescope.antenna_positions)),
+            ),
+            n_workers=2,
+        )[1]
+
+        # The data should be the same regardless of multiprocessing.
+        for d, _d in zip(data, data_mp):
+            np.testing.assert_allclose(d, _d)
+
+
 
 class TestLSTBinFilesFromConfig:
     def get_config(self, season, request, outfile_index=0):

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -389,7 +389,6 @@ class TestLSTBinFilesForBaselines:
             np.testing.assert_allclose(d, _d)
 
 
-
 class TestLSTBinFilesFromConfig:
     def get_config(self, season, request, outfile_index=0):
         cfg = LSTBinConfigurator(


### PR DESCRIPTION
This PR adds functionality to load files in parallel to hera_cal.lst_stack.lst_bin_files_for_baselines which can potentially improve the performance of the function.