### PR TITLE
Add `skycal` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This package only officially supports python 3, though most functionality will s
 * `hera_cal.redcal`: redundant calibration module, with `firstcal`, `logcal`, `lincal`, and `omnical` and helper functions for finding and manipulating sets of redundant baselines.
 
 * `hera_cal.abscal`: absolute calibration module, largely used to calibrate out redcal degeneraices post-redundant calibration using an externally calibrated data set.
+* `hera_cal.skycal`: staged sky-model-based calibration (firstcal-style delays and offsets, autocorrelation-based amplitudes, and per-channel complex gain refinement on inter-SNAP cross baselines), designed so that per-SNAP cross-correlation-only signal loss lands only in the refined gains.
 
 * `hera_cal.apply_cal`: functions to apply calibration solutions (and flags) to data in memory or on disk
 

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -561,17 +561,27 @@ def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
     return delta_phase
 
 
-def _stationarity_residual(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
-                           ant_j_idx):
-    '''Compute the convergence certificate: the per-channel MAXIMUM
-    fixed-point residual over all solved antennas. At the exact weighted
-    least-squares optimum, every gain equals the weighted projection of the
-    data onto the other antennas' gains,
-    g_i = sum_j(w_ij * z_ij * g_j) / sum_j(w_ij * |g_j|^2) = U / D, so
-    max |U/D - g| / |g| measures how far each cell is from stationarity,
-    independently of the solver's own update sizes. Certifying on maxima
+def _relative_chi2_gradient(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
+                            ant_j_idx):
+    '''Compute the convergence criterion: the per-channel MAXIMUM of the
+    relative gradient of chi^2 over all solved antennas. At the exact
+    weighted least-squares optimum the gradient of chi^2 with respect to
+    every gain vanishes — equivalently, every gain equals the weighted
+    projection of the data onto the other antennas' gains,
+    g_i = sum_j(w_ij * z_ij * g_j) / sum_j(w_ij * |g_j|^2) = U / D — so
+    max |U/D - g| / |g|, the chi^2 gradient normalized by the local
+    curvature D and gain scale, measures how far each cell is from the
+    optimum, independently of the solver's own update sizes. Taking maxima
     (never a median or percentile) is deliberate: a median criterion can
     declare victory while an entire contiguous band remains unconverged.
