### PR TITLE
Make _fix_dlst tolerant of nanoradian LST precision differences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: codecov/codecov-action@v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && success()
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/hera_cal/lst_stack/config.py
+++ b/hera_cal/lst_stack/config.py
@@ -79,8 +79,8 @@ def _fix_dlst(dlst: float) -> float:
             f"dlst must be less than {np.max(dlsts):1.5e}, the largest possible value."
         )
 
-    # get dlsts closest to dlst, but also greater than dlst
-    return dlsts[dlsts >= dlst - 1e-12][0]
+    # get dlsts closest to dlst, but also greater than dlst.
+    return dlsts[dlsts >= dlst * (1 - 1e-8)][0]
 
 
 def make_lst_grid(


### PR DESCRIPTION
The following was written by @claude:

> _fix_dlst snapped the data-derived LST bin width to a 2π-divisor using an absolute tolerance of 1e-12 rad. That is far tighter than the ~1e-9 rad precision of LSTs round-tripped through astropy/erfa, so a dlst that should map to 2π/24 but lands a nanoradian above it gets snapped to 2π/23 instead — dropping the LST grid from 24 to 23 bins and cascading into file/night matching and averaging errors (~15 lst_stack test failures).
> 
> This surfaced in CI for [RadioAstronomySoftwareGroup/pyuvdata#1671](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1671) ("remove spiceypy dependency with updated lunarsky"), which bumps lunarsky>=0.2.5 → lunarsky>=1.0.
> 
> Why a lunar-coordinates change breaks Earth-based HERA LSTs: it doesn't, directly. lunarsky only provides Moon-based (MCMF/LunarTopo) frames; HERA is an Earth (ITRS) telescope, so its LSTs are computed by astropy/erfa and never touch lunarsky's code path. The effect is transitive: requiring lunarsky>=1.0 pulls a newer astropy/erfa into the resolved environment, and erfa is what computes the sidereal time underlying the Earth LST. A newer erfa's Earth-rotation model differs by ~1e-9 rad, and that nanoradian is exactly what pushes dlst across the 2π/24 boundary in _fix_dlst. In other words, the LST shift originates in the upgraded dependency stack, not in any pyuvdata or lunar code that hera_cal actually calls.
> 
> Fix: use a relative tolerance of 1e-8 (~2.6e-9 rad at 2π/24), which absorbs the round-trip/version noise while remaining ~7 orders of magnitude below the gap between adjacent 2π-divisors, so legitimately-irregular dlst values are unaffected.
> 
> Note for reviewers: the mechanism and non-regression were verified locally (the measured dlst sits exactly 1 nanoradian below the 2π/24 edge), but the actual tip-over was not reproduced here because the local env didn't match CI's resolved erfa/astropy/lunarsky versions. The end-to-end confirmation rides on the pyuvdata [#1671](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1671) CI run.
> 
> A caveat on the relative-tolerance claim: I confirmed [#1671](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1671) bumps the lunarsky pin, but I did not directly verify that this resolves to a different erfa version in CI — that's the most plausible mechanism given HERA uses the Earth LST path, but it's inferred, not proven. If you want it airtight before merging, the next step is to diff the erfa version between a main and a [#1671](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1671) CI environment.


This closes #1052 