### PR TITLE
Allow some fraction of channels to fail calibration convergence temporarily

### DIFF
--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -540,6 +540,24 @@ def _phase_sync_init(phasors, round_wgts, chan_pos, ei, ej, nchan_active,
     return phases
 
 
+def _solve_or_nan(mats, rhs):
+    '''np.linalg.solve over a stack of systems, with np.nan solutions for any singular
+    members instead of a raise. LAPACK judges near-singular matrices platform-dependently
+    (OpenBLAS raises where Accelerate returns garbage), so a diverging channel's collapsed
+    normal matrix must not take down the whole batch: its np.nan updates propagate into
+    non-finite gains that the refinement loop detects and drops next round.'''
+    try:
+        return np.linalg.solve(mats, rhs)
+    except np.linalg.LinAlgError:
+        solutions = np.full(rhs.shape, np.nan)
+        for k in range(mats.shape[0]):
+            try:
+                solutions[k] = np.linalg.solve(mats[k], rhs[k])
+            except np.linalg.LinAlgError:
+                pass
+        return solutions
+
+
 def _solve_logamp_updates(amp_mats, chan_pos, ei, ej, round_wgts, resids,
                           nchan_active, nsel):
     '''Solve the batched linear weighted least-squares systems for the
@@ -555,7 +573,7 @@ def _solve_logamp_updates(amp_mats, chan_pos, ei, ej, round_wgts, resids,
                + np.bincount(base + ej, weights=wgtd_resids,
                              minlength=nchan_active * nsel)
                ).reshape(nchan_active, nsel)
-    return np.linalg.solve(amp_mats, amp_rhs[:, :, None])[:, :, 0]
+    return _solve_or_nan(amp_mats, amp_rhs[:, :, None])[:, :, 0]
 
 
 def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
@@ -578,8 +596,8 @@ def _solve_phase_updates(phase_mats, chan_pos, ei, ej, round_wgts, resids,
                                minlength=nchan_active * nsel)
                  ).reshape(nchan_active, nsel)
     delta_phase = np.zeros((nchan_active, nsel))
-    delta_phase[:, 1:] = np.linalg.solve(phase_mats,
-                                         phase_rhs[:, 1:, None])[:, :, 0]
+    delta_phase[:, 1:] = _solve_or_nan(phase_mats,
+                                       phase_rhs[:, 1:, None])[:, :, 0]
     return delta_phase
 
 

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -703,37 +703,38 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         sync_tol: convergence threshold (radians) for the phase
             synchronization initialization (see _phase_sync_init)
         sync_maxiter: iteration cap for the phase synchronization
-        max_divergent_chan_frac: fraction of channels permitted to fail
-            (diverge or exhaust refine_maxiter) without raising. Failed
-            channels are dropped from the solve and returned as np.nan.
-            Default 0.0 requires every channel to converge. Intended for
-            coarse antenna-exclusion rounds, whose per-antenna chi^2 is a
-            median over channels and so tolerates a few gaps -- and whose
-            excluded antennas are usually what made those channels fail.
+        max_divergent_chan_frac: fraction of channels allowed to fail
+            (diverge or exhaust refine_maxiter) and come back as np.nan
+            instead of raising. Default 0.0 requires all to converge; a
+            small allowance lets coarse antenna-exclusion rounds, which
+            take a median over channels, proceed to remove whatever
+            antenna made those channels fail.
         verbose: print statements if True
 
     Returns:
         gains: complex ndarray (nants, Nfreqs); np.nan where unsolved
         meta: dict of per-channel (Nfreqs,) arrays, following redcal's
-            solve_iteratively convention: 'iter' (int rounds each channel
-            used before its early exit; 0 where flagged) and 'conv_crit'
-            (max relative chi^2 gradient over antennas in each channel;
-            np.nan where flagged), plus 'divergent_chans', an int array of
-            channel indices that failed and were returned as np.nan
+            solve_iteratively convention: 'iter' (rounds each channel
+            used before its early exit; 0 where flagged, -1 where it
+            failed) and 'conv_crit' (max relative chi^2 gradient over
+            antennas in each channel; np.nan where flagged or failed),
+            plus 'divergent_chans', the indices of the failed channels
 
     Raises:
-        ValueError: if the flagging pattern is not uniform (see
+        ValueError: if max_divergent_chan_frac is not between 0 and 1, if
+            the flagging pattern is not uniform (see
             _shared_channel_flags), or if any unflagged cell has zero or
             non-finite data/model ratio (flags or zero weights must cover
             all bad data)
-        RuntimeError: if more channels fail -- diverging to non-finite
-            gains or exhausting refine_maxiter -- than
-            max_divergent_chan_frac allows. Do not proceed with unconverged
-            gains: partially converged channels retain memory of the
-            initialization and can imprint coherent per-antenna spectral
-            structure, so failed channels are always returned as np.nan,
-            never as partial solutions.
+        RuntimeError: if more channels fail than
+            max_divergent_chan_frac allows. Failed channels always come
+            back as np.nan, never as partial solutions: partially
+            converged channels retain memory of the initialization and
+            can imprint coherent per-antenna spectral structure.
     '''
+    if not 0.0 <= max_divergent_chan_frac <= 1.0:
+        raise ValueError('max_divergent_chan_frac must be a fraction between '
+                         f'0 and 1, got {max_divergent_chan_frac}.')
     nfreqs = vis_ratio.shape[1]
 
     # validate the flags and reduce them to one shared waterfall: whole
@@ -794,9 +795,8 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         with np.errstate(invalid='ignore', divide='ignore'):
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
         if not np.isfinite(resid_ratio).all():
-            # inputs were validated above, so this can only be divergence.
-            # Drop the offending channels and carry on if allowed; they are
-            # returned as np.nan, so nothing partial escapes.
+            # inputs were validated above, so this can only be divergence;
+            # drop the offending channels and carry on if allowed
             newly_failed = active_idx[np.unique(chan_pos[~np.isfinite(resid_ratio)])]
             failed_chans[newly_failed] = True
             active_chans[newly_failed] = False
@@ -844,9 +844,8 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         # redcal.remove_degen_gains), then apply both updates
         # multiplicatively
         delta_phase -= delta_phase.mean(axis=1, keepdims=True)
-        # a diverging channel overflows here before its non-finite residual
-        # is detected at the top of the next round, which is where it is
-        # reported; the overflow itself is expected and not worth warning about
+        # a diverging channel overflows here before the next round detects
+        # and reports its non-finite residual, so the overflow is expected
         with np.errstate(over='ignore', invalid='ignore'):
             gains[:, active_idx] = gains[:, active_idx] \
                 * np.exp(delta_logamp.T + 1j * delta_phase.T)
@@ -860,14 +859,12 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             active_chans[dropped] = False
             chan_iters[good_chan_idx[dropped]] = niter + 1
         niter += 1
-    # channels still active after the last round exhausted refine_maxiter;
-    # they fail on the same terms as the divergent ones
+    # channels still active exhausted refine_maxiter: they fail too
     unconverged = active_chans.copy()
     failed_chans |= unconverged
 
-    # embed the solution back into the full (antenna, channel) grid, blanking
-    # failed channels first so that no partial solution escapes and nothing
-    # downstream (including the convergence criterion) sees diverged values
+    # embed into the full (antenna, channel) grid, blanking failed channels
+    # first so nothing downstream ever sees a partial solution
     gains[:, failed_chans] = np.nan
     full_gains = np.full((nants, nfreqs), np.nan, dtype=complex)
     full_gains[np.ix_(sel_ants, good_chan_idx)] = gains
@@ -875,6 +872,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
     conv_crit = _relative_chi2_gradient(vis_ratio, ratio_wgts, full_gains,
                                         ant_i_idx, ant_j_idx)
     conv_crit[good_chan_idx[failed_chans]] = np.nan
+    chan_iters[good_chan_idx[failed_chans]] = -1   # 0 is reserved for flagged
     if failed_chans.sum() > max_failed:
         worst = (np.nanmax(conv_crit) if np.any(np.isfinite(conv_crit))
                  else np.nan)
@@ -918,8 +916,8 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
     Returns:
         refined_gains: dict mapping (ant, antpol) to complex (Ntimes, Nfreqs)
             gain waterfalls; np.nan where unsolved
-        meta: dict with 'iter', 'conv_crit', and 'divergent_chans', each a
-            dict keyed by (time index, pol) (see
+        meta: dict with 'iter', 'conv_crit', and 'divergent_chans', each
+            keyed by (time index, pol) (see
             _refine_gains_single_pol_time)
 
     Raises:

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -794,16 +794,28 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         gi, gj = gains[ei, echan], gains[ej, echan]
         with np.errstate(invalid='ignore', divide='ignore'):
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
-        if not np.isfinite(resid_ratio).all():
-            # inputs were validated above, so this can only be divergence;
-            # drop the offending channels and carry on if allowed
-            newly_failed = active_idx[np.unique(chan_pos[~np.isfinite(resid_ratio)])]
+        # weights for this round: the initialization uses the data weights, while
+        # Gauss-Newton rounds propagate them through the division by the current
+        # gains, which multiplies each weight by (|g_i| |g_j|)^2
+        with np.errstate(over='ignore', invalid='ignore'):
+            round_wgts = (wgts_here if niter == 0
+                          else wgts_here * (np.abs(gi) * np.abs(gj))**2)
+
+        # inputs were validated above, so this can only be divergence: either
+        # non-finite residuals, or weights that overflowed or underflowed as the
+        # gains ran away (which would leave the normal matrices unsolvable, and
+        # LAPACK reports that differently on different platforms). Drop the
+        # offending channels and carry on if allowed.
+        bad = (~np.isfinite(resid_ratio) | ~np.isfinite(round_wgts)
+               | (round_wgts <= 0))
+        if bad.any():
+            newly_failed = active_idx[np.unique(chan_pos[bad])]
             failed_chans[newly_failed] = True
             active_chans[newly_failed] = False
             if failed_chans.sum() > max_failed:
                 raise RuntimeError(
-                    'Per-channel gain refinement diverged: non-finite gains '
-                    f'in round {niter} at {int(failed_chans.sum())} channels '
+                    'Per-channel gain refinement diverged: non-finite gains or '
+                    f'weights in round {niter} at {int(failed_chans.sum())} channels '
                     f'{good_chan_idx[failed_chans].tolist()}, more than '
                     f'max_divergent_chan_frac={max_divergent_chan_frac} of '
                     f'{nchans} unflagged channels allows.')
@@ -811,7 +823,6 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
         if niter == 0:
             # ---- initialization round ----
-            round_wgts = wgts_here
             amp_mats, phase_mats = _build_normal_matrices(
                 nactive, nsel, chan_pos, ei, ej, round_wgts)
             # log-amplitudes: log|resid_ratio| = eta_i + eta_j is exactly
@@ -824,9 +835,6 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
                 sync_maxiter=sync_maxiter)
         else:
             # ---- Gauss-Newton round ----
-            # propagating the data weights through the division by the
-            # current gains multiplies each weight by (|g_i| |g_j|)^2
-            round_wgts = wgts_here * (np.abs(gi) * np.abs(gj))**2
             amp_mats, phase_mats = _build_normal_matrices(
                 nactive, nsel, chan_pos, ei, ej, round_wgts)
             # linearize: Im(resid_ratio) ~ phi_i - phi_j and

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -632,7 +632,8 @@ def _relative_chi2_gradient(vis_ratio, ratio_wgts, full_gains, ant_i_idx,
 def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
                                   nants, refine_tol=1e-8,
                                   refine_maxiter=100, sync_tol=1e-3,
-                                  sync_maxiter=200, verbose=False):
+                                  sync_maxiter=200,
+                                  max_divergent_chan_frac=0.0, verbose=False):
     '''Solve for per-antenna, per-channel complex gains g such that
     vis_ratio ~ g_i * conj(g_j) on each baseline, for a single
     (time, polarization).
@@ -702,6 +703,13 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         sync_tol: convergence threshold (radians) for the phase
             synchronization initialization (see _phase_sync_init)
         sync_maxiter: iteration cap for the phase synchronization
+        max_divergent_chan_frac: fraction of channels permitted to fail
+            (diverge or exhaust refine_maxiter) without raising. Failed
+            channels are dropped from the solve and returned as np.nan.
+            Default 0.0 requires every channel to converge. Intended for
+            coarse antenna-exclusion rounds, whose per-antenna chi^2 is a
+            median over channels and so tolerates a few gaps -- and whose
+            excluded antennas are usually what made those channels fail.
         verbose: print statements if True
 
     Returns:
@@ -710,17 +718,21 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             solve_iteratively convention: 'iter' (int rounds each channel
             used before its early exit; 0 where flagged) and 'conv_crit'
             (max relative chi^2 gradient over antennas in each channel;
-            np.nan where flagged)
+            np.nan where flagged), plus 'divergent_chans', an int array of
+            channel indices that failed and were returned as np.nan
 
     Raises:
         ValueError: if the flagging pattern is not uniform (see
             _shared_channel_flags), or if any unflagged cell has zero or
             non-finite data/model ratio (flags or zero weights must cover
             all bad data)
-        RuntimeError: if any channel has not converged after refine_maxiter
-            rounds. Do not proceed with unconverged gains: partially
-            converged channels retain memory of the initialization and can
-            imprint coherent per-antenna spectral structure.
+        RuntimeError: if more channels fail -- diverging to non-finite
+            gains or exhausting refine_maxiter -- than
+            max_divergent_chan_frac allows. Do not proceed with unconverged
+            gains: partially converged channels retain memory of the
+            initialization and can imprint coherent per-antenna spectral
+            structure, so failed channels are always returned as np.nan,
+            never as partial solutions.
     '''
     nfreqs = vis_ratio.shape[1]
 