+
+    NOTE: this deliberately differs from redcal's conv_crit, which is the
+    relative step between iterations. A step-size rule shows that the
+    solver stopped moving (true distance ~ step / (1 - contraction rate)),
+    not that the solution is near the optimum; the chi^2 gradient measures
+    distance from the optimum directly and works for gains from any
+    solver. The 'iter'/'conv_crit' meta keys are shared with redcal, but
+    conv_crit's semantics differ as described here.
 
     Returns: (Nfreqs,) ndarray of the max residual over solved antennas in
         each channel; np.nan for channels with no solved cells.'''
@@ -634,7 +644,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     complex objective chi^2 = sum_ij w_ij |vis_ratio_ij - g_i * conj(g_j)|^2
     (the (|g_i| |g_j|)^2 weight factor is that objective's Jacobian), so the
     converged solution is the stationary point of the complex chi^2 —
-    exactly what _stationarity_residual certifies — independent of the
+    exactly what _relative_chi2_gradient checks — independent of the
     starting point. The low-signal-to-noise bias of logcal identified by
     Liu et al. (2010, MNRAS 408, 1029) afflicts estimators whose FINAL
     answer is the log-space optimum; here the log-space solve only starts
@@ -651,9 +661,9 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     with no regularization. The overall phase degeneracy is fixed by pinning
     one antenna inside the solves and then removing the degeneracy from each
     update by setting its mean phase to 0 over participating antennas — the
-    same convention as redcal.remove_degen_gains. Convergence is certified by the maximum
-    fixed-point residual over ALL solved cells (_stationarity_residual) and
-    enforced with a RuntimeError.
+    same convention as redcal.remove_degen_gains. Convergence is verified
+    via the maximum relative chi^2 gradient over ALL solved cells
+    (_relative_chi2_gradient) and enforced with a RuntimeError.
 
     Arguments:
         vis_ratio: complex ndarray (Nbls, Nfreqs) of data/model ratios
@@ -677,7 +687,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         meta: dict of per-channel (Nfreqs,) arrays, following redcal's
             solve_iteratively convention: 'iter' (int rounds each channel
             used before its early exit; 0 where flagged) and 'conv_crit'
-            (max fixed-point residual over antennas in each channel;
+            (max relative chi^2 gradient over antennas in each channel;
             np.nan where flagged)
 
     Raises:
@@ -805,14 +815,14 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     full_gains = np.full((nants, nfreqs), np.nan, dtype=complex)
     full_gains[np.ix_(sel_ants, good_chan_idx)] = gains
 
-    conv_crit = _stationarity_residual(vis_ratio, ratio_wgts, full_gains,
-                                       ant_i_idx, ant_j_idx)
+    conv_crit = _relative_chi2_gradient(vis_ratio, ratio_wgts, full_gains,
+                                        ant_i_idx, ant_j_idx)
     if not converged:
         raise RuntimeError(
             f'Per-channel gain refinement did not converge: '
             f'{int(active_chans.sum())} channels remain above '
             f'refine_tol={refine_tol} after {refine_maxiter} rounds '
-            f'(max fixed-point residual {np.nanmax(conv_crit):.2e}). '
+            f'(max relative chi^2 gradient {np.nanmax(conv_crit):.2e}). '
             'Do not proceed with unconverged gains.')
     return full_gains, {'iter': chan_iters, 'conv_crit': conv_crit}
 
@@ -904,7 +914,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                 refine_maxiter=refine_maxiter, sync_tol=sync_tol,
                 sync_maxiter=sync_maxiter, verbose=verbose)
             utils.echo(f't{tind} {pol}: {int(meta_here["iter"].max())} '
-                       'rounds, max stationarity residual '
+                       'rounds, max relative chi^2 gradient '
                        f'{np.nanmax(meta_here["conv_crit"]):.2e}',
                        verbose=verbose)
             for i, ant in enumerate(ants):

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -1,0 +1,961 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 the HERA Project
+# Licensed under the MIT License
+
+"""Staged sky-model-based calibration.
+
+This module calibrates raw visibilities against a sky model in stages designed
+so that any per-antenna, non-smooth amplitude effect that only appears on cross
+correlations (e.g. per-SNAP signal loss in the correlator, a.k.a. "decoherence")
+lands in exactly one place — the final per-channel refinement gains — where it
+can be measured and corrected downstream:
+
+    1. Firstcal-style delay calibration: per-antenna delays and phase offsets
+       from the phases of the data/model ratio on cross baselines. Phases only,
+       blind to amplitude suppression.
+    2. Amplitude calibration from the autocorrelations: each antenna's |gain|
+       from its own autocorrelation referenced to the median over antennas.
+       Autocorrelations are exempt from cross-correlation-only signal loss, so
+       this amplitude scale cannot absorb it.
+    3. Per-channel complex gain refinement solved on cross baselines — by
+       default restricted to baselines whose antennas are on different SNAPs,
+       since intra-SNAP baselines are likewise exempt from decoherence.
+       Whatever amplitude structure the crosses need beyond stages 1-2 lands
+       in these refined gains.
+
+The final gain is the product of the stage 1-2 gains (g0) and the stage 3
+refined gains.
+
+The primary use case for the "model" is LST-stacked, redundantly-averaged, and
+delay/fringe-rate-filtered visibilities from prior nights (e.g. the corner-
+turned single-baseline sky-model files built for abscal): smooth by
+construction and keyed by redundant group, so a RedDataContainer can map every
+physical baseline to its group's model. Any time-aligned model visibilities
+work in principle, but the noise weighting and the smoothness assumptions
+implicit in downstream analysis are designed around that product.
+
+This module works on already-loaded data: file I/O, sky-model file
+selection/LST-matching, flag sourcing, and the M&C antenna-to-SNAP lookup are
+all the caller's responsibility (hera_mc is deliberately not imported).
+"""
+import numpy as np
+import linsolve
+
+from . import utils
+from .noise import predict_noise_variance_from_autos
+from .datacontainer import DataContainer
+from .abscal import merge_gains
+
+
+########################################################################
+# Shared utilities
+########################################################################
+
+
+def _pack_baseline_arrays(container, bls):
+    '''Stack per-baseline waterfalls into a single array plus antenna indexing.
+
+    Arguments:
+        container: DataContainer (or dict) mapping baseline keys to
+            (Ntimes, Nfreqs) waterfalls
+        bls: list of baseline tuples like (0, 1, 'ee') to stack, in order
+
+    Returns:
+        stacked: (Nbls, Ntimes, Nfreqs) ndarray of the waterfalls, in the
+            order given by bls
+        ant_i_idx: int ndarray of first-antenna indices into ants, per baseline
+        ant_j_idx: int ndarray of second-antenna indices into ants, per baseline
+        ants: sorted list of antenna numbers appearing in bls
+    '''
+    ants = sorted({ant for bl in bls for ant in bl[:2]})
+    idx = {ant: i for i, ant in enumerate(ants)}
+    stacked = np.asarray([container[bl] for bl in bls])
+    ant_i_idx = np.array([idx[bl[0]] for bl in bls], dtype=int)
+    ant_j_idx = np.array([idx[bl[1]] for bl in bls], dtype=int)
+    return stacked, ant_i_idx, ant_j_idx, ants
+
+
+########################################################################
+# Data / model ratio construction
+########################################################################
+
+
+def build_data_model_ratio(data, model, autos=None, data_flags=None,
+                           model_flags=None, ant_flags=None, bls=None,
+                           dt=None, df=None):
+    '''Build the matched-filter data/model ratio and its inverse-variance
+    weights: ratio = V * M^* / |M|^2 (equal to V / M in the low-noise limit)
+    and wgts = |M|^2 / sigma^2 with sigma^2 = auto_i * auto_j / (dt * df) from
+    noise.predict_noise_variance_from_autos. In these conventions the weighted
+    average of ratio over any set of cells is the inverse-variance estimate of
+    the (assumed common) gain factor relating data to model.
+
+    Arguments:
+        data: DataContainer of visibilities (cross-correlations; may also
+            contain the autocorrelations used for noise weights)
+        model: DataContainer or RedDataContainer of model visibilities,
+            time-aligned to data. Primarily intended to be LST-stacked,
+            redundantly-averaged, and filtered visibilities from prior nights
+            (smooth by construction); a RedDataContainer resolves any baseline
+            in a redundant group to its prototype, conjugating as needed.
+        autos: DataContainer containing autocorrelations for noise weights.
+            Default None uses data.
+        data_flags: optional DataContainer of per-baseline flag waterfalls
+        model_flags: optional DataContainer of model flag waterfalls
+        ant_flags: optional dict mapping (ant, antpol) e.g. (0, 'Jee') to flag
+            waterfalls, applied to both antennas of each baseline
+        bls: optional list of baselines to include. Default None uses all
+            cross baselines in data that have corresponding models.
+        dt: integration time in seconds. Default None infers from autos.
+        df: channel width in Hz. Default None infers from autos.
+
+    Returns:
+        data_model_ratio: DataContainer of V * M^* / |M|^2 waterfalls, np.nan
+            where flagged or where the model is missing/zero
+        wgts: DataContainer of |M|^2 / sigma^2 waterfalls, 0 where flagged
+    '''
+    if autos is None:
+        autos = data
+    if bls is None:
+        bls = [bl for bl in data if bl[0] != bl[1] and bl in model]
+
+    ratio_here, wgts_here = {}, {}
+    for bl in bls:
+        mvis = np.asarray(model[bl])
+        flgs = ~np.isfinite(mvis)
+        if data_flags is not None:
+            flgs = flgs | data_flags[bl]
+        if model_flags is not None:
+            flgs = flgs | np.asarray(model_flags[bl])
+        if ant_flags is not None:
+            ant1, ant2 = utils.split_bl(bl)
+            if ant1 in ant_flags:
+                flgs = flgs | ant_flags[ant1]
+            if ant2 in ant_flags:
+                flgs = flgs | ant_flags[ant2]
+        mvis = np.nan_to_num(mvis)
+        m2 = np.abs(mvis)**2
+        sigma2 = predict_noise_variance_from_autos(bl, autos, dt=dt, df=df)
+        good = (~flgs) & (m2 > 0) & np.isfinite(sigma2) & (sigma2 > 0)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            ratio_here[bl] = np.where(good, data[bl] * np.conj(mvis)
+                                      / np.where(m2 > 0, m2, 1), np.nan)
+            wgts_here[bl] = np.where(good, m2 / np.where(good, sigma2, 1), 0)
+    return DataContainer(ratio_here), DataContainer(wgts_here)
+
+
+########################################################################
+# Model-based firstcal: per-antenna delays and phase offsets
+########################################################################
+
+
+def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
+                                              ant_j_idx, nants):
+    '''Weighted least-squares solve of per-baseline differences for per-antenna
+    values, i.e. vals[bl] ~ x[i] - x[j], with the mean over solved antennas
+    fixed to 0 (an overall offset is unobservable in differences).
+
+    Arguments:
+        vals: ndarray of per-baseline measurements (e.g. delays tau_i - tau_j)
+        wgts: ndarray of per-baseline weights (non-positive weights are ignored)
+        ant_i_idx / ant_j_idx: int ndarrays indexing each baseline's antennas
+        nants: total number of antennas indexed
+
+    Returns:
+        x: ndarray of length nants with per-antenna solutions; antennas with no
+            usable baselines are np.nan
+    '''
+    ok = np.isfinite(vals) & (wgts > 0)
+    ls_data, ls_wgts = {}, {}
+    for bi in np.where(ok)[0]:
+        eqn = f'x_{ant_i_idx[bi]} - x_{ant_j_idx[bi]}'
+        if eqn in ls_data:
+            # weighted-average repeated measurements of the same difference
+            wtot = ls_wgts[eqn] + wgts[bi]
+            ls_data[eqn] = (ls_data[eqn] * ls_wgts[eqn]
+                            + vals[bi] * wgts[bi]) / wtot
+            ls_wgts[eqn] = wtot
+        else:
+            ls_data[eqn] = vals[bi]
+            ls_wgts[eqn] = wgts[bi]
+    x = np.full(nants, np.nan)
+    if len(ls_data) > 0:
+        # pinv gives the minimum-norm solution of the (singular) difference
+        # system; the explicit mean subtraction then fixes the mean=0 gauge
+        sol = linsolve.LinearSolver(ls_data, wgts=ls_wgts).solve(mode='pinv')
+        for i in range(nants):
+            if f'x_{i}' in sol:
+                x[i] = float(sol[f'x_{i}'])
+        solved = np.isfinite(x)
+        x[solved] -= x[solved].mean()
+    return x
+
+
+def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
+    '''Solve for per-antenna delays and phase offsets from the phases of the
+    data/model ratio (phases only; amplitudes are untouched), independently
+    for each integration. Per baseline and integration, the weighted FFT of
+    the ratio across frequency peaks at tau_i - tau_j; per-antenna delays
+    follow by weighted least squares with the mean delay fixed to 0 (an
+    overall delay is unobservable). Per-antenna phase offsets are then solved
+    the same way from the delay-corrected mean phases.
+
+    Arguments:
+        data_model_ratio: DataContainer from build_data_model_ratio
+        wgts: DataContainer of weights from build_data_model_ratio
+        freqs: ndarray of frequencies in Hz
+        verbose: print statements if True
+
+    Returns:
+        dlys: dict mapping (ant, antpol) e.g. (0, 'Jee') to (Ntimes, 1)
+            ndarrays of delays in seconds. Antennas with no usable
+            cross-baseline data get 0.0.
+        offsets: dict mapping (ant, antpol) to (Ntimes, 1) ndarrays of phase
+            offsets in radians. Antennas with no usable cross-baseline data
+            get 0.0.
+    '''
+    freqs = np.asarray(freqs)
+    df = np.median(np.diff(freqs))
+    dlys, offsets = {}, {}
+    for pol in sorted({bl[2] for bl in data_model_ratio}):
+        bls_here = [bl for bl in data_model_ratio
+                    if bl[2] == pol and bl[0] != bl[1]]
+        ratio, ant_i_idx, ant_j_idx, ants = _pack_baseline_arrays(
+            data_model_ratio, bls_here)
+        wgt_arr = np.asarray([wgts[bl] for bl in bls_here])
+        nants = len(ants)
+        nbls, ntimes = ratio.shape[0], ratio.shape[1]
+        wgtd_ratio = np.nan_to_num(ratio) * wgt_arr
+        solve_wgts = wgt_arr.sum(axis=2)
+
+        # per-(baseline, integration) delays from the FFT peak
+        flat_ratio = wgtd_ratio.reshape(nbls * ntimes, -1)
+        flat_wgts = solve_wgts.reshape(nbls * ntimes)
+        bl_dlys = np.full(nbls * ntimes, np.nan)
+        has_wgt = flat_wgts > 0
+        if has_wgt.any():
+            bl_dlys[has_wgt] = utils.fft_dly(flat_ratio[has_wgt],
+                                             df)[0].ravel()
+        bl_dlys = bl_dlys.reshape(nbls, ntimes)
+
+        # per-antenna delays (mean-delay gauge = 0), then per-antenna offsets
+        # from delay-corrected mean phases, independently per integration
+        ant_dlys = np.full((ntimes, nants), np.nan)
+        ant_offsets = np.full((ntimes, nants), np.nan)
+        for tind in range(ntimes):
+            ant_dlys[tind] = _solve_per_antenna_weighted_least_squares(
+                bl_dlys[:, tind], solve_wgts[:, tind], ant_i_idx, ant_j_idx,
+                nants)
+            with np.errstate(invalid='ignore'):
+                dly_phasor = np.exp(
+                    -2j * np.pi * freqs[None, :]
+                    * np.nan_to_num(ant_dlys[tind, ant_i_idx]
+                                    - ant_dlys[tind, ant_j_idx])[:, None])
+            resid_phases = np.angle(
+                (wgtd_ratio[:, tind] * dly_phasor).sum(axis=1))
+            ant_offsets[tind] = _solve_per_antenna_weighted_least_squares(
+                resid_phases, solve_wgts[:, tind], ant_i_idx, ant_j_idx,
+                nants)
+
+        n_unsolved = int(np.sum(~np.isfinite(ant_dlys).any(axis=0)))
+        if n_unsolved > 0:
+            utils.echo(f'{n_unsolved} antennas in {pol} have no usable '
+                       'cross-baseline data; setting delays/offsets to 0.',
+                       verbose=verbose)
+        antpol = utils.split_pol(pol)[0]
+        for i, ant in enumerate(ants):
+            dlys[(ant, antpol)] = np.nan_to_num(ant_dlys[:, i])[:, None]
+            offsets[(ant, antpol)] = np.nan_to_num(ant_offsets[:, i])[:, None]
+    return dlys, offsets
+
+
+def firstcal_gains(dlys, offsets, freqs):
+    '''Expand per-antenna delays and offsets into unit-amplitude gain
+    waterfalls.
+
+    Arguments:
+        dlys: dict mapping (ant, antpol) to (Ntimes, 1) ndarrays of delays in
+            seconds, as returned by model_based_firstcal
+        offsets: dict mapping (ant, antpol) to (Ntimes, 1) ndarrays of phase
+            offsets in radians, as returned by model_based_firstcal
+        freqs: ndarray of frequencies in Hz
+
+    Returns:
+        gains: dict mapping (ant, antpol) to complex (Ntimes, len(freqs))
+            gain waterfalls, exp(2j pi freqs dly + 1j offset)
+    '''
+    # same convention as redcal.RedundantCalibrator.firstcal
+    return {ant: np.exp(2j * np.pi * dly * np.asarray(freqs) + 1j * offsets[ant])
+            for ant, dly in dlys.items()}
+
+
+########################################################################
+# Amplitude calibration from the autocorrelations
+########################################################################
+
+
+def calibrate_abs_amp_from_autos(autos, auto_flags=None):
+    '''Derive real, positive per-antenna gain amplitudes from the
+    autocorrelations: |g_i| = sqrt(auto_i / median-over-antennas auto). The
+    median reference divides out the sky, so each antenna's amplitude carries
+    its bandpass and receiver temperature relative to the array median. The
+    job of this stage is to start the per-channel refinement from roughly the
+    right amplitude scale; the refinement then determines the amplitudes
+    absolutely from the cross-correlations. Note that these amplitudes are
+    BIASED wherever receiver temperatures differ from antenna to antenna:
+    each autocorrelation measures |g|^2 * (T_sky + T_rx) while the
+    cross-correlations see only the sky signal, so referencing to the median
+    auto effectively assumes one common T_rx. That per-antenna (and mostly
+    spectrally smooth) error is subsequently absorbed by the refinement.
+    (A useful side effect of using the autos: because autocorrelations are
+    exempt from cross-correlation-only signal loss ("decoherence"), none of
+    that loss is baked into these starting amplitudes, so it appears cleanly
+    in the refined gains instead.)
+
+    Arguments:
+        autos: DataContainer containing autocorrelations, keys (ant, ant, pol)
+        auto_flags: optional DataContainer/dict of flag waterfalls with the
+            same keys; flagged cells are excluded from the median reference
+
+    Returns:
+        gains: dict mapping (ant, antpol) to real-positive (Ntimes, Nfreqs)
+            gain amplitude waterfalls (complex dtype for downstream merging)
+    '''
+    gains = {}
+    for pol in sorted({bl[2] for bl in autos if bl[0] == bl[1]}):
+        auto_bls = sorted(bl for bl in autos if bl[0] == bl[1]
+                          and bl[2] == pol)
+        stack = np.asarray([np.abs(autos[bl]) for bl in auto_bls], dtype=float)
+        if auto_flags is not None:
+            for i, bl in enumerate(auto_bls):
+                if bl in auto_flags:
+                    stack[i][np.asarray(auto_flags[bl])] = np.nan
+        ref_auto = np.nanmedian(stack, axis=0)
+        antpol = utils.split_pol(pol)[0]
+        for bl in auto_bls:
+            with np.errstate(invalid='ignore', divide='ignore'):
+                amp = np.sqrt(np.abs(autos[bl])
+                              / np.where(ref_auto > 0, ref_auto, np.nan))
+            gains[(bl[0], antpol)] = amp.astype(complex)
+    return gains
+
+
+########################################################################
+# Per-channel complex gain refinement
+########################################################################
+
+
+def _shared_channel_flags(ratio_wgts, ant_i_idx, ant_j_idx, nants):
+    '''Validate that the flagging pattern (encoded as zero weights) has the
+    uniform structure this solver requires and reduce it to a single shared
+    flag waterfall. Acceptable flags are combinations of exactly two kinds:
+    whole ANTENNAS flagged (every channel of every baseline containing them
+    at this time) and channels flagged for ALL baselines at once (e.g.
+    array-wide RFI flags). Under that structure every surviving baseline
+    sees the same channels, so every participating antenna appears in every
+    kept channel and the per-channel systems are exactly nonsingular with no
+    regularization. Anything else — a channel flagged for a strict subset of
+    baselines, or a fully-flagged baseline between two otherwise-unflagged
+    antennas — raises a ValueError rather than being silently repaired: fix
+    the flags upstream (the intended file_calibration flagging produces
+    exactly the required structure), and exclude unwanted baselines from the
+    solve by omitting them, not by flagging them.
+
+    Arguments:
+        ratio_wgts: float ndarray (Nbls, Nfreqs) of weights; 0 = flagged
+        ant_i_idx / ant_j_idx: int ndarrays of length Nbls indexing antennas
+        nants: total number of antennas indexed
+
+    Returns:
+        flagged_ants: boolean ndarray over antennas that are entirely flagged
+        chan_flags: boolean ndarray over channels; the OR of the surviving
+            baselines' flags (identical for each of them, by validation)
+    '''
+    unflagged = ratio_wgts > 0
+    flagged_bls = ~unflagged.any(axis=1)
+    # an antenna is flagged if and only if all of its baselines are
+    ant_live = np.zeros(nants, dtype=bool)
+    np.logical_or.at(ant_live, ant_i_idx, ~flagged_bls)
+    np.logical_or.at(ant_live, ant_j_idx, ~flagged_bls)
+    flagged_ants = ~ant_live
+    unexplained = flagged_bls & ~(flagged_ants[ant_i_idx]
+                                  | flagged_ants[ant_j_idx])
+    if unexplained.any():
+        raise ValueError(
+            'Flagging pattern is not uniform: some baselines are entirely '
+            'flagged although neither of their antennas is entirely flagged. '
+            'Only whole-antenna flags and channels flagged for ALL baselines '
+            'are supported; exclude baselines from the solve by omitting '
+            'them, not by flagging them.')
+    if flagged_bls.all():
+        return flagged_ants, np.ones(ratio_wgts.shape[1], dtype=bool)
+    chan_flags = ~unflagged[~flagged_bls].all(axis=0)
+    if not (unflagged[~flagged_bls] == ~chan_flags[None, :]).all():
+        raise ValueError(
+            'Flagging pattern is not uniform: only whole-antenna flags and '
+            'channels flagged for ALL baselines are supported, but some '
+            'channels are flagged for a strict subset of baselines. Fix the '
+            'flags upstream (e.g. broadcast per-antenna channel flags to '
+            'all antennas) before calling this solver.')
+    return flagged_ants, chan_flags
+
+
+def _build_normal_matrices(nchan_active, nsel, chan_pos, ei, ej, round_wgts):
+    '''Build the batched per-channel normal matrices (the matrices of the two
+    weighted least-squares systems solved each round). Amplitude equations
+    have the form resid ~ eta_i + eta_j — log-amplitudes ADD, because
+    |g_i * conj(g_j)| = |g_i| |g_j| — giving matrices with POSITIVE
+    off-diagonal couplings that are positive definite under uniform flagging.
+    Phase equations have the form resid ~ phi_i - phi_j — phases SUBTRACT,
+    from the conjugation of antenna j's gain — giving graph-Laplacian
+    matrices whose one exact null direction (a constant added to every
+    phase) is removed by pinning the first participating antenna to 0; the
+    caller re-gauges the resulting update to mean phase = 0 afterward.
+
+    Arguments:
+        nchan_active: number of channels in the batch
+        nsel: number of participating antennas
+        chan_pos / ei / ej: int ndarrays over unflagged (baseline, channel)
+            entries giving each entry's position in the channel batch and
+            its two antenna indices
+        round_wgts: ndarray of per-entry weights for this round
+
+    Returns:
+        amp_mats: (nchan_active, nsel, nsel) log-amplitude system matrices
+        phase_mats: (nchan_active, nsel - 1, nsel - 1) phase system matrices
+            with the first participating antenna pinned
+    '''
+    # accumulate with np.bincount on flattened indices (several times faster
+    # than np.add.at); the amplitude and phase matrices share their diagonal
+    # blocks and differ only in the sign of the off-diagonal couplings
+    n2 = nsel * nsel
+    base = chan_pos.astype(np.int64) * n2
+    minlength = nchan_active * n2
+    diag = (np.bincount(base + ei * (nsel + 1), weights=round_wgts,
+                        minlength=minlength)
+            + np.bincount(base + ej * (nsel + 1), weights=round_wgts,
+                          minlength=minlength))
+    off = (np.bincount(base + ei * nsel + ej, weights=round_wgts,
+                       minlength=minlength)
+           + np.bincount(base + ej * nsel + ei, weights=round_wgts,
+                         minlength=minlength))
+    amp_mats = (diag + off).reshape(nchan_active, nsel, nsel)
+    phase_mats = (diag - off).reshape(nchan_active, nsel, nsel)
+    return amp_mats, phase_mats[:, 1:, 1:]
+
+
+def _phase_sync_init(phasors, round_wgts, chan_pos, ei, ej, nchan_active,
+                     nsel, sync_tol=1e-3, sync_maxiter=200):
+    '''Wrap-immune initialization of per-antenna phases by eigenvector phase
+    synchronization, batched over channels.
+
+    The problem: given noisy unit-modulus baseline measurements
+    u_ij ~ exp(1j * (phi_i - phi_j)) with weights w_ij, estimate per-antenna
+    phases phi_i. The obvious approach — weighted least squares on the
+    measured angles, angle(u_ij) ~ phi_i - phi_j — is WRAP-BLIND: each
+    measured angle determines phi_i - phi_j only modulo 2 pi, so once the
+    true phases span more than ~1 radian the linear solve lands on the wrong
+    branch. This initialization instead works with the phasors themselves,
+    so no angle is ever unwrapped: build the Hermitian matrix
+    S[i, j] = w_ij * u_ij (with S[j, i] its conjugate). Up to noise,
+    S[i, j] = w_ij * v_i * conj(v_j) for the true phasor vector
+    v_i = exp(1j * phi_i), which makes v the leading eigenvector of S; power
+    iteration converges to it, and the angles of its entries are the desired
+    phases. (This is the standard eigenvector method for the angular
+    synchronization problem — see e.g. Singer 2011, Applied and
+    Computational Harmonic Analysis, 30, 20.) Iteration stops when the
+    largest per-antenna angle change falls below sync_tol. The returned
+    angles have their mean over antennas subtracted, since an overall phase
+    is unobservable in baseline differences.
+
+    Arguments:
+        phasors: complex ndarray of unit-modulus per-entry measurements u_ij
+        round_wgts: ndarray of per-entry weights
+        chan_pos / ei / ej: int ndarrays giving each entry's position in the
+            channel batch and its two antenna indices
+        nchan_active: number of channels in the batch
+        nsel: number of participating antennas
+        sync_tol: convergence threshold in radians
+        sync_maxiter: iteration cap
+
+    Returns:
+        phases: (nchan_active, nsel) ndarray of initial per-antenna phases,
+            mean 0 over antennas in each channel
+    '''
+    sync_mats = np.zeros((nchan_active, nsel, nsel), dtype=np.complex64)
+    np.add.at(sync_mats, (chan_pos, ei, ej),
+              (round_wgts * phasors).astype(np.complex64))
+    np.add.at(sync_mats, (chan_pos, ej, ei),
+              (round_wgts * np.conj(phasors)).astype(np.complex64))
+    eigvec = np.ones((nchan_active, nsel, 1), dtype=np.complex64)
+    phases = np.zeros((nchan_active, nsel))
+    for _ in range(sync_maxiter):
+        # one power-iteration step toward the leading eigenvector
+        eigvec = sync_mats @ eigvec
+        eigvec /= np.linalg.norm(eigvec, axis=1, keepdims=True) + 1e-30
+        new_phases = np.angle(eigvec[:, :, 0])
+        new_phases -= new_phases.mean(axis=1, keepdims=True)
+        max_change = np.max(np.abs(np.angle(np.exp(
+            1j * (new_phases - phases)))))
+        phases = new_phases
+        if max_change < sync_tol:
+            break
+    return phases
+
+
+def _solve_logamp_updates(amp_mats, chan_pos, ei, ej, round_wgts, resids,
+                          nchan_active, nsel):
+    '''Solve the batched linear weighted least-squares systems for the
+    per-antenna log-amplitude updates. Each entry contributes the equation
+    resid ~ eta_i + eta_j, so both antennas' right-hand sides accumulate the
+    residual with POSITIVE sign (see _build_normal_matrices).
+
+    Returns: (nchan_active, nsel) ndarray of log-amplitude updates eta.'''
+    base = chan_pos.astype(np.int64) * nsel
+    wgtd_resids = round_wgts * resids
+    amp_rhs = (np.bincount(base + ei, weights=wgtd_resids,
+                           minlength=nchan_active * nsel)
+               + np.bincount(base + ej, weights=wgtd_resids,
+                             minlength=nchan_active * nsel)
+               ).reshape(nchan_active, nsel)
+    return np.linalg.solve(amp_mats, amp_rhs[:, :, None])[:, :, 0]
+
+
+def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
+                         nchan_active, nsel):
+    '''Solve the batched linear weighted least-squares systems for the
+    per-antenna phase updates. Each entry contributes the equation
+    resid ~ phi_i - phi_j (the sign flip comes from the conjugation of
+    antenna j's gain). The systems are the reduced ones with the first
+    participating antenna pinned to 0 (see _build_normal_matrices); the
+    caller re-gauges the full update to mean phase = 0.
+
+    Returns: (nchan_active, nsel) ndarray of phase updates phi, with the
+        pinned antenna's entry equal to 0.'''
+    base = chan_pos.astype(np.int64) * nsel
+    wgtd_resids = round_wgts * resids
+    phase_rhs = (np.bincount(base + ei, weights=wgtd_resids,
+                             minlength=nchan_active * nsel)
+                 - np.bincount(base + ej, weights=wgtd_resids,
+                               minlength=nchan_active * nsel)
+                 ).reshape(nchan_active, nsel)
+    delta_phase = np.zeros((nchan_active, nsel))
+    delta_phase[:, 1:] = np.linalg.solve(phase_mats,
+                                         phase_rhs[:, 1:, None])[:, :, 0]
+    return delta_phase
+
+
+def _stationarity_residual(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
+                           ant_j_idx):
+    '''Compute the convergence certificate: the MAXIMUM fixed-point residual
+    over all solved (antenna, channel) cells. At the exact weighted
+    least-squares optimum, every gain equals the weighted projection of the
+    data onto the other antennas' gains,
+    g_i = sum_j(w_ij * z_ij * g_j) / sum_j(w_ij * |g_j|^2) = U / D, so
+    max |U/D - g| / |g| measures how far each cell is from stationarity,
+    independently of the solver's own update sizes. Using the max (never a
+    median or percentile) is deliberate: a median criterion can declare
+    victory while an entire contiguous band remains unconverged.'''
+    wgtd_ratio = np.nan_to_num(vis_ratio) * ratio_wgts
+    numerator = np.zeros(full_gains.shape, dtype=complex)
+    denominator = np.zeros(full_gains.shape)
+    gains_zeroed = np.nan_to_num(full_gains)
+    np.add.at(numerator, ant_i_idx, wgtd_ratio * gains_zeroed[ant_j_idx])
+    np.add.at(denominator, ant_i_idx,
+              ratio_wgts * np.abs(gains_zeroed[ant_j_idx])**2)
+    np.add.at(numerator, ant_j_idx,
+              np.conj(wgtd_ratio) * gains_zeroed[ant_i_idx])
+    np.add.at(denominator, ant_j_idx,
+              ratio_wgts * np.abs(gains_zeroed[ant_i_idx])**2)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        resid = np.abs(numerator / np.maximum(denominator, 1e-30)
+                       - full_gains) / np.abs(full_gains)
+    solved_cells = np.isfinite(full_gains) & (denominator > 0)
+    return float(np.nanmax(resid[solved_cells]))
+
+
+def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
+                                  nants, hess_cadence=1, refine_tol=1e-8,
+                                  refine_maxiter=50, sync_tol=1e-3,
+                                  sync_maxiter=200, verbose=False):
+    '''Solve for per-antenna, per-channel complex gains g such that
+    vis_ratio ~ g_i * conj(g_j) on each baseline, for a single
+    (time, polarization).
+
+    The model is BILINEAR in the gains, so the problem itself is not linear.
+    It is solved by iteratively linearized weighted least squares
+    (Gauss-Newton) — the same strategy as redcal's lincal/omnical — with
+    every channel independent and solved as one batch of small dense
+    systems:
+
+        1. Initialization: log-amplitudes come from the EXACTLY linear
+           system log|vis_ratio_ij| = log|g_i| + log|g_j|; phases come from
+           wrap-immune eigenvector phase synchronization (_phase_sync_init),
+           because a linearized solve on measured angles cannot be used to
+           start — angles are only known modulo 2 pi.
+        2. Gauss-Newton rounds: writing the update as
+           g <- g * exp(eta + 1j * phi), the residual ratio
+           vis_ratio / (g_i * conj(g_j)) = exp(eta_i + eta_j
+           + 1j * (phi_i - phi_j)), which is approximately
+           1 + (eta_i + eta_j) + 1j * (phi_i - phi_j) for small updates. To
+           first order the two kinds of unknowns separate: the REAL part
+           minus 1 gives a linear system for the log-amplitude updates and
+           the IMAGINARY part gives a linear system for the phase updates.
+           Both are solved exactly each round; iterating drives the
+           linearization error to zero. Channels whose largest update falls
+           below refine_tol drop out of the batch early.
+
+    Relation to redcal's estimators and the logcal bias: only the
+    initialization is logcal-like. Linearizing g_i * conj(g_j) shows that
+    each Gauss-Newton round solves the normal equations of the UNTRANSFORMED
+    complex objective chi^2 = sum_ij w_ij |vis_ratio_ij - g_i * conj(g_j)|^2
+    (the (|g_i| |g_j|)^2 weight factor is that objective's Jacobian), so the
+    converged solution is the stationary point of the complex chi^2 —
+    exactly what _stationarity_residual certifies — independent of the
+    starting point. The low-signal-to-noise bias of logcal identified by
+    Liu et al. (2010, MNRAS 408, 1029) afflicts estimators whose FINAL
+    answer is the log-space optimum; here the log-space solve only starts
+    the iteration. (Iterating in log space instead was observed, during this
+    algorithm's development, to converge to a measurably offset optimum at
+    low signal-to-noise — which is why the rounds target the complex
+    objective.) The remaining bias is the generic second-order-in-noise bias
+    of any nonlinear least-squares fit, shared with redcal's lincal/omnical.
+
+    The flags (zero weights) are required to have a uniform structure —
+    whole antennas flagged plus channels flagged for all baselines at once —
+    which is validated and reduced to a single shared flag waterfall
+    (_shared_channel_flags); this makes every system exactly nonsingular
+    with no regularization. The phase gauge is fixed by pinning one antenna
+    inside the solves and then re-gauging each update to mean phase = 0 over
+    participating antennas — the same convention as
+    redcal.remove_degen_gains. Convergence is certified by the maximum
+    fixed-point residual over ALL solved cells (_stationarity_residual) and
+    enforced with a RuntimeError.
+
+    Arguments:
+        vis_ratio: complex ndarray (Nbls, Nfreqs) of data/model ratios
+            divided by g0_i * conj(g0_j); np.nan excludes a cell. Baselines
+            that should not participate (e.g. intra-SNAP) must be omitted
+            from the input, not flagged.
+        ratio_wgts: float ndarray (Nbls, Nfreqs) of inverse-variance weights
+            for vis_ratio; 0 excludes a cell
+        ant_i_idx / ant_j_idx: int ndarrays of length Nbls indexing antennas
+        nants: total number of antennas indexed
+        hess_cadence: rebuild the normal matrices every this many rounds (a
+            speed knob only; the converged solution is cadence-invariant)
+        refine_tol: convergence threshold on the largest per-(antenna,
+            channel) update
+        refine_maxiter: maximum number of Gauss-Newton rounds
+        sync_tol: convergence threshold (radians) for the phase
+            synchronization initialization (see _phase_sync_init)
+        sync_maxiter: iteration cap for the phase synchronization
+        verbose: print statements if True
+
+    Returns:
+        gains: complex ndarray (nants, Nfreqs); np.nan where unsolved
+        meta: dict with 'iter' (rounds used) and 'conv_crit' (max fixed-point
+            residual over all solved cells)
+
+    Raises:
+        ValueError: if the flagging pattern is not uniform (see
+            _shared_channel_flags)
+        RuntimeError: if any channel has not converged after refine_maxiter
+            rounds. Do not proceed with unconverged gains: partially
+            converged channels retain memory of the initialization and can
+            imprint coherent per-antenna spectral structure.
+    '''
+    nfreqs = vis_ratio.shape[1]
+
+    # validate the flags and reduce them to one shared waterfall: whole
+    # antennas out, plus channels flagged for everyone; guarantees that the
+    # linear systems below are exactly nonsingular (no regularization)
+    flagged_ants, chan_flags = _shared_channel_flags(ratio_wgts, ant_i_idx,
+                                                     ant_j_idx, nants)
+    good_chans = ~chan_flags
+    sel_ants = np.where(~flagged_ants)[0]
+    nsel = len(sel_ants)
+    unflagged = ratio_wgts > 0
+
+    # flatten the unflagged (baseline, channel) cells into 1D entry arrays,
+    # each tagged with its kept-channel index and its two antenna positions
+    ant_map = np.full(nants, -1)
+    ant_map[sel_ants] = np.arange(nsel)
+    good_chan_idx = np.where(good_chans)[0]
+    nchans = len(good_chan_idx)
+    bl_inds, chan_inds = np.where(unflagged[:, good_chan_idx])
+    sel_i = ant_map[ant_i_idx[bl_inds]]
+    sel_j = ant_map[ant_j_idx[bl_inds]]
+    entry_wgts = ratio_wgts[:, good_chan_idx][bl_inds, chan_inds]
+    entry_ratio = vis_ratio[:, good_chan_idx][bl_inds, chan_inds]
+
+    gains = np.ones((nsel, nchans), dtype=complex)
+    active_chans = np.ones(nchans, dtype=bool)   # channels still iterating
+    amp_mats = phase_mats = cached_chans = None
+    niter = 0
+    while niter <= refine_maxiter and active_chans.any():
+        # restrict the flattened entries to channels still iterating,
+        # renumbering channels to positions within this round's batch
+        active_idx = np.where(active_chans)[0]
+        remap = np.full(nchans, -1)
+        remap[active_idx] = np.arange(len(active_idx))
+        in_active = active_chans[chan_inds]
+        chan_pos = remap[chan_inds[in_active]]
+        ei, ej = sel_i[in_active], sel_j[in_active]
+        echan = chan_inds[in_active]
+        wgts_here = entry_wgts[in_active]
+        nactive = len(active_idx)
+
+        # residual ratio: the data with the current gain model divided out;
+        # exactly exp(eta_i + eta_j + 1j * (phi_i - phi_j)) for the updates
+        # (eta, phi) that remain to be solved
+        gi, gj = gains[ei, echan], gains[ej, echan]
+        with np.errstate(invalid='ignore', divide='ignore'):
+            resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
+        assert np.isfinite(resid_ratio).all(), \
+            'non-finite ratio under enforced flags'
+
+        if niter == 0:
+            # ---- initialization round ----
+            round_wgts = wgts_here
+            amp_mats, phase_mats = _build_normal_matrices(
+                nactive, nsel, chan_pos, ei, ej, round_wgts)
+            cached_chans = active_idx
+            amp_here, phase_here = amp_mats, phase_mats
+            # log-amplitudes: log|resid_ratio| = eta_i + eta_j is exactly
+            # linear in the log-amplitudes — no approximation needed
+            amp_resids = np.log(np.abs(resid_ratio))
+            # phases: wrap-immune eigenvector synchronization (see helper)
+            delta_phase = _phase_sync_init(
+                resid_ratio / np.abs(resid_ratio), round_wgts, chan_pos,
+                ei, ej, nactive, nsel, sync_tol=sync_tol,
+                sync_maxiter=sync_maxiter)
+        else:
+            # ---- Gauss-Newton round ----
+            # propagating the data weights through the division by the
+            # current gains multiplies each weight by (|g_i| |g_j|)^2
+            round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
+            if (niter - 1) % hess_cadence == 0:
+                amp_mats, phase_mats = _build_normal_matrices(
+                    nactive, nsel, chan_pos, ei, ej, round_wgts)
+                cached_chans = active_idx
+                amp_here, phase_here = amp_mats, phase_mats
+            else:
+                # reuse cached matrices, selecting this round's channels
+                rows = np.searchsorted(cached_chans, active_idx)
+                amp_here, phase_here = amp_mats[rows], phase_mats[rows]
+            # linearize: Im(resid_ratio) ~ phi_i - phi_j and
+            # Re(resid_ratio) - 1 ~ eta_i + eta_j
+            delta_phase = _solve_phase_updates(
+                phase_here, chan_pos, ei, ej, round_wgts,
+                np.imag(resid_ratio), nactive, nsel)
+            amp_resids = np.real(resid_ratio) - 1.0
+        delta_logamp = _solve_logamp_updates(
+            amp_here, chan_pos, ei, ej, round_wgts, amp_resids, nactive,
+            nsel)
+
+        # re-gauge the phase update to mean 0 over participating antennas
+        # (same convention as redcal.remove_degen_gains), then apply both
+        # updates multiplicatively
+        delta_phase -= delta_phase.mean(axis=1, keepdims=True)
+        gains[:, active_idx] = gains[:, active_idx] \
+            * np.exp(delta_logamp.T + 1j * delta_phase.T)
+
+        # channels whose largest update is below tolerance are converged
+        # and drop out of subsequent rounds
+        if niter > 0:
+            max_update = np.hypot(delta_logamp, delta_phase).max(axis=1)
+            active_chans[active_idx[max_update < refine_tol]] = False
+        niter += 1
+    converged = not active_chans.any()
+
+    # embed the solution back into the full (antenna, channel) grid
+    full_gains = np.full((nants, nfreqs), np.nan, dtype=complex)
+    full_gains[np.ix_(sel_ants, good_chan_idx)] = gains
+
+    conv_crit = _stationarity_residual(vis_ratio, ratio_wgts, full_gains,
+                                       ant_i_idx, ant_j_idx)
+    if not converged:
+        raise RuntimeError(
+            f'Per-channel gain refinement did not converge: '
+            f'{int(active_chans.sum())} channels remain above '
+            f'refine_tol={refine_tol} after {refine_maxiter} rounds '
+            f'(max fixed-point residual {conv_crit:.2e}). Do not proceed '
+            'with unconverged gains.')
+    return full_gains, {'iter': niter, 'conv_crit': conv_crit}
+
+
+def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
+                 hess_cadence=1, refine_tol=1e-8, refine_maxiter=50,
+                 sync_tol=1e-3, sync_maxiter=200, verbose=False):
+    '''Solve for per-antenna, per-channel refined gains on cross baselines,
+    given starting gains g0. The data/model ratio divided by g0_i g0_j^* should
+    be ~1 up to per-antenna corrections beyond g0 — including any per-SNAP
+    cross-correlation-only signal loss, which is the quantity this stage is
+    designed to capture. If ant_to_SNAP_dict is given, only baselines between
+    antennas on DIFFERENT SNAPs are used (intra-SNAP baselines are exempt from
+    decoherence and would bias it toward zero).
+
+    Arguments:
+        data_model_ratio: DataContainer from build_data_model_ratio
+        wgts: DataContainer of weights from build_data_model_ratio
+        g0: dict mapping (ant, antpol) to starting gain waterfalls (e.g. the
+            product of firstcal_gains and calibrate_abs_amp_from_autos gains)
+        ant_to_SNAP_dict: optional dict mapping antenna numbers to SNAP IDs
+            (any hashable). If given, EVERY antenna appearing in the solve must
+            be present (raises ValueError otherwise); if None, all cross
+            baselines participate.
+        hess_cadence, refine_tol, refine_maxiter, sync_tol, sync_maxiter:
+            see _refine_gains_single_pol_time
+        verbose: print statements if True
+
+    Returns:
+        refined_gains: dict mapping (ant, antpol) to complex (Ntimes, Nfreqs)
+            gain waterfalls; np.nan where unsolved
+        meta: dict with 'iter' and 'conv_crit', each a dict keyed by
+            (time index, pol)
+
+    Raises:
+        ValueError: if ant_to_SNAP_dict is given but missing antennas, or if
+            the flagging pattern is not uniform (see _shared_channel_flags)
+        RuntimeError: if the solve fails to converge for any (time, pol)
+    '''
+    bls = [bl for bl in data_model_ratio if bl[0] != bl[1]]
+    all_ants = sorted({ant for bl in bls for ant in bl[:2]})
+    if ant_to_SNAP_dict is not None:
+        missing = [ant for ant in all_ants if ant not in ant_to_SNAP_dict]
+        if len(missing) > 0:
+            raise ValueError('ant_to_SNAP_dict is missing antennas that '
+                             f'appear in the data: {missing}. All antennas '
+                             'must be mapped to SNAPs if any are.')
+
+    refined_gains = {}
+    meta = {'iter': {}, 'conv_crit': {}}
+    for pol in sorted({bl[2] for bl in bls}):
+        antpol = utils.split_pol(pol)[0]
+        bls_here = [bl for bl in bls if bl[2] == pol
+                    and (bl[0], antpol) in g0 and (bl[1], antpol) in g0]
+        if ant_to_SNAP_dict is not None:
+            # intra-SNAP baselines are excluded from the solve by omission
+            # (they are exempt from decoherence and would bias it low)
+            n_cross = len(bls_here)
+            bls_here = [bl for bl in bls_here
+                        if ant_to_SNAP_dict[bl[0]] != ant_to_SNAP_dict[bl[1]]]
+            utils.echo(f'{len(bls_here)} of {n_cross} {pol} baselines are '
+                       'inter-SNAP and enter the solve', verbose=verbose)
+        if len(bls_here) == 0:
+            continue
+        ratio, ant_i_idx, ant_j_idx, ants = _pack_baseline_arrays(
+            data_model_ratio, bls_here)
+        wgt_arr = np.asarray([wgts[bl] for bl in bls_here])
+        g0_arr = np.asarray([g0[(ant, antpol)] for ant in ants])
+        nants = len(ants)
+        ntimes, nfreqs = ratio.shape[1], ratio.shape[2]
+
+        for ant in ants:
+            refined_gains[(ant, antpol)] = np.full((ntimes, nfreqs), np.nan,
+                                                   dtype=complex)
+        for tind in range(ntimes):
+            gain_ij = g0_arr[ant_i_idx, tind] * np.conj(g0_arr[ant_j_idx, tind])
+            with np.errstate(invalid='ignore', divide='ignore'):
+                vis_ratio = np.where(
+                    np.isfinite(gain_ij) & (np.abs(gain_ij) > 0),
+                    ratio[:, tind] / gain_ij, np.nan)
+            ratio_wgts = np.where(np.isfinite(vis_ratio),
+                                  wgt_arr[:, tind] * np.abs(gain_ij)**2, 0)
+            gains_here, meta_here = _refine_gains_single_pol_time(
+                vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx, nants,
+                hess_cadence=hess_cadence, refine_tol=refine_tol,
+                refine_maxiter=refine_maxiter, sync_tol=sync_tol,
+                sync_maxiter=sync_maxiter, verbose=verbose)
+            utils.echo(f't{tind} {pol}: {meta_here["iter"]} rounds, max '
+                       f'stationarity residual {meta_here["conv_crit"]:.2e}',
+                       verbose=verbose)
+            for i, ant in enumerate(ants):
+                refined_gains[(ant, antpol)][tind] = gains_here[i]
+            for key in meta:
+                meta[key][(tind, pol)] = meta_here[key]
+    return refined_gains, meta
+
+
+########################################################################
+# Full staged calibration pipeline
+########################################################################
+
+
+def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
+                  ant_flags=None, auto_flags=None, ant_to_SNAP_dict=None,
+                  freqs=None, bls=None, dt=None, df=None, hess_cadence=1,
+                  refine_tol=1e-8, refine_maxiter=50, sync_tol=1e-3,
+                  sync_maxiter=200, verbose=False):
+    '''Run the full staged sky-model-based calibration: data/model ratio →
+    firstcal delays and offsets → autocorrelation-based amplitudes → per-channel
+    refinement on (inter-SNAP) cross baselines. Returns gains g = g0 * refined,
+    where g0 (firstcal phases × auto-derived amplitudes) is constructed so that
+    per-SNAP cross-correlation-only signal loss can land only in the refined
+    gains.
+
+    Arguments:
+        data: DataContainer of visibilities, including autocorrelations unless
+            autos is given separately
+        model: DataContainer or RedDataContainer of model visibilities,
+            time-aligned to data. Primarily intended to be LST-stacked,
+            redundantly-averaged, and filtered visibilities from prior nights
+            (see build_data_model_ratio).
+        autos: optional DataContainer of autocorrelations (default: data)
+        data_flags, model_flags: optional flag DataContainers
+        ant_flags: optional dict mapping (ant, antpol) to flag waterfalls
+        auto_flags: optional flags for the autocorrelations (see
+            calibrate_abs_amp_from_autos)
+        ant_to_SNAP_dict: optional dict mapping antennas to SNAP IDs; see
+            refine_gains. The M&C lookup is the caller's responsibility.
+        freqs: ndarray of frequencies in Hz (default: data.freqs)
+        bls: optional list of baselines to calibrate with
+        dt: integration time in seconds (default: inferred from autos)
+        df: channel width in Hz (default: inferred from autos)
+        hess_cadence, refine_tol, refine_maxiter, sync_tol, sync_maxiter:
+            see _refine_gains_single_pol_time
+        verbose: print statements if True
+
+    Returns:
+        gains: dict mapping (ant, antpol) to complex (Ntimes, Nfreqs) gain
+            waterfalls, g0 * refined_gains; np.nan where unsolved
+        meta: dict of stage products and diagnostics: 'data_model_ratio',
+            'wgts', 'dlys', 'offsets', 'abs_amp_gains', 'g0', 'refined_gains',
+            and the refinement's 'iter' and 'conv_crit' dicts keyed by
+            (time index, pol)
+    '''
+    if freqs is None:
+        freqs = data.freqs
+    freqs = np.asarray(freqs)
+    if autos is None:
+        autos = data
+
+    utils.echo('Building data/model ratio and weights...', verbose=verbose)
+    data_model_ratio, wgts = build_data_model_ratio(
+        data, model, autos=autos, data_flags=data_flags,
+        model_flags=model_flags, ant_flags=ant_flags, bls=bls, dt=dt, df=df)
+
+    utils.echo('Solving model-based firstcal delays and offsets...',
+               verbose=verbose)
+    dlys, offsets = model_based_firstcal(data_model_ratio, wgts, freqs,
+                                         verbose=verbose)
+    fc_gains = firstcal_gains(dlys, offsets, freqs)
+
+    utils.echo('Calibrating amplitudes from autocorrelations...',
+               verbose=verbose)
+    abs_amp_gains = calibrate_abs_amp_from_autos(autos, auto_flags=auto_flags)
+    g0 = merge_gains([abs_amp_gains, fc_gains])
+
+    utils.echo('Refining gains per channel on cross baselines...',
+               verbose=verbose)
+    refined_gains, refine_meta = refine_gains(
+        data_model_ratio, wgts, g0, ant_to_SNAP_dict=ant_to_SNAP_dict,
+        hess_cadence=hess_cadence, refine_tol=refine_tol,
+        refine_maxiter=refine_maxiter, sync_tol=sync_tol,
+        sync_maxiter=sync_maxiter, verbose=verbose)
+
+    gains = merge_gains([g0, refined_gains])
+    meta = {'data_model_ratio': data_model_ratio, 'wgts': wgts, 'dlys': dlys,
+            'offsets': offsets, 'abs_amp_gains': abs_amp_gains, 'g0': g0,
+            'refined_gains': refined_gains, **refine_meta}
+    return gains, meta

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -158,7 +158,7 @@ def build_data_model_ratio(data, model, autos=None, data_flags=None,
 
 
 def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
-                                              ant_j_idx, nants):
+                                              ant_j_idx, nants, mode='pinv'):
     '''Weighted least-squares solve of per-baseline differences for per-antenna
     values, i.e. vals[bl] ~ x[i] - x[j], with the mean over solved antennas
     fixed to 0 (an overall offset is unobservable in differences).
@@ -168,6 +168,8 @@ def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
         wgts: ndarray of per-baseline weights (non-positive weights are ignored)
         ant_i_idx / ant_j_idx: int ndarrays indexing each baseline's antennas
         nants: total number of antennas indexed
+        mode: linsolve.LinearSolver solve mode (default 'pinv', which gives
+            the minimum-norm solution of the singular difference system)
 
     Returns:
         x: ndarray of length nants with per-antenna solutions; antennas with no
@@ -188,10 +190,9 @@ def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
             ls_wgts[eqn] = wgts[bi]
     x = np.full(nants, np.nan)
     if len(ls_data) > 0:
-        # pinv gives the minimum-norm solution of the (singular) difference
-        # system; the explicit mean subtraction then removes the degeneracy
-        # by fixing the mean to 0
-        sol = linsolve.LinearSolver(ls_data, wgts=ls_wgts).solve(mode='pinv')
+        # the explicit mean subtraction after the solve removes the
+        # degeneracy by fixing the mean to 0
+        sol = linsolve.LinearSolver(ls_data, wgts=ls_wgts).solve(mode=mode)
         for i in range(nants):
             if f'x_{i}' in sol:
                 x[i] = float(sol[f'x_{i}'])
@@ -200,7 +201,8 @@ def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
     return x
 
 
-def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
+def model_based_firstcal(data_model_ratio, wgts, freqs, mode='pinv',
+                         verbose=False):
     '''Solve for per-antenna delays and phase offsets from the phases of the
     data/model ratio (phases only; amplitudes are untouched), independently
     for each integration. Per baseline and integration, the weighted FFT of
