### PR TITLE
Implement in-place row permutation and add related tests in lst_stack

### DIFF
--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -44,6 +44,72 @@ def adjust_lst_bin_edges(lst_bin_edges: np.ndarray) -> np.ndarray:
         lst_bin_edges -= 2 * np.pi
 
 
+def _permute_rows_inplace(
+    arrs: Sequence[np.ndarray], perm: np.ndarray
+) -> None:
+    """Apply ``perm`` to the 0th axis of every array in ``arrs`` in place.
+
+    After the call, for each ``arr`` in ``arrs``, ``arr_new[i] = arr_old[perm[i]]``.
+
+    Uses a cycle-decomposition walk, so each cycle in ``perm`` is traversed
+    **once** regardless of how many arrays are being permuted -- all arrays
+    are advanced in lockstep at each step of the cycle. Auxiliary memory is
+    O(one row per array + n bools for the visited mask), independent of the
+    dtype or trailing shape of each array.
+
+    This is the natural primitive for reordering a master array alongside its
+    parallel siblings (flags, nsamples, where_inpainted, ...) by a single
+    permutation without allocating a full-master-sized temporary, as
+    ``arrs[:] = arrs[perm]`` or ``np.take(arrs, perm, axis=0)`` would.
+
+    Parameters
+    ----------
+    arrs
+        Sequence of arrays to permute. Each is modified in place. All arrays
+        must share ``arrs[k].shape[0] == len(perm)``; trailing shapes and
+        dtypes may differ.
+    perm
+        Integer permutation of ``range(n)``. ``perm[i]`` gives the source row
+        index whose data should end up at output position ``i``.
+    """
+    if len(arrs) == 0:
+        return
+    n = arrs[0].shape[0]
+    for a in arrs:
+        if a.shape[0] != n:
+            raise ValueError(
+                f"all arrays in arrs must share axis-0 length {n}, "
+                f"got {a.shape[0]}"
+            )
+    if n == 0:
+        return
+
+    visited = np.zeros(n, dtype=bool)
+    for start in range(n):
+        if visited[start]:
+            continue
+        if perm[start] == start:
+            visited[start] = True
+            continue
+        # Save the rows that will be overwritten at the start of this cycle,
+        # one scratch copy per array. Allocated here (not outside the loop)
+        # so we work uniformly for 1D arrays, where ``arr[start]`` is a
+        # scalar rather than a view supporting ``[...] = `` assignment. The
+        # previous cycle's scratch rows are released as we rebind.
+        tmps = [a[start].copy() for a in arrs]
+        i = start
+        while True:
+            visited[i] = True
+            src = perm[i]
+            if src == start:
+                for a, tmp in zip(arrs, tmps):
+                    a[i] = tmp  # close the cycle
+                break
+            for a in arrs:
+                a[i] = a[src]
+            i = src
+
+
 def lst_align(
     data: np.ndarray,
     data_lsts: np.ndarray,

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -1054,7 +1054,7 @@ class SingleBaselineStacker:
         for list_obj in (data, flags, nsamples, where_inpainted):
             for j, arr in enumerate(list_obj):
                 if arr is not None and arr.ndim == 4:
-                    list_obj[j] = arr[:, 0, :, :].copy()
+                    list_obj[j] = arr[:, 0, :, :]
 
         # Roll the lists to the branch cut
         if lst_branch_cut is not None:

--- a/hera_cal/lst_stack/binning.py
+++ b/hera_cal/lst_stack/binning.py
@@ -57,9 +57,9 @@ def _permute_rows_inplace(
     O(one row per array + n bools for the visited mask), independent of the
     dtype or trailing shape of each array.
 
-    This is the natural primitive for reordering a master array alongside its
+    This is the natural primitive for reordering a data array alongside its
     parallel siblings (flags, nsamples, where_inpainted, ...) by a single
-    permutation without allocating a full-master-sized temporary, as
+    permutation without allocating a full-data-sized temporary, as
     ``arrs[:] = arrs[perm]`` or ``np.take(arrs, perm, axis=0)`` would.
 
     Parameters
@@ -137,14 +137,15 @@ def lst_align(
     incur similar errors.
 
     .. warning::
-        When ``rephase=True``, the input ``data`` array is modified **in place** to
-        save memory. Rows whose LSTs fall inside the LST range are
-        overwritten with their rephased values; rows outside the LST range are left
-        unchanged (their rephase shift is forced to 0). If the caller still needs
-        the original unrephased data afterward, it must pass in a ``data.copy()``.
-        The per-bin arrays returned in the output list are fancy-index copies of
-        this (now rephased) master, so they are independent of it.
-        ``flags``, ``nsamples``, and ``where_inpainted`` are **not** mutated.
+        This function **modifies its input arrays in place** to save memory.
+        The 0th axis of ``data``, ``flags``, ``nsamples``, and ``where_inpainted``
+        is **permuted in place** (stable-sorted by LST bin index). The per-bin
+        arrays returned in the output lists are **views** into the permuted master
+        arrays and share memory with them. If the caller needs the original row order,
+        unrephased data, or independent copies of the per-bin arrays, it must pass
+        in copies. When ``rephase=True``, rows of ``data`` whose LSTs fall inside
+        the LST range are overwritten with their rephased values (rows outside the
+        LST range are left unchanged, with a rephase shift of 0).
 
     Parameters
     ----------
@@ -261,35 +262,39 @@ def lst_align(
         lst_shift[~lst_mask] = 0.0  # doesn't do any rephasing
         utils.lst_rephase(data, bls, freq_array, lst_shift, lat=lat, inplace=True)
 
-    # In case we don't rephase, the data/flags/nsamples arrays are still the original
-    # input arrays. We don't mask out the data outside the LST range, because we're
-    # just going to omit it from our bins naturally anyway. We also don't care if its
-    # not a copy here, because we're not going to modify it, and this saves memory.
+    # Permute the master arrays in place so that rows belonging to the same
+    # LST bin are contiguous. Each per-bin output is then a *view* into the
+    # permuted master (no row-data copy), which prevents the memory duplication
+    # of fancy indexing.
+    #
+    # We use a stable argsort so that, within each bin, rows retain their original
+    # input order, keeping any caller's parallel arrays (e.g. times, lsts) in sync.
+    #
+    # Rows outside the LST range have grid_indices == -1 or == Nbins (from
+    # get_lst_bins) and are naturally excluded from every bin's slice by the
+    # searchsorted edges below.
+    Nbins = len(lst_bin_centres)
+    order = np.argsort(grid_indices, kind='stable')
+    wip_to_add = ([where_inpainted] if where_inpainted is not None else [])
+    _permute_rows_inplace([data, flags, nsamples] + wip_to_add, order)
+    grid_indices_sorted = grid_indices[order]
+    bin_edges_idx = np.searchsorted(grid_indices_sorted, np.arange(Nbins + 1))
 
-    # We anyway end up with a ~full copy of the data in the output arrays, because
-    # we do a fancy-index of the input arrays to get the relevant data for each bin.
-
-    # shortcut -- just return all the data, re-organized.
+    # For each bin, take a contiguous slice of the now bin-sorted masters. This
+    # is equivalent to ``data[grid_indices == lstbin]`` fancy-index, but returns
+    # a *view* into the master instead of a copy. An empty bin naturally yields
+    # a zero-length view with the correct trailing shape and dtype.
     _data, _flags, _nsamples, _where_inpainted = [], [], [], []
-    empty_shape = (0, len(antpairs), len(freq_array), npols)
-    for lstbin in range(len(lst_bin_centres)):
-        mask = (grid_indices == lstbin)
-        if np.any(mask):
-            _data.append(data[mask])
-            _flags.append(flags[mask])
-            _nsamples.append(nsamples[mask])
-            if where_inpainted is not None:
-                _where_inpainted.append(where_inpainted[mask])
-            else:
-                _where_inpainted.append(None)
+    for lstbin in range(Nbins):
+        lo = int(bin_edges_idx[lstbin])
+        hi = int(bin_edges_idx[lstbin + 1])
+        _data.append(data[lo:hi])
+        _flags.append(flags[lo:hi])
+        _nsamples.append(nsamples[lo:hi])
+        if where_inpainted is not None:
+            _where_inpainted.append(where_inpainted[lo:hi])
         else:
-            _data.append(np.zeros(empty_shape, complex))
-            _flags.append(np.zeros(empty_shape, bool))
-            _nsamples.append(np.zeros(empty_shape, int))
-            if where_inpainted is not None:
-                _where_inpainted.append(np.zeros(empty_shape, bool))
-            else:
-                _where_inpainted.append(None)
+            _where_inpainted.append(None)
 
     return lst_bin_centres, _data, _flags, _nsamples, _where_inpainted
 

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -284,14 +284,19 @@ class TestLSTAlign:
 
     def test_multi_days_one_per_bin(self):
         kwargs = self.get_lst_align_data(ndays=2, ntimes=7)
+        # lst_align permutes its inputs in place (stable sort by bin), so
+        # save the original data before the call to compare against.
+        orig_data = kwargs["data"].copy()
         bins, d, f, n, inp = binning.lst_align(rephase=False, **kwargs)
 
-        # We should not be changing the data at all.
         d = np.squeeze(np.asarray(d))
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
+        # For ndays=2, ntimes=7 with one LST per bin, bin i gets rows i and
+        # i+7 from the original data (stable sort preserves within-bin order,
+        # so day 1 comes before day 2 in each bin).
+        np.testing.assert_allclose(d[:, 0], orig_data[:7])
         assert not np.any(f)
         assert np.all(n == 1.0)
         assert len(bins) == 7
@@ -303,6 +308,8 @@ class TestLSTAlign:
         flags = np.zeros_like(kwargs["data"], dtype=bool)
         flags[7:] = True
         kwargs["data"][7:] = 1000.0
+        # lst_align permutes its inputs in place; snapshot for comparison.
+        orig_data = kwargs["data"].copy()
 
         bins, d, f, n, inp = binning.lst_align(rephase=False, flags=flags, **kwargs)
 
@@ -310,7 +317,7 @@ class TestLSTAlign:
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
+        np.testing.assert_allclose(d[:, 0], orig_data[:7])
         assert not np.any(f[:, 0])
         assert np.all(f[:, 1])
         assert len(bins) == 7
@@ -322,6 +329,8 @@ class TestLSTAlign:
         nsamples = np.ones_like(kwargs["data"], dtype=float)
         nsamples[7:] = 0.0
         kwargs["data"][7:] = 1000.0
+        # lst_align permutes its inputs in place; snapshot for comparison.
+        orig_data = kwargs["data"].copy()
 
         bins, d, f, n, inp = binning.lst_align(
             rephase=False, nsamples=nsamples, **kwargs
@@ -331,7 +340,7 @@ class TestLSTAlign:
         f = np.squeeze(np.asarray(f))
         n = np.squeeze(np.asarray(n))
 
-        np.testing.assert_allclose(d[:, 0], kwargs["data"][:7])
+        np.testing.assert_allclose(d[:, 0], orig_data[:7])
         assert not np.any(f)
         assert np.all(n[:, 0] == 1.0)
         assert np.all(n[:, 1] == 0.0)

--- a/hera_cal/lst_stack/tests/test_binning.py
+++ b/hera_cal/lst_stack/tests/test_binning.py
@@ -38,6 +38,149 @@ class TestAdjustLSTBinEdges:
             binning.adjust_lst_bin_edges(x)
 
 
+class TestPermuteRowsInplace:
+    """Unit tests for ``binning._permute_rows_inplace``.
+
+    The helper applies a single permutation to axis 0 of every array in a
+    list, in place, using a cycle-decomposition walk. These tests pin down
+    correctness (matches ``arr[perm]``), the multi-array lockstep contract,
+    error paths, and the memory-efficiency promise (no full-size temporary
+    allocated).
+    """
+
+    @pytest.mark.parametrize("seed", [0, 1, 42])
+    def test_matches_fancy_index_single_array_1d(self, seed):
+        rng = np.random.default_rng(seed)
+        n = 50
+        arr = rng.standard_normal(n)
+        perm = rng.permutation(n)
+        expected = arr[perm].copy()
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, expected)
+
+    @pytest.mark.parametrize("seed", [0, 1, 7])
+    def test_matches_fancy_index_single_array_multidim(self, seed):
+        rng = np.random.default_rng(seed)
+        arr = rng.standard_normal((30, 4, 5))
+        perm = rng.permutation(30)
+        expected = arr[perm].copy()
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_multiple_arrays_heterogeneous_dtypes_and_shapes(self):
+        rng = np.random.default_rng(123)
+        n = 40
+        a = rng.standard_normal((n, 3)).astype(np.complex128)
+        b = rng.integers(0, 2, size=n).astype(bool)
+        c = rng.standard_normal((n, 2, 2)).astype(np.float64)
+        d = rng.integers(-5, 5, size=(n, 1)).astype(np.int32)
+        perm = rng.permutation(n)
+
+        ea, eb, ec, ed = a[perm].copy(), b[perm].copy(), c[perm].copy(), d[perm].copy()
+        binning._permute_rows_inplace([a, b, c, d], perm)
+        np.testing.assert_array_equal(a, ea)
+        np.testing.assert_array_equal(b, eb)
+        np.testing.assert_array_equal(c, ec)
+        np.testing.assert_array_equal(d, ed)
+
+    def test_identity_permutation_is_noop(self):
+        rng = np.random.default_rng(0)
+        arr = rng.standard_normal((10, 3)).copy()
+        original = arr.copy()
+        perm = np.arange(10)
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, original)
+
+    def test_reverse_permutation(self):
+        arr = np.arange(20).reshape(10, 2).copy()
+        perm = np.arange(10)[::-1].copy()  # reverse
+        expected = arr[perm].copy()
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_single_giant_cycle(self):
+        # perm = [1, 2, 3, ..., n-1, 0] is a single n-cycle; exercises the
+        # longest possible cycle walk with one scratch-row allocation.
+        n = 12
+        arr = np.arange(n * 4).reshape(n, 4).astype(float)
+        perm = np.concatenate([np.arange(1, n), [0]])
+        expected = arr[perm].copy()
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_many_fixed_points(self):
+        # Only two rows swap; everything else is a fixed point. The helper's
+        # `perm[start] == start` fast-path handles these without a scratch copy.
+        arr = np.arange(50 * 3).reshape(50, 3).astype(float)
+        perm = np.arange(50)
+        perm[10], perm[40] = 40, 10
+        expected = arr[perm].copy()
+        binning._permute_rows_inplace([arr], perm)
+        np.testing.assert_array_equal(arr, expected)
+
+    def test_empty_arrs_list_is_noop(self):
+        # No arrays -> nothing to do, nothing to raise. The passed perm is
+        # irrelevant here.
+        binning._permute_rows_inplace([], np.array([0]))
+
+    def test_zero_length_arrays(self):
+        a = np.empty((0, 3), dtype=float)
+        b = np.empty((0,), dtype=bool)
+        binning._permute_rows_inplace([a, b], np.array([], dtype=int))
+        assert a.shape == (0, 3)
+        assert b.shape == (0,)
+
+    def test_mismatched_axis0_lengths_raises(self):
+        a = np.zeros((5, 2))
+        b = np.zeros((6, 2))
+        with pytest.raises(ValueError, match="axis-0 length"):
+            binning._permute_rows_inplace([a, b], np.arange(5))
+
+    def test_in_place_object_identity_preserved(self):
+        # The patched lst_align relies on `_permute_rows_inplace` leaving the
+        # passed arrays as the *same* underlying ndarray (so downstream views
+        # into them share memory). Verify we never rebind.
+        rng = np.random.default_rng(3)
+        arr = rng.standard_normal((15, 2))
+        arr_id = id(arr)
+        data_ptr = arr.__array_interface__["data"][0]
+        perm = rng.permutation(15)
+        binning._permute_rows_inplace([arr], perm)
+        assert id(arr) == arr_id
+        assert arr.__array_interface__["data"][0] == data_ptr
+
+    def test_no_bulk_temporary_allocation(self):
+        # The whole point of the helper: peak resident size during the call
+        # should not require a full extra copy of the array. We proxy this
+        # by tracking numpy allocations via tracemalloc and asserting that
+        # the single largest new block is much smaller than arr.nbytes.
+        # (Scratch = one row; arr.nbytes/n_rows is the expected ceiling.)
+        import tracemalloc
+
+        rng = np.random.default_rng(5)
+        n, width = 200, 64
+        arr = rng.standard_normal((n, width)).astype(np.complex128)  # 200 * 64 * 16 B
+        perm = rng.permutation(n)
+        row_bytes = arr.strides[0]
+
+        tracemalloc.start()
+        snap_before = tracemalloc.take_snapshot()
+        binning._permute_rows_inplace([arr], perm)
+        snap_after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+        stats = snap_after.compare_to(snap_before, "filename")
+        biggest = max((s.size_diff for s in stats), default=0)
+        # Generous slack for the bool visited mask (n bytes) and the single
+        # scratch row. A full-master temporary would be n * row_bytes, which
+        # is ~200x larger than our budget here.
+        budget = row_bytes + n + 4096  # row + visited + small overhead
+        assert biggest <= budget, (
+            f"_permute_rows_inplace allocated {biggest} bytes; "
+            f"expected <= {budget} (row={row_bytes}, visited={n})"
+        )
+
+
 class TestLSTAlign:
     @classmethod
     def get_lst_align_data(


### PR DESCRIPTION
This PR follows up from #1047 and should allow us to reduce the memory footprint from by a factor of 2 (for a total of a factor of 3 improvement including that PR) by shuffling data, flags, nsamples, and where_inpainted arrays around in place so that individual LST bins can be accessed as _views_ not copies via fancy indexing. 

This PR also adds a bunch of tests to make sure that shuffling works properly.