@@ -758,6 +770,8 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
 
     gains = np.ones((nsel, nchans), dtype=complex)
     active_chans = np.ones(nchans, dtype=bool)   # channels still iterating
+    failed_chans = np.zeros(nchans, dtype=bool)  # channels that gave up (nan)
+    max_failed = int(np.floor(max_divergent_chan_frac * nchans))
     chan_iters = np.zeros(nfreqs, dtype=int)     # rounds each channel used
     niter = 0
     while niter <= refine_maxiter and active_chans.any():
@@ -780,9 +794,20 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         with np.errstate(invalid='ignore', divide='ignore'):
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
         if not np.isfinite(resid_ratio).all():
-            # inputs were validated above, so this can only be divergence
-            raise RuntimeError('Per-channel gain refinement diverged: '
-                               f'non-finite gains in round {niter}.')
+            # inputs were validated above, so this can only be divergence.
+            # Drop the offending channels and carry on if allowed; they are
+            # returned as np.nan, so nothing partial escapes.
+            newly_failed = active_idx[np.unique(chan_pos[~np.isfinite(resid_ratio)])]
+            failed_chans[newly_failed] = True
+            active_chans[newly_failed] = False
+            if failed_chans.sum() > max_failed:
+                raise RuntimeError(
+                    'Per-channel gain refinement diverged: non-finite gains '
+                    f'in round {niter} at {int(failed_chans.sum())} channels '
+                    f'{good_chan_idx[failed_chans].tolist()}, more than '
+                    f'max_divergent_chan_frac={max_divergent_chan_frac} of '
+                    f'{nchans} unflagged channels allows.')
+            continue
 
         if niter == 0:
             # ---- initialization round ----