@@ -213,6 +215,8 @@ def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
         data_model_ratio: DataContainer from build_data_model_ratio
         wgts: DataContainer of weights from build_data_model_ratio
         freqs: ndarray of frequencies in Hz
+        mode: linsolve.LinearSolver solve mode for the per-antenna solves
+            (default 'pinv'; see _solve_per_antenna_weighted_least_squares)
         verbose: print statements if True
 
     Returns:
@@ -255,7 +259,7 @@ def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
         for tind in range(ntimes):
             ant_dlys[tind] = _solve_per_antenna_weighted_least_squares(
                 bl_dlys[:, tind], solve_wgts[:, tind], ant_i_idx, ant_j_idx,
-                nants)
+                nants, mode=mode)
             with np.errstate(invalid='ignore'):
                 dly_phasor = np.exp(
                     -2j * np.pi * freqs[None, :]
@@ -265,7 +269,7 @@ def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
                 (wgtd_ratio[:, tind] * dly_phasor).sum(axis=1))
             ant_offsets[tind] = _solve_per_antenna_weighted_least_squares(
                 resid_phases, solve_wgts[:, tind], ant_i_idx, ant_j_idx,
-                nants)
+                nants, mode=mode)
 
         n_unsolved = int(np.sum(~np.isfinite(ant_dlys).any(axis=0)))
         if n_unsolved > 0:

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -181,7 +181,8 @@ def _solve_per_antenna_weighted_least_squares(vals, wgts, ant_i_idx,
     x = np.full(nants, np.nan)
     if len(ls_data) > 0:
         # pinv gives the minimum-norm solution of the (singular) difference
-        # system; the explicit mean subtraction then fixes the mean=0 gauge
+        # system; the explicit mean subtraction then removes the degeneracy
+        # by fixing the mean to 0
         sol = linsolve.LinearSolver(ls_data, wgts=ls_wgts).solve(mode='pinv')
         for i in range(nants):
             if f'x_{i}' in sol:
@@ -238,8 +239,9 @@ def model_based_firstcal(data_model_ratio, wgts, freqs, verbose=False):
                                              df)[0].ravel()
         bl_dlys = bl_dlys.reshape(nbls, ntimes)
 
-        # per-antenna delays (mean-delay gauge = 0), then per-antenna offsets
-        # from delay-corrected mean phases, independently per integration
+        # per-antenna delays (degeneracy fixed: mean delay = 0), then
+        # per-antenna offsets from delay-corrected mean phases,
+        # independently per integration
         ant_dlys = np.full((ntimes, nants), np.nan)
         ant_offsets = np.full((ntimes, nants), np.nan)
         for tind in range(ntimes):
@@ -410,7 +412,8 @@ def _build_normal_matrices(nchan_active, nsel, chan_pos, ei, ej, round_wgts):
     from the conjugation of antenna j's gain — giving graph-Laplacian
     matrices whose one exact null direction (a constant added to every
     phase) is removed by pinning the first participating antenna to 0; the
-    caller re-gauges the resulting update to mean phase = 0 afterward.
+    caller then removes the degeneracy of the resulting update by setting
+    its mean phase to 0.
 
     Arguments:
         nchan_active: number of channels in the batch
@@ -528,7 +531,8 @@ def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
     resid ~ phi_i - phi_j (the sign flip comes from the conjugation of
     antenna j's gain). The systems are the reduced ones with the first
     participating antenna pinned to 0 (see _build_normal_matrices); the
-    caller re-gauges the full update to mean phase = 0.
+    caller removes the degeneracy of the full update by setting its mean
+    phase to 0.
 
     Returns: (nchan_active, nsel) ndarray of phase updates phi, with the
         pinned antenna's entry equal to 0.'''
@@ -625,10 +629,10 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     whole antennas flagged plus channels flagged for all baselines at once —
     which is validated and reduced to a single shared flag waterfall
     (_shared_channel_flags); this makes every system exactly nonsingular
-    with no regularization. The phase gauge is fixed by pinning one antenna
-    inside the solves and then re-gauging each update to mean phase = 0 over
-    participating antennas — the same convention as
-    redcal.remove_degen_gains. Convergence is certified by the maximum
+    with no regularization. The overall phase degeneracy is fixed by pinning
+    one antenna inside the solves and then removing the degeneracy from each
+    update by setting its mean phase to 0 over participating antennas — the
+    same convention as redcal.remove_degen_gains. Convergence is certified by the maximum
     fixed-point residual over ALL solved cells (_stationarity_residual) and
     enforced with a RuntimeError.
 
@@ -753,9 +757,10 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             amp_here, chan_pos, ei, ej, round_wgts, amp_resids, nactive,
             nsel)
 