@@ -819,8 +844,12 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         # redcal.remove_degen_gains), then apply both updates
         # multiplicatively
         delta_phase -= delta_phase.mean(axis=1, keepdims=True)
-        gains[:, active_idx] = gains[:, active_idx] \
-            * np.exp(delta_logamp.T + 1j * delta_phase.T)
+        # a diverging channel overflows here before its non-finite residual
+        # is detected at the top of the next round, which is where it is
+        # reported; the overflow itself is expected and not worth warning about
+        with np.errstate(over='ignore', invalid='ignore'):
+            gains[:, active_idx] = gains[:, active_idx] \
+                * np.exp(delta_logamp.T + 1j * delta_phase.T)
 
         # channels whose largest update is below tolerance are converged
         # and drop out of subsequent rounds; record the rounds each used
@@ -831,27 +860,39 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             active_chans[dropped] = False
             chan_iters[good_chan_idx[dropped]] = niter + 1
         niter += 1
-    converged = not active_chans.any()
+    # channels still active after the last round exhausted refine_maxiter;
+    # they fail on the same terms as the divergent ones
+    unconverged = active_chans.copy()
+    failed_chans |= unconverged
 
-    # embed the solution back into the full (antenna, channel) grid
+    # embed the solution back into the full (antenna, channel) grid, blanking
+    # failed channels first so that no partial solution escapes and nothing
+    # downstream (including the convergence criterion) sees diverged values
+    gains[:, failed_chans] = np.nan
     full_gains = np.full((nants, nfreqs), np.nan, dtype=complex)
     full_gains[np.ix_(sel_ants, good_chan_idx)] = gains
 
     conv_crit = _relative_chi2_gradient(vis_ratio, ratio_wgts, full_gains,
                                         ant_i_idx, ant_j_idx)
-    if not converged:
+    conv_crit[good_chan_idx[failed_chans]] = np.nan
+    if failed_chans.sum() > max_failed:
+        worst = (np.nanmax(conv_crit) if np.any(np.isfinite(conv_crit))
+                 else np.nan)
         raise RuntimeError(
             f'Per-channel gain refinement did not converge: '
-            f'{int(active_chans.sum())} channels remain above '
+            f'{int(unconverged.sum())} channels remain above '
             f'refine_tol={refine_tol} after {refine_maxiter} rounds '
-            f'(max relative chi^2 gradient {np.nanmax(conv_crit):.2e}). '
+            f'{good_chan_idx[unconverged].tolist()} '
+            f'(max relative chi^2 gradient over solved channels {worst:.2e}). '
             'Do not proceed with unconverged gains.')
-    return full_gains, {'iter': chan_iters, 'conv_crit': conv_crit}
+    return full_gains, {'iter': chan_iters, 'conv_crit': conv_crit,
+                        'divergent_chans': good_chan_idx[failed_chans]}
 
 
 def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                  refine_tol=1e-8, refine_maxiter=100,
-                 sync_tol=1e-3, sync_maxiter=200, verbose=False):
+                 sync_tol=1e-3, sync_maxiter=200,
+                 max_divergent_chan_frac=0.0, verbose=False):
     '''Solve for per-antenna, per-channel refined gains on cross baselines,
     given starting gains g0. The data/model ratio divided by g0_i g0_j^* should
     be ~1 up to per-antenna corrections beyond g0 — including any per-SNAP
@@ -870,22 +911,23 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
             baseline of data_model_ratio must be present, whether or not it
             ends up in the solve (raises ValueError otherwise); if None, all
             cross baselines participate.
-        refine_tol, refine_maxiter, sync_tol, sync_maxiter:
-            see _refine_gains_single_pol_time
+        refine_tol, refine_maxiter, sync_tol, sync_maxiter,
+            max_divergent_chan_frac: see _refine_gains_single_pol_time
         verbose: print statements if True
 
     Returns:
         refined_gains: dict mapping (ant, antpol) to complex (Ntimes, Nfreqs)
             gain waterfalls; np.nan where unsolved
-        meta: dict with 'iter' and 'conv_crit', each a dict keyed by
-            (time index, pol) of per-channel (Nfreqs,) arrays (see
+        meta: dict with 'iter', 'conv_crit', and 'divergent_chans', each a
+            dict keyed by (time index, pol) (see
             _refine_gains_single_pol_time)
 
     Raises:
         ValueError: if ant_to_SNAP_dict is given but missing antennas, if
             the flagging pattern is not uniform (see _shared_channel_flags),
             or if any unflagged cell has zero or non-finite data/model ratio
-        RuntimeError: if the solve fails to converge for any (time, pol)
+        RuntimeError: if any (time, pol) has more failed channels than
+            max_divergent_chan_frac allows
     '''
     bls = [bl for bl in data_model_ratio if bl[0] != bl[1]]
     all_antnums = sorted({antnum for bl in bls for antnum in bl[:2]})