-        # re-gauge the phase update to mean 0 over participating antennas
-        # (same convention as redcal.remove_degen_gains), then apply both
-        # updates multiplicatively
+        # remove the phase degeneracy by setting the update's mean over
+        # participating antennas to 0 (same convention as
+        # redcal.remove_degen_gains), then apply both updates
+        # multiplicatively
         delta_phase -= delta_phase.mean(axis=1, keepdims=True)
         gains[:, active_idx] = gains[:, active_idx] \
             * np.exp(delta_logamp.T + 1j * delta_phase.T)

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -586,7 +586,7 @@ def _stationarity_residual(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
 
 
 def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
-                                  nants, hess_cadence=1, refine_tol=1e-8,
+                                  nants, refine_tol=1e-8,
                                   refine_maxiter=100, sync_tol=1e-3,
                                   sync_maxiter=200, verbose=False):
     '''Solve for per-antenna, per-channel complex gains g such that
@@ -652,15 +652,6 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             for vis_ratio; 0 excludes a cell
         ant_i_idx / ant_j_idx: int ndarrays of length Nbls indexing antennas
         nants: total number of antennas indexed
-        hess_cadence: rebuild the normal matrices at most every this many
-            rounds; between rebuilds the cached matrices AND the weights
-            frozen into them are reused with fresh residuals (frozen-Hessian
-            Gauss-Newton). Reuse only begins once updates fall below ~3%
-            (steps against a stale Hessian can diverge far from the
-            optimum), and channels may only exit as converged on rounds with
-            a freshly rebuilt Hessian, so convergence is always judged
-            against the exact linearization. A speed knob only; the
-            converged solution is cadence-invariant.
         refine_tol: convergence threshold on the largest per-(antenna,
             channel) update
         refine_maxiter: maximum number of Gauss-Newton rounds
@@ -712,7 +703,6 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     gains = np.ones((nsel, nchans), dtype=complex)
     active_chans = np.ones(nchans, dtype=bool)   # channels still iterating
     chan_iters = np.zeros(nfreqs, dtype=int)     # rounds each channel used
-    amp_mats = phase_mats = cached_chans = cached_wgts = None
     niter = 0
     while niter <= refine_maxiter and active_chans.any():
         # restrict the flattened entries to channels still iterating,
@@ -743,15 +733,9 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
         if niter == 0:
             # ---- initialization round ----
-            # (these raw-weight matrices are never reused: forcing
-            # rounds_since_rebuild to the cadence makes round 1 rebuild)
-            fresh_hessian = True
-            rounds_since_rebuild = hess_cadence
             round_wgts = wgts_here
             amp_mats, phase_mats = _build_normal_matrices(
                 nactive, nsel, chan_pos, ei, ej, round_wgts)
-            cached_chans = active_idx
-            amp_here, phase_here = amp_mats, phase_mats
             # log-amplitudes: log|resid_ratio| = eta_i + eta_j is exactly
             # linear in the log-amplitudes — no approximation needed
             amp_resids = np.log(np.abs(resid_ratio))
@@ -762,48 +746,19 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
                 sync_maxiter=sync_maxiter)
         else:
             # ---- Gauss-Newton round ----
-            # rebuild on the hess_cadence schedule, but NEVER reuse while
-            # updates are still large: far from the optimum the curvature
-            # and the (|g_i| |g_j|)^2 weight factors change substantially
-            # between rounds, and steps against a stale Hessian can
-            # overshoot and diverge. Updates below 0.03 in (log-amplitude,
-            # phase) units — gains within ~3% of their fixed point — mark
-            # the asymptotic regime where reuse is safe.
-            fresh_hessian = (rounds_since_rebuild >= hess_cadence
-                             or prev_max_update > 0.03)
-            if fresh_hessian:
-                # propagating the data weights through the division by the
-                # current gains multiplies each weight by (|g_i| |g_j|)^2
-                round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
-                amp_mats, phase_mats = _build_normal_matrices(
-                    nactive, nsel, chan_pos, ei, ej, round_wgts)
-                cached_chans = active_idx
-                # freeze the per-entry weights alongside the matrices (on
-                # the full entry grid, so shrinking active sets can subset)
-                cached_wgts = np.zeros(len(entry_wgts))
-                cached_wgts[in_active] = round_wgts
-                amp_here, phase_here = amp_mats, phase_mats
-                rounds_since_rebuild = 1
-            else:
-                # reuse cached matrices, selecting this round's channels.
-                # The right-hand sides must be built with the SAME frozen
-                # weights as the cached matrices (frozen-Hessian Gauss-
-                # Newton, with only the residuals updated): mixing fresh
-                # weights with stale matrices solves an inconsistent system
-                # that can amplify updates and diverge as the gains drift
-                # from where the matrices were built
-                rows = np.searchsorted(cached_chans, active_idx)
-                amp_here, phase_here = amp_mats[rows], phase_mats[rows]
-                round_wgts = cached_wgts[in_active]
-                rounds_since_rebuild += 1
+            # propagating the data weights through the division by the
+            # current gains multiplies each weight by (|g_i| |g_j|)^2
+            round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
+            amp_mats, phase_mats = _build_normal_matrices(
+                nactive, nsel, chan_pos, ei, ej, round_wgts)
             # linearize: Im(resid_ratio) ~ phi_i - phi_j and
             # Re(resid_ratio) - 1 ~ eta_i + eta_j
             delta_phase = _solve_phase_updates(
-                phase_here, chan_pos, ei, ej, round_wgts,
+                phase_mats, chan_pos, ei, ej, round_wgts,
                 np.imag(resid_ratio), nactive, nsel)
             amp_resids = np.real(resid_ratio) - 1.0
         delta_logamp = _solve_logamp_updates(
-            amp_here, chan_pos, ei, ej, round_wgts, amp_resids, nactive,
+            amp_mats, chan_pos, ei, ej, round_wgts, amp_resids, nactive,
             nsel)
 
         # remove the phase degeneracy by setting the update's mean over
@@ -814,15 +769,11 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         gains[:, active_idx] = gains[:, active_idx] \
             * np.exp(delta_logamp.T + 1j * delta_phase.T)
 
-        # track the largest update: it gates Hessian reuse (above), and on
-        # rounds with a freshly rebuilt Hessian it retires converged
-        # channels. Reuse rounds may NOT retire channels, so convergence is
-        # always judged against the exact linearization rather than the
-        # frozen-weight one. Record the rounds each channel used (redcal's
-        # solve_iteratively likewise reports per-channel counts)
-        max_update = np.hypot(delta_logamp, delta_phase).max(axis=1)
-        prev_max_update = max_update.max()
-        if niter > 0 and fresh_hessian:
+        # channels whose largest update is below tolerance are converged
+        # and drop out of subsequent rounds; record the rounds each used
+        # (redcal's solve_iteratively likewise reports per-channel counts)
+        if niter > 0:
+            max_update = np.hypot(delta_logamp, delta_phase).max(axis=1)
             dropped = active_idx[max_update < refine_tol]
             active_chans[dropped] = False
             chan_iters[good_chan_idx[dropped]] = niter + 1
@@ -846,7 +797,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
 
 def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
-                 hess_cadence=1, refine_tol=1e-8, refine_maxiter=100,
+                 refine_tol=1e-8, refine_maxiter=100,
                  sync_tol=1e-3, sync_maxiter=200, verbose=False):
     '''Solve for per-antenna, per-channel refined gains on cross baselines,
     given starting gains g0. The data/model ratio divided by g0_i g0_j^* should
@@ -865,7 +816,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
             (any hashable). If given, EVERY antenna appearing in the solve must
             be present (raises ValueError otherwise); if None, all cross
             baselines participate.
-        hess_cadence, refine_tol, refine_maxiter, sync_tol, sync_maxiter:
+        refine_tol, refine_maxiter, sync_tol, sync_maxiter:
             see _refine_gains_single_pol_time
         verbose: print statements if True
 
@@ -926,7 +877,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                                   wgt_arr[:, tind] * np.abs(gain_ij)**2, 0)
             gains_here, meta_here = _refine_gains_single_pol_time(
                 vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx, nants,
-                hess_cadence=hess_cadence, refine_tol=refine_tol,
+                refine_tol=refine_tol,
                 refine_maxiter=refine_maxiter, sync_tol=sync_tol,
                 sync_maxiter=sync_maxiter, verbose=verbose)
             utils.echo(f't{tind} {pol}: {int(meta_here["iter"].max())} '
@@ -947,7 +898,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
 
 def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
                   ant_flags=None, auto_flags=None, ant_to_SNAP_dict=None,
-                  freqs=None, bls=None, dt=None, df=None, hess_cadence=1,
+                  freqs=None, bls=None, dt=None, df=None,
                   refine_tol=1e-8, refine_maxiter=100, sync_tol=1e-3,
                   sync_maxiter=200, verbose=False):
     '''Run the full staged sky-model-based calibration: data/model ratio →
@@ -975,7 +926,7 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
         bls: optional list of baselines to calibrate with
         dt: integration time in seconds (default: inferred from autos)
         df: channel width in Hz (default: inferred from autos)
-        hess_cadence, refine_tol, refine_maxiter, sync_tol, sync_maxiter:
+        refine_tol, refine_maxiter, sync_tol, sync_maxiter:
             see _refine_gains_single_pol_time
         verbose: print statements if True
 
@@ -1013,7 +964,7 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
                verbose=verbose)
     refined_gains, refine_meta = refine_gains(
         data_model_ratio, wgts, g0, ant_to_SNAP_dict=ant_to_SNAP_dict,
-        hess_cadence=hess_cadence, refine_tol=refine_tol,
+        refine_tol=refine_tol,
         refine_maxiter=refine_maxiter, sync_tol=sync_tol,
         sync_maxiter=sync_maxiter, verbose=verbose)
 

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -551,15 +551,18 @@ def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
 
 def _stationarity_residual(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
                            ant_j_idx):
-    '''Compute the convergence certificate: the MAXIMUM fixed-point residual
-    over all solved (antenna, channel) cells. At the exact weighted
+    '''Compute the convergence certificate: the per-channel MAXIMUM
+    fixed-point residual over all solved antennas. At the exact weighted
     least-squares optimum, every gain equals the weighted projection of the
     data onto the other antennas' gains,
     g_i = sum_j(w_ij * z_ij * g_j) / sum_j(w_ij * |g_j|^2) = U / D, so
     max |U/D - g| / |g| measures how far each cell is from stationarity,
-    independently of the solver's own update sizes. Using the max (never a
-    median or percentile) is deliberate: a median criterion can declare
-    victory while an entire contiguous band remains unconverged.'''
+    independently of the solver's own update sizes. Certifying on maxima
+    (never a median or percentile) is deliberate: a median criterion can
+    declare victory while an entire contiguous band remains unconverged.
+
+    Returns: (Nfreqs,) ndarray of the max residual over solved antennas in
+        each channel; np.nan for channels with no solved cells.'''
     wgtd_ratio = np.nan_to_num(vis_ratio) * ratio_wgts
     numerator = np.zeros(full_gains.shape, dtype=complex)
     denominator = np.zeros(full_gains.shape)
@@ -575,12 +578,16 @@ def _stationarity_residual(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
         resid = np.abs(numerator / np.maximum(denominator, 1e-30)
                        - full_gains) / np.abs(full_gains)
     solved_cells = np.isfinite(full_gains) & (denominator > 0)
-    return float(np.nanmax(resid[solved_cells]))
+    per_chan = np.full(full_gains.shape[1], np.nan)
+    solved_chans = solved_cells.any(axis=0)
+    per_chan[solved_chans] = np.where(solved_cells, resid,
+                                      -np.inf).max(axis=0)[solved_chans]
+    return per_chan
 
 
 def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
                                   nants, hess_cadence=1, refine_tol=1e-8,
-                                  refine_maxiter=50, sync_tol=1e-3,
+                                  refine_maxiter=100, sync_tol=1e-3,
                                   sync_maxiter=200, verbose=False):
     '''Solve for per-antenna, per-channel complex gains g such that
     vis_ratio ~ g_i * conj(g_j) on each baseline, for a single
@@ -645,8 +652,15 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             for vis_ratio; 0 excludes a cell
         ant_i_idx / ant_j_idx: int ndarrays of length Nbls indexing antennas
         nants: total number of antennas indexed
-        hess_cadence: rebuild the normal matrices every this many rounds (a
-            speed knob only; the converged solution is cadence-invariant)
+        hess_cadence: rebuild the normal matrices at most every this many
+            rounds; between rebuilds the cached matrices AND the weights
+            frozen into them are reused with fresh residuals (frozen-Hessian
+            Gauss-Newton). Reuse only begins once updates fall below ~3%
+            (steps against a stale Hessian can diverge far from the
+            optimum), and channels may only exit as converged on rounds with
+            a freshly rebuilt Hessian, so convergence is always judged
+            against the exact linearization. A speed knob only; the
+            converged solution is cadence-invariant.
         refine_tol: convergence threshold on the largest per-(antenna,
             channel) update
         refine_maxiter: maximum number of Gauss-Newton rounds
@@ -657,8 +671,11 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
     Returns:
         gains: complex ndarray (nants, Nfreqs); np.nan where unsolved
-        meta: dict with 'iter' (rounds used) and 'conv_crit' (max fixed-point
-            residual over all solved cells)
+        meta: dict of per-channel (Nfreqs,) arrays, following redcal's
+            solve_iteratively convention: 'iter' (int rounds each channel
+            used before its early exit; 0 where flagged) and 'conv_crit'
+            (max fixed-point residual over antennas in each channel;
+            np.nan where flagged)
 
     Raises:
         ValueError: if the flagging pattern is not uniform (see
@@ -694,7 +711,8 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
     gains = np.ones((nsel, nchans), dtype=complex)
     active_chans = np.ones(nchans, dtype=bool)   # channels still iterating
-    amp_mats = phase_mats = cached_chans = None
+    chan_iters = np.zeros(nfreqs, dtype=int)     # rounds each channel used
+    amp_mats = phase_mats = cached_chans = cached_wgts = None
     niter = 0
     while niter <= refine_maxiter and active_chans.any():
         # restrict the flattened entries to channels still iterating,
@@ -715,11 +733,20 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         gi, gj = gains[ei, echan], gains[ej, echan]
         with np.errstate(invalid='ignore', divide='ignore'):
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
-        assert np.isfinite(resid_ratio).all(), \
-            'non-finite ratio under enforced flags'
+        if not np.isfinite(resid_ratio).all():
+            if niter == 0:
+                raise ValueError('Non-finite data/model ratio on unflagged '
+                                 'cells: the flags do not cover all bad '
+                                 'data.')
+            raise RuntimeError('Per-channel gain refinement diverged: '
+                               f'non-finite gains in round {niter}.')
 
         if niter == 0:
             # ---- initialization round ----
+            # (these raw-weight matrices are never reused: forcing
+            # rounds_since_rebuild to the cadence makes round 1 rebuild)
+            fresh_hessian = True
+            rounds_since_rebuild = hess_cadence
             round_wgts = wgts_here
             amp_mats, phase_mats = _build_normal_matrices(
                 nactive, nsel, chan_pos, ei, ej, round_wgts)
@@ -735,18 +762,40 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
                 sync_maxiter=sync_maxiter)
         else:
             # ---- Gauss-Newton round ----
-            # propagating the data weights through the division by the
-            # current gains multiplies each weight by (|g_i| |g_j|)^2
-            round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
-            if (niter - 1) % hess_cadence == 0:
+            # rebuild on the hess_cadence schedule, but NEVER reuse while
+            # updates are still large: far from the optimum the curvature
+            # and the (|g_i| |g_j|)^2 weight factors change substantially
+            # between rounds, and steps against a stale Hessian can
+            # overshoot and diverge. Updates below 0.03 in (log-amplitude,
+            # phase) units — gains within ~3% of their fixed point — mark
+            # the asymptotic regime where reuse is safe.
+            fresh_hessian = (rounds_since_rebuild >= hess_cadence
+                             or prev_max_update > 0.03)
+            if fresh_hessian:
+                # propagating the data weights through the division by the
+                # current gains multiplies each weight by (|g_i| |g_j|)^2
+                round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
                 amp_mats, phase_mats = _build_normal_matrices(
                     nactive, nsel, chan_pos, ei, ej, round_wgts)
                 cached_chans = active_idx
+                # freeze the per-entry weights alongside the matrices (on
+                # the full entry grid, so shrinking active sets can subset)
+                cached_wgts = np.zeros(len(entry_wgts))
+                cached_wgts[in_active] = round_wgts
                 amp_here, phase_here = amp_mats, phase_mats
+                rounds_since_rebuild = 1
             else:
-                # reuse cached matrices, selecting this round's channels
+                # reuse cached matrices, selecting this round's channels.
+                # The right-hand sides must be built with the SAME frozen
+                # weights as the cached matrices (frozen-Hessian Gauss-
+                # Newton, with only the residuals updated): mixing fresh
+                # weights with stale matrices solves an inconsistent system
+                # that can amplify updates and diverge as the gains drift
+                # from where the matrices were built
                 rows = np.searchsorted(cached_chans, active_idx)
                 amp_here, phase_here = amp_mats[rows], phase_mats[rows]
+                round_wgts = cached_wgts[in_active]
+                rounds_since_rebuild += 1
             # linearize: Im(resid_ratio) ~ phi_i - phi_j and
             # Re(resid_ratio) - 1 ~ eta_i + eta_j
             delta_phase = _solve_phase_updates(
@@ -765,11 +814,18 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         gains[:, active_idx] = gains[:, active_idx] \
             * np.exp(delta_logamp.T + 1j * delta_phase.T)
 
-        # channels whose largest update is below tolerance are converged
-        # and drop out of subsequent rounds
-        if niter > 0:
-            max_update = np.hypot(delta_logamp, delta_phase).max(axis=1)
-            active_chans[active_idx[max_update < refine_tol]] = False
+        # track the largest update: it gates Hessian reuse (above), and on
+        # rounds with a freshly rebuilt Hessian it retires converged
+        # channels. Reuse rounds may NOT retire channels, so convergence is
+        # always judged against the exact linearization rather than the
+        # frozen-weight one. Record the rounds each channel used (redcal's
+        # solve_iteratively likewise reports per-channel counts)
+        max_update = np.hypot(delta_logamp, delta_phase).max(axis=1)
+        prev_max_update = max_update.max()
+        if niter > 0 and fresh_hessian:
+            dropped = active_idx[max_update < refine_tol]
+            active_chans[dropped] = False
+            chan_iters[good_chan_idx[dropped]] = niter + 1
         niter += 1
     converged = not active_chans.any()
 
@@ -784,13 +840,13 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             f'Per-channel gain refinement did not converge: '
             f'{int(active_chans.sum())} channels remain above '
             f'refine_tol={refine_tol} after {refine_maxiter} rounds '
-            f'(max fixed-point residual {conv_crit:.2e}). Do not proceed '
-            'with unconverged gains.')
-    return full_gains, {'iter': niter, 'conv_crit': conv_crit}
+            f'(max fixed-point residual {np.nanmax(conv_crit):.2e}). '
+            'Do not proceed with unconverged gains.')
+    return full_gains, {'iter': chan_iters, 'conv_crit': conv_crit}
 
 
 def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