@@ -898,7 +940,7 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                              'must be mapped to SNAPs if any are.')
 
     refined_gains = {}
-    meta = {'iter': {}, 'conv_crit': {}}
+    meta = {'iter': {}, 'conv_crit': {}, 'divergent_chans': {}}
     for pol in sorted({bl[2] for bl in bls}):
         antpol = utils.split_pol(pol)[0]
         bls_here = [bl for bl in bls if bl[2] == pol
@@ -935,7 +977,9 @@ def refine_gains(data_model_ratio, wgts, g0, ant_to_SNAP_dict=None,
                 vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx, nants,
                 refine_tol=refine_tol,
                 refine_maxiter=refine_maxiter, sync_tol=sync_tol,
-                sync_maxiter=sync_maxiter, verbose=verbose)
+                sync_maxiter=sync_maxiter,
+                max_divergent_chan_frac=max_divergent_chan_frac,
+                verbose=verbose)
             utils.echo(f't{tind} {pol}: {int(meta_here["iter"].max())} '
                        'rounds, max relative chi^2 gradient '
                        f'{np.nanmax(meta_here["conv_crit"]):.2e}',
@@ -956,7 +1000,8 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
                   ant_flags=None, auto_flags=None, ant_to_SNAP_dict=None,
                   freqs=None, bls=None, dt=None, df=None,
                   refine_tol=1e-8, refine_maxiter=100, sync_tol=1e-3,
-                  sync_maxiter=200, verbose=False):
+                  sync_maxiter=200, max_divergent_chan_frac=0.0,
+                  verbose=False):
     '''Run the full staged sky-model-based calibration: data/model ratio →
     firstcal delays and offsets → autocorrelation-based amplitudes → per-channel
     refinement on (inter-SNAP) cross baselines. Returns gains g = g0 * refined,
@@ -991,7 +1036,8 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
             waterfalls, g0 * refined_gains; np.nan where unsolved
         meta: dict of stage products and diagnostics: 'data_model_ratio',
             'wgts', 'dlys', 'offsets', 'abs_amp_gains', 'g0', 'refined_gains',
-            and the refinement's 'iter' and 'conv_crit' dicts keyed by
+            and the refinement's 'iter', 'conv_crit', and
+            'divergent_chans' dicts keyed by
             (time index, pol) of per-channel (Nfreqs,) arrays
     '''
     if freqs is None:
@@ -1022,7 +1068,8 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
         data_model_ratio, wgts, g0, ant_to_SNAP_dict=ant_to_SNAP_dict,
         refine_tol=refine_tol,
         refine_maxiter=refine_maxiter, sync_tol=sync_tol,
-        sync_maxiter=sync_maxiter, verbose=verbose)
+        sync_maxiter=sync_maxiter,
+        max_divergent_chan_frac=max_divergent_chan_frac, verbose=verbose)
 
     # every antenna with starting gains must come through refinement — a gap
     # would otherwise be silently dropped by the key intersection in

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -705,10 +705,10 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
         sync_maxiter: iteration cap for the phase synchronization
         max_divergent_chan_frac: fraction of channels allowed to fail
             (diverge or exhaust refine_maxiter) and come back as np.nan
-            instead of raising. Default 0.0 requires all to converge; a
-            small allowance lets coarse antenna-exclusion rounds, which
-            take a median over channels, proceed to remove whatever
-            antenna made those channels fail.
+            instead of raising an error. Default 0.0 requires all to
+            converge; a small allowance lets coarse antenna-exclusion
+            rounds, which take a median over channels, proceed to remove
+            whatever antenna made those channels fail.
         verbose: print statements if True
 
     Returns:
@@ -796,7 +796,7 @@ def _refine_gains_single_pol_time(vis_ratio, ratio_wgts, ant_i_idx, ant_j_idx,
             resid_ratio = entry_ratio[in_active] / (gi * np.conj(gj))
         # weights for this round: the initialization uses the data weights, while
         # Gauss-Newton rounds propagate them through the division by the current
-        # gains, which multiplies each weight by (|g_i| |g_j|)^2
+        # gains, which multiplies each inverse variance weight by (|g_i| |g_j|)^2
         with np.errstate(over='ignore', invalid='ignore'):
             round_wgts = (wgts_here if niter == 0
                           else wgts_here * (np.abs(gi) * np.abs(gj))**2)

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1176,6 +1176,29 @@ class TestDivergentChannelTolerance:
             wrecked, wgts, ant_i, ant_j, nants, max_divergent_chan_frac=0.5)
         assert len(meta['divergent_chans']) == 4
 
+    @pytest.mark.parametrize('frac', [-0.1, 1.5, np.nan, np.inf])
+    def test_invalid_frac_raises(self, frac):
+        '''Out-of-range values -- including a channel count mistaken for a
+        fraction -- fail legibly instead of deep inside the solver.'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        with pytest.raises(ValueError, match='fraction between'):
+            skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i, ant_j, nants,
+                                                 max_divergent_chan_frac=frac)
+
+    def test_failed_channels_marked_in_iter(self):
+        '''meta['iter'] distinguishes failed channels (-1) from flagged (0).'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        wgts[:, 7] = 0   # channel 7 flagged for every baseline
+        wrecked = vis_ratio.copy()
+        touches_0 = np.where(ant_i == 0)[0]
+        wrecked[touches_0[::2], 3] *= -1e6
+        gains, meta = skycal._refine_gains_single_pol_time(
+            wrecked, wgts, ant_i, ant_j, nants, max_divergent_chan_frac=0.25)
+        assert meta['iter'][7] == 0            # flagged
+        assert meta['iter'][3] == -1           # failed
+        assert np.all(meta['iter'][[0, 1, 2]] > 0)   # solved
+        np.testing.assert_array_equal(meta['divergent_chans'], [3])
+
     def test_default_is_unchanged_behavior(self):
         '''With the default, a clean solve is bit-identical and reports nothing.'''
         true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays(noise=0.01)

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1199,6 +1199,30 @@ class TestDivergentChannelTolerance:
         assert np.all(meta['iter'][[0, 1, 2]] > 0)   # solved
         np.testing.assert_array_equal(meta['divergent_chans'], [3])
 
+    def test_normal_matrices_stay_finite(self, monkeypatch):
+        '''However badly a channel diverges, the linear solver is never handed a
+        non-finite normal matrix. LAPACK reports those platform-dependently (as a
+        LinAlgError on Linux but not macOS), so the solver detects the collapse
+        itself rather than letting that escape.'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        wrecked = vis_ratio.copy()
+        touches_0 = np.where(ant_i == 0)[0]
+        for c in [3, 11]:
+            wrecked[touches_0[::2], c] *= -1e6
+
+        original = skycal._build_normal_matrices
+        all_finite = []
+
+        def checked(*args, **kwargs):
+            amp_mats, phase_mats = original(*args, **kwargs)
+            all_finite.append(bool(np.isfinite(amp_mats).all() and np.isfinite(phase_mats).all()))
+            return amp_mats, phase_mats
+
+        monkeypatch.setattr(skycal, '_build_normal_matrices', checked)
+        skycal._refine_gains_single_pol_time(wrecked, wgts, ant_i, ant_j, nants,
+                                             max_divergent_chan_frac=0.25)
+        assert len(all_finite) > 1 and all(all_finite)
+
     def test_default_is_unchanged_behavior(self):
         '''With the default, a clean solve is bit-identical and reports nothing.'''
         true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays(noise=0.01)

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1101,6 +1101,15 @@ class TestCoverageGaps:
 
 
 class TestDivergentChannelTolerance:
+    def test_solve_or_nan(self):
+        '''A singular member of a batched solve yields np.nan for that system only,
+        deterministically on every platform, rather than raising for the whole batch.'''
+        mats = np.array([np.eye(3), np.zeros((3, 3))])
+        rhs = np.ones((2, 3, 1))
+        solutions = skycal._solve_or_nan(mats, rhs)
+        np.testing.assert_array_equal(solutions[0], rhs[0])
+        assert np.all(np.isnan(solutions[1]))
+
     '''Tests for max_divergent_chan_frac: failed channels may be dropped and
     returned as nan instead of failing the whole solve, which lets coarse
     antenna-exclusion rounds (whose per-antenna chi^2 is a median over

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1098,3 +1098,99 @@ class TestCoverageGaps:
         # empty bands are a no-op
         skycal._fix_band_floors(vals, [[]])
         np.testing.assert_allclose(vals[3:6], [0.0, 0.15, 0.05])
+
+
+class TestDivergentChannelTolerance:
+    '''Tests for max_divergent_chan_frac: failed channels may be dropped and
+    returned as nan instead of failing the whole solve, which lets coarse
+    antenna-exclusion rounds (whose per-antenna chi^2 is a median over
+    channels) proceed and remove whatever made those channels fail.'''
+
+    def setup_method(self):
+        self.rng = np.random.default_rng(5)
+
+    def _arrays(self, nants=6, nfreqs=16, noise=0.0):
+        true_h = ((1.0 + 0.2 * self.rng.uniform(-1, 1, (nants, nfreqs)))
+                  * np.exp(1j * 0.3 * self.rng.uniform(-1, 1, (nants, nfreqs))))
+        true_h *= np.exp(-1j * np.angle(true_h / np.abs(true_h)).mean(axis=0))[None, :]
+        bls = [(i, j) for i in range(nants) for j in range(i + 1, nants)]
+        ant_i = np.array([bl[0] for bl in bls])
+        ant_j = np.array([bl[1] for bl in bls])
+        vis_ratio = true_h[ant_i] * np.conj(true_h[ant_j])
+        if noise > 0:
+            vis_ratio = vis_ratio + noise * (self.rng.normal(size=vis_ratio.shape)
+                                             + 1j * self.rng.normal(size=vis_ratio.shape)) / np.sqrt(2)
+        wgts = np.ones_like(vis_ratio, dtype=float)
+        return true_h, vis_ratio, wgts, ant_i, ant_j, nants
+
+    def test_maxiter_failures_tolerated_and_reported(self):
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        # refine_maxiter=0 fails every channel: intolerable by default...
+        with pytest.raises(RuntimeError, match='did not converge'):
+            skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i, ant_j, nants,
+                                                 refine_maxiter=0)
+        # ...but tolerated in full, and every failed channel comes back nan
+        gains, meta = skycal._refine_gains_single_pol_time(
+            vis_ratio, wgts, ant_i, ant_j, nants, refine_maxiter=0,
+            max_divergent_chan_frac=1.0)
+        assert np.all(np.isnan(gains))
+        np.testing.assert_array_equal(meta['divergent_chans'], np.arange(vis_ratio.shape[1]))
+
+    def test_surviving_channels_are_unaffected(self):
+        '''A few bad channels neither corrupt nor perturb the good ones.'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        clean, _ = skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i, ant_j, nants)
+
+        # wreck two channels by making one antenna's visibilities inconsistent
+        # with any per-antenna gain model (sign flips on a subset of its bls)
+        bad_chans = [3, 11]
+        wrecked = vis_ratio.copy()
+        touches_0 = np.where(ant_i == 0)[0]
+        for c in bad_chans:
+            wrecked[touches_0[::2], c] *= -1e6
+        with pytest.raises(RuntimeError):
+            skycal._refine_gains_single_pol_time(wrecked, wgts, ant_i, ant_j, nants)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            wrecked, wgts, ant_i, ant_j, nants, max_divergent_chan_frac=0.25)
+
+        failed = set(meta['divergent_chans'].tolist())
+        assert failed and failed.issubset(set(bad_chans))
+        good = [c for c in range(vis_ratio.shape[1]) if c not in failed]
+        assert np.all(np.isnan(gains[:, sorted(failed)]))
+        assert np.all(np.isfinite(gains[:, good]))
+        # the surviving channels are bit-identical to the all-clean solve
+        np.testing.assert_allclose(gains[:, good], clean[:, good], atol=1e-10)
+
+    def test_frac_bounds_the_damage(self):
+        '''Tolerance is a budget: exceeding it still raises, naming channels.'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays()
+        wrecked = vis_ratio.copy()
+        touches_0 = np.where(ant_i == 0)[0]
+        for c in [2, 5, 9, 13]:
+            wrecked[touches_0[::2], c] *= -1e6
+        # 1/16 of channels allowed, 4 fail
+        with pytest.raises(RuntimeError, match='diverged'):
+            skycal._refine_gains_single_pol_time(wrecked, wgts, ant_i, ant_j, nants,
+                                                 max_divergent_chan_frac=1 / 16)
+        gains, meta = skycal._refine_gains_single_pol_time(
+            wrecked, wgts, ant_i, ant_j, nants, max_divergent_chan_frac=0.5)
+        assert len(meta['divergent_chans']) == 4
+
+    def test_default_is_unchanged_behavior(self):
+        '''With the default, a clean solve is bit-identical and reports nothing.'''
+        true_h, vis_ratio, wgts, ant_i, ant_j, nants = self._arrays(noise=0.01)
+        g1, m1 = skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i, ant_j, nants)
+        g2, m2 = skycal._refine_gains_single_pol_time(vis_ratio, wgts, ant_i, ant_j, nants,
+                                                      max_divergent_chan_frac=0.5)
+        np.testing.assert_array_equal(g1, g2)
+        assert len(m1['divergent_chans']) == 0 and len(m2['divergent_chans']) == 0
+
+    def test_passes_through_sky_calibrate(self):
+        '''The kwarg reaches the solver from the top-level driver.'''
+        sim = build_sim(nants=7, nfreqs=32, seed=4)
+        gains, meta = skycal.sky_calibrate(
+            sim['data'], sim['model'], freqs=sim['freqs'], dt=sim['dt'], df=sim['df'],
+            max_divergent_chan_frac=0.1)
+        assert 'divergent_chans' in meta
+        for key, chans in meta['divergent_chans'].items():
+            assert len(chans) == 0  # clean sim: nothing should fail


### PR DESCRIPTION
Bad antennas can lead to non-convergence. We instead want to temporarily tolerate some level of non-convergence, find those bad antennas, and then re-run the calibration without them.