-                 hess_cadence=1, refine_tol=1e-8, refine_maxiter=50,
+                 hess_cadence=1, refine_tol=1e-8, refine_maxiter=100,
                  sync_tol=1e-3, sync_maxiter=200, verbose=False):
     '''Solve for per-antenna, per-channel refined gains on cross baselines,
     given starting gains g0. The data/model ratio divided by g0_i g0_j^* should
@@ -817,7 +873,8 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
         refined_gains: dict mapping (ant, antpol) to complex (Ntimes, Nfreqs)
             gain waterfalls; np.nan where unsolved
         meta: dict with 'iter' and 'conv_crit', each a dict keyed by
-            (time index, pol)
+            (time index, pol) of per-channel (Nfreqs,) arrays (see
+            _refine_gains_single_pol_time)
 
     Raises:
         ValueError: if ant_to_SNAP_dict is given but missing antennas, or if
@@ -872,8 +929,9 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                 hess_cadence=hess_cadence, refine_tol=refine_tol,
                 refine_maxiter=refine_maxiter, sync_tol=sync_tol,
                 sync_maxiter=sync_maxiter, verbose=verbose)
-            utils.echo(f't{tind} {pol}: {meta_here["iter"]} rounds, max '
-                       f'stationarity residual {meta_here["conv_crit"]:.2e}',
+            utils.echo(f't{tind} {pol}: {int(meta_here["iter"].max())} '
+                       'rounds, max stationarity residual '
+                       f'{np.nanmax(meta_here["conv_crit"]):.2e}',
                        verbose=verbose)
             for i, ant in enumerate(ants):
                 refined_gains[(ant, antpol)][tind] = gains_here[i]
@@ -890,7 +948,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
 def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
                   ant_flags=None, auto_flags=None, ant_to_SNAP_dict=None,
                   freqs=None, bls=None, dt=None, df=None, hess_cadence=1,
-                  refine_tol=1e-8, refine_maxiter=50, sync_tol=1e-3,
+                  refine_tol=1e-8, refine_maxiter=100, sync_tol=1e-3,
                   sync_maxiter=200, verbose=False):
     '''Run the full staged sky-model-based calibration: data/model ratio →
     firstcal delays and offsets → autocorrelation-based amplitudes → per-channel
@@ -927,7 +985,7 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
         meta: dict of stage products and diagnostics: 'data_model_ratio',
             'wgts', 'dlys', 'offsets', 'abs_amp_gains', 'g0', 'refined_gains',
             and the refinement's 'iter' and 'conv_crit' dicts keyed by
-            (time index, pol)
+            (time index, pol) of per-channel (Nfreqs,) arrays
     '''
     if freqs is None:
         freqs = data.freqs

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -118,6 +118,14 @@ def build_data_model_ratio(data, model, autos=None, data_flags=None,
         autos = data
     if bls is None:
         bls = [bl for bl in data if bl[0] != bl[1] and bl in model]
+    # fail early and legibly if any noise-weight autocorrelation is missing
+    # (otherwise this surfaces as an opaque KeyError inside noise.py)
+    missing_autos = sorted({utils.join_bl(ant, ant) for bl in bls
+                            for ant in utils.split_bl(bl)
+                            if utils.join_bl(ant, ant) not in autos})
+    if len(missing_autos) > 0:
+        raise ValueError('Autocorrelations needed for noise weights are '
+                         f'missing from autos: {missing_autos}.')
 
     ratio_here, wgts_here = {}, {}
     for bl in bls:
@@ -670,7 +678,9 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
     Raises:
         ValueError: if the flagging pattern is not uniform (see
-            _shared_channel_flags)
+            _shared_channel_flags), or if any unflagged cell has zero or
+            non-finite data/model ratio (flags or zero weights must cover
+            all bad data)
         RuntimeError: if any channel has not converged after refine_maxiter
             rounds. Do not proceed with unconverged gains: partially
             converged channels retain memory of the initialization and can
@@ -700,6 +710,16 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     entry_wgts = ratio_wgts[:, good_chan_idx][bl_inds, chan_inds]
     entry_ratio = vis_ratio[:, good_chan_idx][bl_inds, chan_inds]
 
+    # exact zeros are as fatal as NaNs here (log-amplitudes and unit phasors
+    # are both undefined) and typically mean bad data stored as 0 without
+    # accompanying flags, so fail loudly rather than diverge confusingly
+    bad_entries = ~np.isfinite(entry_ratio) | (entry_ratio == 0)
+    if bad_entries.any():
+        raise ValueError(
+            f'{int(bad_entries.sum())} unflagged (baseline, channel) cells '
+            'have zero or non-finite data/model ratio. Flags or zero '
+            'weights must cover all bad data.')
+
     gains = np.ones((nsel, nchans), dtype=complex)
     active_chans = np.ones(nchans, dtype=bool)   # channels still iterating
     chan_iters = np.zeros(nfreqs, dtype=int)     # rounds each channel used
@@ -724,10 +744,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         with np.errstate(invalid='ignore', divide='ignore'):
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
         if not np.isfinite(resid_ratio).all():
-            if niter == 0:
-                raise ValueError('Non-finite data/model ratio on unflagged '
-                                 'cells: the flags do not cover all bad '
-                                 'data.')
+            # inputs were validated above, so this can only be divergence
             raise RuntimeError('Per-channel gain refinement diverged: '
                                f'non-finite gains in round {niter}.')
 
@@ -813,9 +830,10 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
         g0: dict mapping (ant, antpol) to starting gain waterfalls (e.g. the
             product of firstcal_gains and calibrate_abs_amp_from_autos gains)
         ant_to_SNAP_dict: optional dict mapping antenna numbers to SNAP IDs
-            (any hashable). If given, EVERY antenna appearing in the solve must
-            be present (raises ValueError otherwise); if None, all cross
-            baselines participate.
+            (any hashable). If given, EVERY antenna appearing in any cross
+            baseline of data_model_ratio must be present, whether or not it
+            ends up in the solve (raises ValueError otherwise); if None, all
+            cross baselines participate.
         refine_tol, refine_maxiter, sync_tol, sync_maxiter:
             see _refine_gains_single_pol_time
         verbose: print statements if True
@@ -828,8 +846,9 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
             _refine_gains_single_pol_time)
 
     Raises:
-        ValueError: if ant_to_SNAP_dict is given but missing antennas, or if
-            the flagging pattern is not uniform (see _shared_channel_flags)
+        ValueError: if ant_to_SNAP_dict is given but missing antennas, if
+            the flagging pattern is not uniform (see _shared_channel_flags),
+            or if any unflagged cell has zero or non-finite data/model ratio
         RuntimeError: if the solve fails to converge for any (time, pol)
     '''
     bls = [bl for bl in data_model_ratio if bl[0] != bl[1]]
@@ -968,6 +987,16 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
         refine_maxiter=refine_maxiter, sync_tol=sync_tol,
         sync_maxiter=sync_maxiter, verbose=verbose)
 
+    # every antenna with starting gains must come through refinement — a gap
+    # would otherwise be silently dropped by the key intersection in
+    # merge_gains. Whole antennas should only ever be excluded by omission
+    # from bls, so a gap here is an error, not a fallback.
+    unrefined = sorted(set(g0) - set(refined_gains))
+    if len(unrefined) > 0:
+        raise ValueError('No baselines in the refinement solve for '
+                         f'{unrefined} (e.g. all their partners are on the '
+                         'same SNAP). Exclude these antennas from bls '
+                         'instead.')
     gains = merge_gains([g0, refined_gains])
     meta = {'data_model_ratio': data_model_ratio, 'wgts': wgts, 'dlys': dlys,
             'offsets': offsets, 'abs_amp_gains': abs_amp_gains, 'g0': g0,

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -259,7 +259,7 @@ class TestRefineGainsCore:
         gains, meta = skycal._refine_gains_single_pol_time(
             vis_ratio, wgts, ant_i, ant_j, nants)
         np.testing.assert_allclose(gains, true_h, atol=1e-7)
-        assert meta['conv_crit'] < 1e-7
+        assert np.nanmax(meta['conv_crit']) < 1e-7
 
     def test_wrap_immunity(self):
         # phases uniform on (-pi, pi]: a linearized phase solve would fail
@@ -416,6 +416,46 @@ class TestRefineGainsCore:
             vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=3)
         np.testing.assert_allclose(gains1, gains3, atol=1e-7)
 
+        # high amplitude dynamic range makes the (|g_i| |g_j|)^2 weight
+        # factor drift strongly between Hessian rebuilds — reuse must stay
+        # stable and still land on the cadence=1 solution
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            amp_scale=0.9, phase_scale=np.pi, noise=0.05)
+        gains1, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
+        gains4, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=4)
+        np.testing.assert_allclose(gains1, gains4, atol=1e-7)
+
+    def test_hess_cadence_regression_wide_weights(self):
+        # regression test (2026-08-03, first seen on real data): with
+        # weights spanning decades and gains far from unity, hess_cadence>1
+        # used to mix freshly computed weights into the right-hand sides
+        # against stale cached normal matrices — an inconsistent system
+        # whose steps amplified until the gains overflowed to non-finite.
+        # This seeded draw diverges under that scheme, and also under
+        # frozen weights WITHOUT the no-reuse-until-updates-are-small
+        # guard, so it protects both halves of the fix.
+        rng = np.random.default_rng(5)
+        nants, nfreqs = 20, 16
+        true_g = ((1.0 + 0.9 * rng.uniform(-1, 1, (nants, nfreqs)))
+                  * np.exp(1j * np.pi
+                           * rng.uniform(-1, 1, (nants, nfreqs))))
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vis_ratio = true_g[ant_i] * np.conj(true_g[ant_j])
+        vis_ratio = vis_ratio + 0.3 * (
+            rng.normal(size=vis_ratio.shape)
+            + 1j * rng.normal(size=vis_ratio.shape)) / np.sqrt(2)
+        wgts = 10.0 ** rng.uniform(0, 3, size=vis_ratio.shape)
+        gains1, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
+        gains2, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=2)
+        assert np.isfinite(gains2).all()
+        np.testing.assert_allclose(gains1, gains2, atol=1e-7)
+
 
 class TestRefineGains:
     def setup_method(self):
@@ -513,4 +553,4 @@ class TestSkyCalibrate:
                     'conv_crit']:
             assert key in meta
         assert (0, sim['pol']) in meta['iter']
-        assert meta['conv_crit'][(0, sim['pol'])] < 1e-6
+        assert np.nanmax(meta['conv_crit'][(0, sim['pol'])]) < 1e-6

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -86,7 +86,7 @@ class TestSolvePerAntennaWeightedLeastSquares:
     def setup_method(self):
         self.rng = np.random.default_rng(21)
 
-    def test_recovery_and_gauge(self):
+    def test_recovery_and_degeneracy_fixing(self):
         nants = 6
         x = self.rng.normal(size=nants)
         x -= x.mean()
@@ -240,7 +240,7 @@ class TestRefineGainsCore:
         true_h = ((1.0 + amp_scale * self.rng.uniform(-1, 1, (nants, nfreqs)))
                   * np.exp(1j * phase_scale
                            * self.rng.uniform(-1, 1, (nants, nfreqs))))
-        # gauge the truth: mean phase 0 per channel
+        # remove the truth's degeneracy: mean phase 0 per channel
         true_h *= np.exp(-1j * np.angle(true_h /
                                         np.abs(true_h)).mean(axis=0))[None, :]
         bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
@@ -267,7 +267,7 @@ class TestRefineGainsCore:
             phase_scale=np.pi, amp_scale=0.1)
         gains, meta = skycal._refine_gains_single_pol_time(
             vis_ratio, wgts, ant_i, ant_j, nants)
-        # compare baseline-level products (immune to any residual gauge)
+        # compare baseline-level products (immune to the phase degeneracy)
         np.testing.assert_allclose(gains[ant_i] * np.conj(gains[ant_j]),
                                    vis_ratio, atol=1e-7)
 
@@ -278,7 +278,7 @@ class TestRefineGainsCore:
             vis_ratio, wgts, ant_i, ant_j, nants)
 
         # independent solve: scipy least_squares per channel with ant 0's
-        # phase pinned, then re-gauged to mean phase = 0
+        # phase pinned, then degeneracy re-fixed to mean phase = 0
         for chan in range(3):
             z, w = vis_ratio[:, chan], wgts[:, chan]
 
@@ -310,9 +310,9 @@ class TestRefineGainsCore:
         solved_ants[2] = False
         good = np.ones(gains.shape[1], dtype=bool)
         good[4] = False
-        # remaining antennas/channels still recovered (gauge over the
-        # surviving antennas differs from the truth's, so compare
-        # baseline-level products, which are gauge-invariant)
+        # remaining antennas/channels still recovered (the degeneracy is
+        # fixed over the surviving antennas, so it differs from the truth's;
+        # compare baseline-level products, which are degeneracy-invariant)
         for i in np.where(solved_ants)[0]:
             for j in np.where(solved_ants)[0]:
                 np.testing.assert_allclose(
@@ -345,7 +345,7 @@ class TestRefineGainsCore:
             skycal._refine_gains_single_pol_time(
                 vis_ratio, wgts, ant_i, ant_j, nants, refine_maxiter=0)
 
-    def test_mean_phase_gauge(self):
+    def test_mean_phase_degeneracy_fixing(self):
         true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
             noise=0.02)
         gains, meta = skycal._refine_gains_single_pol_time(
@@ -489,14 +489,14 @@ class TestSkyCalibrate:
             df=sim['df'])
         # calibrating the data with the returned gains should recover the
         # model on all cross baselines (baseline products are invariant to
-        # the per-channel mean-phase gauge)
+        # how the per-channel mean-phase degeneracy is fixed)
         data = DataContainer({bl: np.array(sim['data'][bl])
                               for bl in sim['data'] if bl[0] != bl[1]})
         calibrate_in_place(data, gains)
         for bl in data:
             np.testing.assert_allclose(data[bl], sim['model'][bl],
                                        rtol=2e-2, atol=0)
-        # amplitudes are recovered absolutely; phases up to the gauge
+        # amplitudes are recovered absolutely; phases up to the degeneracy
         antpol = utils.split_pol(sim['pol'])[0]
         for ant in sim['ants']:
             np.testing.assert_allclose(

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -407,35 +407,10 @@ class TestRefineGainsCore:
             biases.append(np.mean(np.abs(gains) - np.abs(true_g)))
         assert np.abs(np.mean(biases)) < 0.015
 
-    def test_hess_cadence_invariance(self):
-        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
-            noise=0.05)
-        gains1, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
-        gains3, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=3)
-        np.testing.assert_allclose(gains1, gains3, atol=1e-7)
-
-        # high amplitude dynamic range makes the (|g_i| |g_j|)^2 weight
-        # factor drift strongly between Hessian rebuilds — reuse must stay
-        # stable and still land on the cadence=1 solution
-        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
-            amp_scale=0.9, phase_scale=np.pi, noise=0.05)
-        gains1, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
-        gains4, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=4)
-        np.testing.assert_allclose(gains1, gains4, atol=1e-7)
-
-    def test_hess_cadence_regression_wide_weights(self):
-        # regression test (2026-08-03, first seen on real data): with
-        # weights spanning decades and gains far from unity, hess_cadence>1
-        # used to mix freshly computed weights into the right-hand sides
-        # against stale cached normal matrices — an inconsistent system
-        # whose steps amplified until the gains overflowed to non-finite.
-        # This seeded draw diverges under that scheme, and also under
-        # frozen weights WITHOUT the no-reuse-until-updates-are-small
-        # guard, so it protects both halves of the fix.
+    def test_wide_weight_dynamic_range(self):
+        # stress test: weights spanning 3 decades, amplitudes 0.1-1.9x, and
+        # fully wrapped phases (real inverse-variance weights span decades
+        # across the band, and this regime once exposed a solver divergence)
         rng = np.random.default_rng(5)
         nants, nfreqs = 20, 16
         true_g = ((1.0 + 0.9 * rng.uniform(-1, 1, (nants, nfreqs)))
@@ -449,12 +424,10 @@ class TestRefineGainsCore:
             rng.normal(size=vis_ratio.shape)
             + 1j * rng.normal(size=vis_ratio.shape)) / np.sqrt(2)
         wgts = 10.0 ** rng.uniform(0, 3, size=vis_ratio.shape)
-        gains1, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
-        gains2, _ = skycal._refine_gains_single_pol_time(
-            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=2)
-        assert np.isfinite(gains2).all()
-        np.testing.assert_allclose(gains1, gains2, atol=1e-7)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+        assert np.isfinite(gains).all()
+        assert np.nanmax(meta['conv_crit']) < 1e-6
 
 
 class TestRefineGains:

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -99,6 +99,25 @@ class TestSolvePerAntennaWeightedLeastSquares:
         np.testing.assert_allclose(sol, x, atol=1e-8)
         assert np.abs(np.mean(sol)) < 1e-10
 
+    def test_solve_mode_kwarg(self):
+        # the linsolve mode is plumbed through, and alternate modes solve
+        # the same (singular) difference system: 'lsqr' and 'pinv' agree
+        # once the mean-zero degeneracy fixing is applied
+        nants = 6
+        x = self.rng.normal(size=nants)
+        x -= x.mean()
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vals = x[ant_i] - x[ant_j]
+        wgts = self.rng.uniform(0.5, 2.0, size=len(bls))
+        sol_pinv = skycal._solve_per_antenna_weighted_least_squares(
+            vals, wgts, ant_i, ant_j, nants, mode='pinv')
+        sol_lsqr = skycal._solve_per_antenna_weighted_least_squares(
+            vals, wgts, ant_i, ant_j, nants, mode='lsqr')
+        np.testing.assert_allclose(sol_pinv, sol_lsqr, atol=1e-6)
+        np.testing.assert_allclose(sol_lsqr, x, atol=1e-6)
+
     def test_unsolvable_antenna_is_nan(self):
         # antenna 3 appears in no baselines
         bls = [(0, 1), (0, 2), (1, 2)]

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -115,6 +115,16 @@ class TestBuildDataModelRatio:
     def setup_method(self):
         self.sim = build_sim(nants=5, nfreqs=32, ntimes=2, seed=1)
 
+    def test_missing_autos_raise(self):
+        # a clear error, rather than a KeyError deep inside noise.py
+        sim = self.sim
+        autos = DataContainer({bl: sim['data'][bl] for bl in sim['data']
+                               if bl[0] == bl[1] and bl[0] != 0})
+        with pytest.raises(ValueError, match='Autocorrelations'):
+            skycal.build_data_model_ratio(sim['data'], sim['model'],
+                                          autos=autos, dt=sim['dt'],
+                                          df=sim['df'])
+
     def test_perfect_data_gives_unity_ratio(self):
         # unity gains: data equals model on crosses
         sim = build_sim(nants=5, nfreqs=32, ntimes=2, seed=2, amp_ripple=0,
@@ -253,6 +263,15 @@ class TestRefineGainsCore:
                 + 1j * self.rng.normal(size=vis_ratio.shape)) / np.sqrt(2)
         wgts = self.rng.uniform(0.5, 2.0, size=vis_ratio.shape)
         return true_h, vis_ratio, wgts, ant_i, ant_j, nants
+
+    def test_zero_on_unflagged_cell_raises(self):
+        # bad data stored as 0 without flags must fail loudly: log-amplitude
+        # and unit-phasor initialization are both undefined at zero
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
+        vis_ratio[3, 2] = 0.0
+        with pytest.raises(ValueError, match='zero or non-finite'):
+            skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i,
+                                                 ant_j, nants)
 
     def test_known_gain_recovery(self):
         true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
@@ -492,6 +511,17 @@ class TestRefineGains:
 
 
 class TestSkyCalibrate:
+    def test_unrefinable_antennas_raise(self):
+        # all antennas on one SNAP -> every baseline is intra-SNAP -> nothing
+        # to refine; must error rather than silently drop antennas at the
+        # final merge (whole antennas are only ever excluded by omission)
+        sim = build_sim(nants=5, nfreqs=32, ntimes=1, seed=11)
+        with pytest.raises(ValueError, match='refinement solve'):
+            skycal.sky_calibrate(
+                sim['data'], sim['model'], freqs=sim['freqs'],
+                dt=sim['dt'], df=sim['df'],
+                ant_to_SNAP_dict={ant: 'A' for ant in sim['ants']})
+
     def test_end_to_end_recovery(self):
         dlys_true = {ant: d for ant, d in enumerate(
             [0.0, 20e-9, -30e-9, 45e-9, -35e-9, 10e-9, -10e-9])}

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 the HERA Project
+# Licensed under the MIT License
+
+import pytest
+import numpy as np
+from scipy.optimize import least_squares
+import linsolve
+
+from .. import skycal
+from ..datacontainer import DataContainer
+from ..apply_cal import calibrate_in_place
+from .. import utils
+
+
+def build_sim(nants=7, nfreqs=128, ntimes=2, pol='ee', seed=21, dlys=None,
+              offsets=None, amp_ripple=0.1, phs_ripple=0.05, noise=0.0,
+              snap_suppression=None, ant_to_SNAP_dict=None, dt=10.0, df=122e3):
+    '''Build a synthetic dataset with known gains: V_ij = g_i g_j^* M_ij and
+    autos_i = |g_i|^2 * A_sky. Returns a dict of everything needed for tests.
+    If snap_suppression is given (dict mapping SNAP ID to loss fraction p),
+    inter-SNAP cross visibilities are multiplied by (1 - p_i)(1 - p_j) while
+    autos and intra-SNAP baselines are left untouched (mimicking correlator
+    decoherence).'''
+    rng = np.random.default_rng(seed)
+    freqs = 100e6 + np.arange(nfreqs) * df
+    ants = list(range(nants))
+    if dlys is None:
+        dlys = {ant: 0.0 for ant in ants}
+    if offsets is None:
+        offsets = {ant: 0.0 for ant in ants}
+
+    # smooth true gains: few-mode ripples on top of delay/offset phases
+    def smooth_ripple(scale):
+        modes = rng.normal(size=3) * scale
+        x = np.linspace(0, 1, nfreqs)
+        return sum(m * np.cos((k + 1) * np.pi * x + rng.uniform(0, np.pi))
+                   for k, m in enumerate(modes))
+
+    true_gains = {}
+    for ant in ants:
+        amp = 1.0 + smooth_ripple(amp_ripple)
+        phs = (2 * np.pi * freqs * dlys[ant] + offsets[ant]
+               + smooth_ripple(phs_ripple))
+        g = (amp * np.exp(1j * phs))[None, :] * np.ones((ntimes, 1))
+        true_gains[(ant, utils.split_pol(pol)[0])] = g
+
+    # random smooth-ish model visibilities and a common sky auto spectrum
+    sky_auto = 200.0 * (1.0 + 0.3 * np.cos(np.linspace(0, 3, nfreqs)))
+    data, model = {}, {}
+    for i in ants:
+        gi = true_gains[(i, utils.split_pol(pol)[0])]
+        data[(i, i, pol)] = (np.abs(gi)**2 * sky_auto[None, :]
+                             * np.ones((ntimes, 1))).astype(complex)
+    for i in ants:
+        gi = true_gains[(i, utils.split_pol(pol)[0])]
+        for j in ants:
+            if j <= i:
+                continue
+            gj = true_gains[(j, utils.split_pol(pol)[0])]
+            amp = 10.0 * (0.5 + rng.uniform(size=nfreqs))
+            phs = rng.uniform(0, 2 * np.pi) + np.linspace(
+                0, rng.uniform(-3, 3), nfreqs)
+            mvis = (amp * np.exp(1j * phs))[None, :] * np.ones((ntimes, 1))
+            model[(i, j, pol)] = mvis
+            vis = gi * np.conj(gj) * mvis
+            if snap_suppression is not None:
+                si, sj = ant_to_SNAP_dict[i], ant_to_SNAP_dict[j]
+                if si != sj:
+                    pi_, pj_ = snap_suppression.get(si, 0), \
+                        snap_suppression.get(sj, 0)
+                    vis = vis * (1 - pi_) * (1 - pj_)
+            if noise > 0:
+                sigma = np.sqrt(np.abs(data[(i, i, pol)] * data[(j, j, pol)])
+                                / dt / df)
+                vis = vis + noise * sigma * (rng.normal(size=vis.shape)
+                                             + 1j * rng.normal(size=vis.shape)
+                                             ) / np.sqrt(2)
+            data[(i, j, pol)] = vis
+    return {'data': DataContainer(data), 'model': DataContainer(model),
+            'true_gains': true_gains, 'freqs': freqs, 'ants': ants,
+            'pol': pol, 'dt': dt, 'df': df, 'ntimes': ntimes}
+
+
+class TestSolvePerAntennaWeightedLeastSquares:
+    def setup_method(self):
+        self.rng = np.random.default_rng(21)
+
+    def test_recovery_and_gauge(self):
+        nants = 6
+        x = self.rng.normal(size=nants)
+        x -= x.mean()
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vals = x[ant_i] - x[ant_j]
+        wgts = self.rng.uniform(0.5, 2.0, size=len(bls))
+        sol = skycal._solve_per_antenna_weighted_least_squares(vals, wgts, ant_i, ant_j, nants)
+        np.testing.assert_allclose(sol, x, atol=1e-8)
+        assert np.abs(np.mean(sol)) < 1e-10
+
+    def test_unsolvable_antenna_is_nan(self):
+        # antenna 3 appears in no baselines
+        bls = [(0, 1), (0, 2), (1, 2)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vals = np.array([1.0, 2.0, 1.0])
+        wgts = np.ones(3)
+        sol = skycal._solve_per_antenna_weighted_least_squares(vals, wgts, ant_i, ant_j, 4)
+        assert np.isnan(sol[3])
+        assert np.all(np.isfinite(sol[:3]))
+
+
+class TestBuildDataModelRatio:
+    def setup_method(self):
+        self.sim = build_sim(nants=5, nfreqs=32, ntimes=2, seed=1)
+
+    def test_perfect_data_gives_unity_ratio(self):
+        # unity gains: data equals model on crosses
+        sim = build_sim(nants=5, nfreqs=32, ntimes=2, seed=2, amp_ripple=0,
+                        phs_ripple=0)
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        for bl in ratio:
+            np.testing.assert_allclose(ratio[bl], 1.0, atol=1e-10)
+            sigma2 = np.abs(sim['data'][(bl[0], bl[0], bl[2])]
+                            * sim['data'][(bl[1], bl[1], bl[2])]
+                            ) / sim['dt'] / sim['df']
+            np.testing.assert_allclose(
+                wgts[bl], np.abs(sim['model'][bl])**2 / sigma2, rtol=1e-10)
+
+    def test_flag_propagation(self):
+        sim = self.sim
+        pol = sim['pol']
+        bl = (0, 1, pol)
+        data_flags = DataContainer({k: np.zeros_like(sim['data'][k], dtype=bool)
+                                    for k in sim['data'] if k[0] != k[1]})
+        data_flags[bl][0, 5] = True
+        antpol = utils.split_pol(pol)[0]
+        ant_flags = {(2, antpol): np.zeros((sim['ntimes'], 32), dtype=bool)}
+        ant_flags[(2, antpol)][1, 7] = True
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], data_flags=data_flags,
+            ant_flags=ant_flags, dt=sim['dt'], df=sim['df'])
+        assert np.isnan(ratio[bl][0, 5])
+        assert wgts[bl][0, 5] == 0
+        for other in ratio:
+            if 2 in other[:2]:
+                assert np.isnan(ratio[other][1, 7])
+                assert wgts[other][1, 7] == 0
+
+
+class TestModelBasedFirstcal:
+    def test_signed_delay_and_offset_recovery(self):
+        # includes a delay that wraps many times across the band
+        nants = 6
+        dlys_true = {0: 0.0, 1: 30e-9, 2: -55e-9, 3: 500e-9, 4: -100e-9,
+                     5: 10e-9}
+        mean_dly = np.mean(list(dlys_true.values()))
+        dlys_true = {ant: d - mean_dly for ant, d in dlys_true.items()}
+        offsets_true = {0: 0.1, 1: -0.4, 2: 0.3, 3: 0.0, 4: -0.2, 5: 0.2}
+        mean_off = np.mean(list(offsets_true.values()))
+        offsets_true = {ant: o - mean_off for ant, o in offsets_true.items()}
+        sim = build_sim(nants=nants, nfreqs=256, ntimes=2, seed=3,
+                        dlys=dlys_true, offsets=offsets_true,
+                        amp_ripple=0, phs_ripple=0)
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        dlys, offsets = skycal.model_based_firstcal(ratio, wgts, sim['freqs'])
+        antpol = utils.split_pol(sim['pol'])[0]
+        for ant in sim['ants']:
+            # per-integration solves: (Ntimes, 1) arrays
+            assert dlys[(ant, antpol)].shape == (sim['ntimes'], 1)
+            # ~ns-level accuracy: Quinn interpolation is slightly biased by
+            # the frequency structure of the weights, but this is already
+            # better than a pad-8 FFT grid and far tighter than needed (the
+            # per-channel refinement solves phases exactly and its phase-sync
+            # initialization is wrap-immune). The signed comparison locks the
+            # delay sign convention.
+            assert np.max(np.abs(dlys[(ant, antpol)]
+                                 - dlys_true[ant])) < 2e-9
+            # delays and offsets covary through the absolute-frequency lever
+            # arm (a delay error dtau shifts the fitted offset by ~2 pi f0
+            # dtau), so only the total phase model over the band is
+            # meaningful — and it's what firstcal_gains actually uses
+            phase_err = (2 * np.pi * sim['freqs']
+                         * (dlys[(ant, antpol)] - dlys_true[ant])
+                         + offsets[(ant, antpol)] - offsets_true[ant])
+            # bound: far inside wrap-safety (pi), small enough that the
+            # per-channel refinement takes over from an excellent start
+            assert np.max(np.abs(np.angle(np.exp(1j * phase_err)))) < 0.3
+
+    def test_firstcal_gains_expression(self):
+        freqs = 100e6 + np.arange(16) * 1e5
+        dlys = {(0, 'Jee'): np.full((3, 1), 25e-9)}
+        offsets = {(0, 'Jee'): np.full((3, 1), 0.3)}
+        gains = skycal.firstcal_gains(dlys, offsets, freqs)
+        expected = np.exp(2j * np.pi * 25e-9 * freqs + 1j * 0.3)
+        assert gains[(0, 'Jee')].shape == (3, 16)
+        np.testing.assert_allclose(gains[(0, 'Jee')][2], expected, rtol=1e-12)
+
+
+class TestCalibrateAbsAmpFromAutos:
+    def test_amplitude_recovery(self):
+        sim = build_sim(nants=6, nfreqs=32, ntimes=2, seed=4, amp_ripple=0.2,
+                        phs_ripple=0)
+        gains = skycal.calibrate_abs_amp_from_autos(sim['data'])
+        antpol = utils.split_pol(sim['pol'])[0]
+        # recovered amps should equal true amps up to a per-channel rescaling
+        # (the median reference) that is COMMON to all antennas
+        ratios = np.asarray([np.abs(gains[(ant, antpol)])
+                             / np.abs(sim['true_gains'][(ant, antpol)])
+                             for ant in sim['ants']])
+        np.testing.assert_allclose(
+            ratios, np.broadcast_to(ratios[0:1], ratios.shape), rtol=1e-10)
+
+    def test_flagged_cells_excluded_from_reference(self):
+        sim = build_sim(nants=6, nfreqs=32, ntimes=2, seed=5)
+        pol = sim['pol']
+        auto_flags = {(0, 0, pol): np.zeros((sim['ntimes'], 32), dtype=bool)}
+        auto_flags[(0, 0, pol)][0, 3] = True
+        # with the cell flagged, corrupting it must not change anyone's gains
+        gains_before = skycal.calibrate_abs_amp_from_autos(
+            sim['data'], auto_flags=auto_flags)
+        sim['data'][(0, 0, pol)][0, 3] *= 100
+        gains_after = skycal.calibrate_abs_amp_from_autos(
+            sim['data'], auto_flags=auto_flags)
+        antpol = utils.split_pol(pol)[0]
+        for ant in sim['ants'][1:]:
+            np.testing.assert_allclose(gains_after[(ant, antpol)],
+                                       gains_before[(ant, antpol)], rtol=1e-8)
+
+
+class TestRefineGainsCore:
+    def setup_method(self):
+        self.rng = np.random.default_rng(21)
+
+    def _setup_arrays(self, nants=5, nfreqs=8, phase_scale=0.3, amp_scale=0.2,
+                      noise=0.0):
+        true_h = ((1.0 + amp_scale * self.rng.uniform(-1, 1, (nants, nfreqs)))
+                  * np.exp(1j * phase_scale
+                           * self.rng.uniform(-1, 1, (nants, nfreqs))))
+        # gauge the truth: mean phase 0 per channel
+        true_h *= np.exp(-1j * np.angle(true_h /
+                                        np.abs(true_h)).mean(axis=0))[None, :]
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vis_ratio = true_h[ant_i] * np.conj(true_h[ant_j])
+        if noise > 0:
+            vis_ratio = vis_ratio + noise * (
+                self.rng.normal(size=vis_ratio.shape)
+                + 1j * self.rng.normal(size=vis_ratio.shape)) / np.sqrt(2)
+        wgts = self.rng.uniform(0.5, 2.0, size=vis_ratio.shape)
+        return true_h, vis_ratio, wgts, ant_i, ant_j, nants
+
+    def test_known_gain_recovery(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+        np.testing.assert_allclose(gains, true_h, atol=1e-7)
+        assert meta['conv_crit'] < 1e-7
+
+    def test_wrap_immunity(self):
+        # phases uniform on (-pi, pi]: a linearized phase solve would fail
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            phase_scale=np.pi, amp_scale=0.1)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+        # compare baseline-level products (immune to any residual gauge)
+        np.testing.assert_allclose(gains[ant_i] * np.conj(gains[ant_j]),
+                                   vis_ratio, atol=1e-7)
+
+    def test_brute_force_cross_check(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            nants=5, nfreqs=3, noise=0.05)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+
+        # independent solve: scipy least_squares per channel with ant 0's
+        # phase pinned, then re-gauged to mean phase = 0
+        for chan in range(3):
+            z, w = vis_ratio[:, chan], wgts[:, chan]
+
+            def resid(x):
+                amps = x[:nants]
+                phases = np.concatenate([[0], x[nants:]])
+                h = amps * np.exp(1j * phases)
+                r = np.sqrt(w) * (z - h[ant_i] * np.conj(h[ant_j]))
+                return np.concatenate([r.real, r.imag])
+
+            x0 = np.concatenate([np.ones(nants), np.zeros(nants - 1)])
+            sol = least_squares(resid, x0, xtol=1e-15, ftol=1e-15, gtol=1e-15)
+            h_bf = sol.x[:nants] * np.exp(
+                1j * np.concatenate([[0], sol.x[nants:]]))
+            h_bf = h_bf * np.exp(-1j * np.angle(h_bf / np.abs(h_bf)).mean())
+            np.testing.assert_allclose(gains[:, chan], h_bf, atol=1e-6)
+
+    def test_uniform_flag_structure_accepted(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
+        # the two supported flag types: a whole antenna out (all its
+        # baselines) and a channel flagged for ALL baselines
+        wgts[(ant_i == 2) | (ant_j == 2), :] = 0
+        wgts[:, 4] = 0
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+        assert np.all(np.isnan(gains[2]))
+        assert np.all(np.isnan(gains[:, 4]))
+        solved_ants = np.ones(nants, dtype=bool)
+        solved_ants[2] = False
+        good = np.ones(gains.shape[1], dtype=bool)
+        good[4] = False
+        # remaining antennas/channels still recovered (gauge over the
+        # surviving antennas differs from the truth's, so compare
+        # baseline-level products, which are gauge-invariant)
+        for i in np.where(solved_ants)[0]:
+            for j in np.where(solved_ants)[0]:
+                np.testing.assert_allclose(
+                    (gains[i] * np.conj(gains[j]))[good],
+                    (true_h[i] * np.conj(true_h[j]))[good], atol=1e-6)
+
+    def test_nonuniform_flags_raise(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
+        # a channel flagged for only SOME baselines is not a supported
+        # pattern: it must be fixed upstream, not silently repaired
+        wgts[(ant_i == 2) | (ant_j == 2), 4] = 0
+        with pytest.raises(ValueError):
+            skycal._refine_gains_single_pol_time(
+                vis_ratio, wgts, ant_i, ant_j, nants)
+
+    def test_whole_baseline_flag_raises(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays()
+        # a fully-flagged baseline between two otherwise-unflagged antennas
+        # is also unsupported: baselines are excluded by omission, and only
+        # whole ANTENNAS may be flagged
+        wgts[0, :] = 0
+        with pytest.raises(ValueError):
+            skycal._refine_gains_single_pol_time(
+                vis_ratio, wgts, ant_i, ant_j, nants)
+
+    def test_convergence_failure_raises(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            noise=0.3)
+        with pytest.raises(RuntimeError):
+            skycal._refine_gains_single_pol_time(
+                vis_ratio, wgts, ant_i, ant_j, nants, refine_maxiter=0)
+
+    def test_mean_phase_gauge(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            noise=0.02)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants)
+        # the solver zeroes the arithmetic mean of the accumulated phase
+        # updates (same convention as redcal.remove_degen_gains)
+        mean_phase = np.angle(gains).mean(axis=0)
+        np.testing.assert_allclose(mean_phase, 0, atol=1e-7)
+
+    def test_amp_updates_match_linsolve(self):
+        # the scatter-built batched normal matrices are a pure speed
+        # optimization (linsolve on the same equations is ~20x slower at
+        # production scale); this cross-check keeps linsolve as the
+        # independent referee for the custom machinery
+        nsel, nchan = 8, 4
+        bls = [(i, j) for i in range(nsel) for j in range(i + 1, nsel)]
+        nbl = len(bls)
+        wgts2d = self.rng.uniform(0.5, 2.0, (nbl, nchan))
+        resids2d = self.rng.normal(size=(nbl, nchan))
+        bl_inds, chan_inds = np.divmod(np.arange(nbl * nchan), nchan)
+        ei = np.array([bls[k][0] for k in bl_inds])
+        ej = np.array([bls[k][1] for k in bl_inds])
+        w = wgts2d[bl_inds, chan_inds]
+        r = resids2d[bl_inds, chan_inds]
+        amp_mats, _ = skycal._build_normal_matrices(
+            nchan, nsel, chan_inds, ei, ej, w)
+        ours = skycal._solve_logamp_updates(
+            amp_mats, chan_inds, ei, ej, w, r, nchan, nsel)
+        ls_data = {f'e_{i} + e_{j}': resids2d[k]
+                   for k, (i, j) in enumerate(bls)}
+        ls_wgts = {f'e_{i} + e_{j}': wgts2d[k]
+                   for k, (i, j) in enumerate(bls)}
+        sol = linsolve.LinearSolver(ls_data, wgts=ls_wgts).solve()
+        theirs = np.array([sol[f'e_{i}'] for i in range(nsel)]).T
+        np.testing.assert_allclose(ours, theirs, atol=1e-8)
+
+    def test_low_snr_amplitude_unbiased(self):
+        # the converged solution is the stationary point of the complex
+        # least-squares objective, NOT the log-space optimum, so it should
+        # not show the low-SNR amplitude bias of logcal (Liu et al. 2010);
+        # at this noise level a log-space estimator's bias benchmark is
+        # ~sigma^2/2 = 0.045, which the bound below excludes
+        nants, nfreqs, sigma = 6, 2, 0.3
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        wgts = np.full((len(bls), nfreqs), 1 / sigma**2)
+        biases = []
+        for trial in range(200):
+            true_g = ((1.0 + 0.1 * self.rng.uniform(-1, 1, (nants, nfreqs)))
+                      * np.exp(0.3j * self.rng.uniform(-1, 1,
+                                                       (nants, nfreqs))))
+            vis_ratio = (true_g[ant_i] * np.conj(true_g[ant_j])
+                         + sigma * (self.rng.normal(size=wgts.shape)
+                                    + 1j * self.rng.normal(size=wgts.shape))
+                         / np.sqrt(2))
+            gains, _ = skycal._refine_gains_single_pol_time(
+                vis_ratio, wgts, ant_i, ant_j, nants, refine_maxiter=500)
+            biases.append(np.mean(np.abs(gains) - np.abs(true_g)))
+        assert np.abs(np.mean(biases)) < 0.015
+
+    def test_hess_cadence_invariance(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._setup_arrays(
+            noise=0.05)
+        gains1, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=1)
+        gains3, _ = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, hess_cadence=3)
+        np.testing.assert_allclose(gains1, gains3, atol=1e-7)
+
+
+class TestRefineGains:
+    def setup_method(self):
+        self.ant_to_SNAP_dict = {0: 'A', 1: 'A', 2: 'A', 3: 'B', 4: 'B',
+                                 5: 'B', 6: 'C'}
+
+    def test_missing_snap_raises(self):
+        sim = build_sim(nants=7, nfreqs=16, ntimes=1, seed=6)
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        antpol = utils.split_pol(sim['pol'])[0]
+        g0 = {(ant, antpol): np.ones((1, 16), dtype=complex)
+              for ant in sim['ants']}
+        incomplete = {ant: 'A' for ant in sim['ants'][:-1]}
+        with pytest.raises(ValueError):
+            skycal.refine_gains(ratio, wgts, g0,
+                                ant_to_SNAP_dict=incomplete)
+
+    def test_intra_snap_corruption_invariance(self):
+        sim = build_sim(nants=7, nfreqs=16, ntimes=1, seed=7)
+        antpol = utils.split_pol(sim['pol'])[0]
+        g0 = {(ant, antpol): np.ones((1, 16), dtype=complex)
+              for ant in sim['ants']}
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        clean, _ = skycal.refine_gains(
+            ratio, wgts, g0, ant_to_SNAP_dict=self.ant_to_SNAP_dict)
+        # corrupt every intra-SNAP visibility: solution must not change
+        for bl in sim['data']:
+            if (bl[0] != bl[1] and self.ant_to_SNAP_dict[bl[0]]
+                    == self.ant_to_SNAP_dict[bl[1]]):
+                sim['data'][bl] *= 17.0
+        ratio2, wgts2 = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        corrupted, _ = skycal.refine_gains(
+            ratio2, wgts2, g0, ant_to_SNAP_dict=self.ant_to_SNAP_dict)
+        for key in clean:
+            np.testing.assert_allclose(corrupted[key], clean[key], atol=1e-9)
+
+    def test_amplitude_exemption_property(self):
+        # the physics headline: per-SNAP suppression applied to inter-SNAP
+        # crosses only (autos untouched) must land entirely in the refined
+        # gains, not in the auto-derived amplitudes
+        suppression = {'A': 0.05, 'B': 0.0, 'C': 0.02}
+        sim = build_sim(nants=7, nfreqs=16, ntimes=1, seed=8, amp_ripple=0,
+                        phs_ripple=0, snap_suppression=suppression,
+                        ant_to_SNAP_dict=self.ant_to_SNAP_dict)
+        antpol = utils.split_pol(sim['pol'])[0]
+        amp_gains = skycal.calibrate_abs_amp_from_autos(sim['data'])
+        for ant in sim['ants']:
+            np.testing.assert_allclose(np.abs(amp_gains[(ant, antpol)]), 1.0,
+                                       atol=1e-10)
+        ratio, wgts = skycal.build_data_model_ratio(
+            sim['data'], sim['model'], dt=sim['dt'], df=sim['df'])
+        refined, _ = skycal.refine_gains(
+            ratio, wgts, amp_gains, ant_to_SNAP_dict=self.ant_to_SNAP_dict)
+        for ant in sim['ants']:
+            expected = 1 - suppression[self.ant_to_SNAP_dict[ant]]
+            np.testing.assert_allclose(np.abs(refined[(ant, antpol)]),
+                                       expected, atol=1e-8)
+
+
+class TestSkyCalibrate:
+    def test_end_to_end_recovery(self):
+        dlys_true = {ant: d for ant, d in enumerate(
+            [0.0, 20e-9, -30e-9, 45e-9, -35e-9, 10e-9, -10e-9])}
+        sim = build_sim(nants=7, nfreqs=128, ntimes=2, seed=9, dlys=dlys_true,
+                        amp_ripple=0.1, phs_ripple=0.05, noise=0.1)
+        gains, meta = skycal.sky_calibrate(
+            sim['data'], sim['model'], freqs=sim['freqs'], dt=sim['dt'],
+            df=sim['df'])
+        # calibrating the data with the returned gains should recover the
+        # model on all cross baselines (baseline products are invariant to
+        # the per-channel mean-phase gauge)
+        data = DataContainer({bl: np.array(sim['data'][bl])
+                              for bl in sim['data'] if bl[0] != bl[1]})
+        calibrate_in_place(data, gains)
+        for bl in data:
+            np.testing.assert_allclose(data[bl], sim['model'][bl],
+                                       rtol=2e-2, atol=0)
+        # amplitudes are recovered absolutely; phases up to the gauge
+        antpol = utils.split_pol(sim['pol'])[0]
+        for ant in sim['ants']:
+            np.testing.assert_allclose(
+                np.abs(gains[(ant, antpol)]),
+                np.abs(sim['true_gains'][(ant, antpol)]), rtol=2e-2)
+
+    def test_meta_completeness(self):
+        sim = build_sim(nants=5, nfreqs=32, ntimes=1, seed=10)
+        gains, meta = skycal.sky_calibrate(
+            sim['data'], sim['model'], freqs=sim['freqs'], dt=sim['dt'],
+            df=sim['df'])
+        for key in ['data_model_ratio', 'wgts', 'dlys', 'offsets',
+                    'abs_amp_gains', 'g0', 'refined_gains', 'iter',
+                    'conv_crit']:
+            assert key in meta
+        assert (0, sim['pol']) in meta['iter']
+        assert meta['conv_crit'][(0, sim['pol'])] < 1e-6


### PR DESCRIPTION
This is my first PR in what will likely be a series dealing with the per-SNAP, per-X-engine decoherence, which effectively introduces a time dependent gain on inter-SNAP baselines (so not autos). This needs to be measured, and corrected, which I'll do in a future PR.

The calibration routine developed here is designed to calibrate against a redundantly averaged sky model (in practice, redavg, LST-stacked, and filtered data). It does so in four steps:

1) delay only firstcal
2) rough amplitude calibration using autocorrelations (this has a possible Trx bias)
3) log-linearized solver for amplitudes and phases separately, with a wrap-immunue phase measurement
4) properly linearized, full complex iterator using Gauss-Newton

Working with @claude code, I developed this independently of @tyler-a-cox's implementation of `StEFCal` in #892, which never got merged. This provided a nice test of the code, where I've done steps 1 and 2 to get initial gains on real data, then fed that into either StEFCal or steps 3 and 4 above. The results are below:

<img width="1311" height="1111" alt="image" src="https://github.com/user-attachments/assets/e26cda42-401f-4496-9052-2717c91f944f" />

The good news is that they get the same answer. With ~105 good antennas on this file, the Gauss-Newton approach is ~5x faster. The scaling of StEFCal should be better, so if we got up to 500+ antennas, it might start being advantageous.... not a regime we're going to be in with HERA.

So, I think this implementation can replace that one and we can close #892 , though @tyler-a-cox we should talk that through.
