### PR TITLE
Graduate functions used in file_sky_calibration, namely `skycal.expand_sky_gains()` and `apply_cal.calibrate_and_red_avg()`

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -11,6 +11,8 @@ import warnings
 from . import io
 from . import utils
 from . import redcal
+from . import noise
+from . import datacontainer
 import pyuvdata.utils as uvutils
 from pyuvdata import UVData
 
@@ -225,6 +227,285 @@ def correct_SNAP_decoherence_in_place(data, decoherence, ant_to_SNAP_dict,
             continue
         data[bl] /= (coherence_factor[ant_to_SNAP_dict[i]]
                      * coherence_factor[ant_to_SNAP_dict[j]])
+
+
+def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, snap_decoherence=None,
+                          dt=None, df=None, compute_chisq=True, effective_nsamples=True):
+    '''Calibrate visibilities and redundantly average them with inverse-variance noise
+    weights, one group at a time (a full-size calibrated copy of the data is never
+    materialized). data must include co-polarized autocorrelations: they set each
+    cross-correlation's noise variance, sigma^2 = A_i * A_j / (dt * df), and their
+    per-polarization averages over unflagged antennas (binary weights, since
+    inverse-variance weighting would bias this noise-prediction statistic low) are
+    always included in the results. Cross-polarized autocorrelations are averaged the
+    same way if their groups are listed, though they are never used for noise weights.
+    What is averaged is governed entirely by reds.
+
+    By default the returned nsamples are EFFECTIVE nsamples, defined so that the
+    standard predictor sigma^2 = Abar_i * Abar_j / (dt * df * nsamples), evaluated with
+    the averaged autocorrelations returned here, is exact for every averaged product:
+    Abar_i * Abar_j * sum(w) / (dt * df) for cross groups (above the count, since the
+    average leans on quieter-than-typical pairs) and n^2 * Abar_i * Abar_j / (the sum
+    over antennas of their co-polarized auto products) for the autocorrelations.
+    Effective nsamples is spectrally smooth (auto structure common to all antennas
+    cancels), so it can be sensibly inpainted across flagging gaps.
+
+    If snap_decoherence is given, gains are first cleaned of the fitted suppression
+    staircase (SNAPDecoherence.correct_gains; autocorrelations and intra-SNAP baselines
+    are exempt) and inter-SNAP cross-correlations instead get the exact correction
+    (correct_SNAP_decoherence_in_place), with unmeasured (np.nan) blocks flagged. The
+    stored antenna -> SNAP mapping is used throughout and must cover every antenna in
+    gains.
+
+    Chi^2 (co-polarized only): each group's mean is the only fit parameter, so a
+    participating baseline's weighted scatter about it has expectation 1 - w / sum(w)
+    per pixel. Antennas in ex_ants never enter the averages, but those with usable data
+    still get chi^2 against the good-antenna group means, attributed only to themselves,
+    with expectation 1 + w / sum(w_good).
+
+    Arguments:
+        data: DataContainer of visibilities, including co-polarized autocorrelations
+            (ValueError otherwise). Baselines lacking gains or autos are omitted.
+        gains: dict mapping (ant, antpol) e.g. (0, 'Jee') to (Ntimes, Nfreqs) complex
+            gain waterfalls. Nonfinite gains are treated as flagged.
+        reds: list of lists of redundant groups (antpairpol tuples) to average, e.g.
+            from redcal.get_reds(antpos, pols=pols, include_autos=True). Their
+            polarizations govern what is averaged: include 'en'/'ne' groups to average
+            cross-polarized cross-correlations (calibrated by e.g. g_Jee * conj(g_Jnn)).
+            MUST include a co-polarized autocorrelation group for every polarization
+            used (ValueError otherwise). reds is passed to the returned
+            RedDataContainers verbatim, so every listed baseline -- including flagged
+            or excluded antennas' -- resolves to its group's average.
+        ant_flags: optional dict mapping (ant, antpol) to boolean flag waterfalls.
+        ex_ants: optional iterable of (ant, antpol) tuples excluded from all averages.
+        snap_decoherence: optional io.SNAPDecoherence, e.g. from
+            SNAPDecoherence.from_estimate. Default None: no decoherence handling.
+        dt: integration time in seconds. Default None infers from data's times.
+        df: channel width in Hz. Default None infers from data's freqs.
+        compute_chisq: if True (default), accumulate DoF-normalized chi^2.
+        effective_nsamples: if True (default), return effective nsamples; else counts.
+
+    Returns:
+        red_avg_data: RedDataContainer of weighted group averages, keyed by each group's
+            first contributing baseline and including the averaged autocorrelations
+        red_avg_flags: RedDataContainer, True where a group has no unflagged members
+        red_avg_nsamples: RedDataContainer of effective nsamples (or counts)
+        meta: {'chisq_per_ant': (ant, antpol) -> chi^2 waterfalls (np.nan where nothing
+            was accumulated), 'total_chisq': antpol -> per-polarization totals} if
+            compute_chisq, else {}
+    '''
+    ant_flags = ({} if ant_flags is None else ant_flags)
+    ex_ants = set([] if ex_ants is None else ex_ants)
+    if dt is None:
+        dt = noise.infer_dt(data.times_by_bl, next(iter(data))) * 24.0 * 3600.0
+    if df is None:
+        df = np.median(np.ediff1d(data.freqs))
+    if not any(utils.join_bl(ant, ant) in data for ant in gains):
+        raise ValueError('data must include co-polarized autocorrelations: they set the noise '
+                         'weights and the averaged autocorrelations that anchor effective nsamples.')
+    listed_auto_antpols = {utils.split_pol(red[0][2])[0] for red in reds if red[0][0] == red[0][1]
+                           and utils.split_pol(red[0][2])[0] == utils.split_pol(red[0][2])[1]}
+    missing_antpols = ({antpol for red in reds for antpol in utils.split_pol(red[0][2])}
+                       - listed_auto_antpols)
+    if len(missing_antpols) > 0:
+        raise ValueError('reds must include a co-polarized autocorrelation group for every '
+                         f'polarization it uses (e.g. via redcal.get_reds with include_autos=True), '
+                         f'but is missing {sorted(missing_antpols)}.')
+
+    # per-antenna flags (excluded antennas are handled by membership, not flags). if decoherence
+    # is given, correct the staircase out of the gains and precompute per-SNAP suppression and
+    # unmeasured-block waterfalls
+    gain_flags = {ant: (~np.isfinite(g) | ant_flags.get(ant, False)) for ant, g in gains.items()}
+    finite_gains = {ant: np.where(np.isfinite(g), g, 1) for ant, g in gains.items()}
+    if snap_decoherence is not None:
+        finite_gains = snap_decoherence.correct_gains(finite_gains)
+        ant_to_SNAP = snap_decoherence.ant_to_SNAP_dict
+        nchans_per_block = snap_decoherence.block_freqs.shape[1]
+        log_supp = {SNAP: np.repeat(np.nan_to_num(ls), nchans_per_block, axis=1)
+                    for SNAP, ls in snap_decoherence._log_suppression.items()}
+        unmeasured = {SNAP: np.repeat(np.isnan(p), nchans_per_block, axis=1)
+                      for SNAP, p in snap_decoherence.decoherence.items()}
+
+        def _is_inter_SNAP(bl):
+            return ant_to_SNAP.get(bl[0]) != ant_to_SNAP.get(bl[1])
+
+    # calibrated autocorrelations (small: per-antenna) set every baseline's noise variance
+    cal_autos = {}
+    for ant in finite_gains:
+        auto_bl = utils.join_bl(ant, ant)
+        if auto_bl in data:
+            with np.errstate(divide='ignore', invalid='ignore'):
+                cal_autos[auto_bl] = np.abs(data[auto_bl]) / np.abs(finite_gains[ant])**2
+    cal_autos = datacontainer.DataContainer(cal_autos)
+
+    def _bl_flags(bl):
+        '''Both antennas' gain_flags, plus unmeasured decoherence blocks for inter-SNAP baselines.'''
+        ant_i, ant_j = utils.split_bl(bl)
+        flags = gain_flags[ant_i] | gain_flags[ant_j]
+        if snap_decoherence is not None and _is_inter_SNAP(bl):
+            # .get defaults: SNAPs without stored results (possible for excluded antennas) add no flags
+            flags = flags | unmeasured.get(ant_to_SNAP.get(bl[0]), False) | unmeasured.get(ant_to_SNAP.get(bl[1]), False)
+        return flags
+
+    def _noise_wgts(bl, flags):
+        '''Inverse noise variance from the calibrated autos, zeroed where flagged.'''
+        with np.errstate(all='ignore'):
+            sigma2 = noise.predict_noise_variance_from_autos(bl, cal_autos, dt=dt, df=df)
+            return np.where(flags | ~(sigma2 > 0), 0, 1 / np.where(sigma2 > 0, sigma2, 1))
+
+    def _usable_bl(bl, exclusion_chisq=False):
+        '''True if bl has the gains and co-polarized autos it needs and the right number of
+        excluded antennas: none for the averages, exactly one for the excluded-antenna chi^2.'''
+        ant_i, ant_j = utils.split_bl(bl)
+        if ant_i not in finite_gains or ant_j not in finite_gains:
+            return False
+        if (ant_i in ex_ants) + (ant_j in ex_ants) != (1 if exclusion_chisq else 0):
+            return False
+        return utils.join_bl(ant_i, ant_i) in cal_autos and utils.join_bl(ant_j, ant_j) in cal_autos
+
+    # average reds' autocorrelation groups (co-polarized first, then cross-polarized, whose
+    # effective nsamples need the co-polarized averages) with binary weights: every listed
+    # antenna's auto key resolves to the average via the returned RedDataContainers, but
+    # only usable antennas contribute
+    red_avg_data, red_avg_flags, red_avg_nsamples = {}, {}, {}
+    avg_autos = {}
+    auto_reds = sorted((red for red in reds if red[0][0] == red[0][1]),
+                       key=lambda red: (utils.split_pol(red[0][2])[0] != utils.split_pol(red[0][2])[1],
+                                        red[0][2]))
+    for red in auto_reds:
+        pol = red[0][2]
+        members = [bl for bl in red if bl in data and _usable_bl(bl)]
+        if len(members) == 0:
+            continue
+        cal_group = datacontainer.DataContainer({bl: data[bl].copy() for bl in members})
+        with np.errstate(divide='ignore', invalid='ignore'):
+            calibrate_in_place(cal_group, finite_gains)
+        binary = [(~_bl_flags(bl)).astype(float) for bl in members]
+        wgt_sum = np.sum(binary, axis=0)
+        with np.errstate(all='ignore'):
+            avg = np.sum([b * cal_group[bl] for b, bl in zip(binary, members)], axis=0) \
+                  / np.where(wgt_sum > 0, wgt_sum, 1)
+        avg = np.where(wgt_sum > 0, avg, 0)
+        key = members[0]
+        red_avg_data[key] = avg
+        red_avg_flags[key] = wgt_sum == 0
+        antpol_i, antpol_j = utils.split_pol(pol)
+        if antpol_i == antpol_j:
+            avg_autos[antpol_i] = np.abs(avg)
+        if effective_nsamples:
+            # uniform weighting of per-antenna auto noise: Var = sum(P_k) / (n^2 dt df) with P_k
+            # each antenna's co-polarized auto product, so n_eff = n^2 Abar_i Abar_j / sum(P_k)
+            product_sum = np.sum([b * np.abs(cal_autos[utils.join_bl((bl[0], antpol_i), (bl[0], antpol_i))]
+                                             * cal_autos[utils.join_bl((bl[0], antpol_j), (bl[0], antpol_j))])
+                                  for b, bl in zip(binary, members)], axis=0)
+            with np.errstate(all='ignore'):
+                red_avg_nsamples[key] = np.where(product_sum > 0,
+                                                 wgt_sum**2 * avg_autos[antpol_i] * avg_autos[antpol_j]
+                                                 / np.where(product_sum > 0, product_sum, 1), 0)
+        else:
+            red_avg_nsamples[key] = wgt_sum
+
+    chisq_num, chisq_dof, total_num, total_dof = {}, {}, {}, {}
+    for red in reds:
+        if red[0][0] == red[0][1]:
+            continue  # autocorrelations are always averaged separately, above
+        # members with usable gains and autocorrelations and at least one unflagged cell
+        group_wgts, group_flags = {}, {}
+        for bl in red:
+            if bl in data and _usable_bl(bl):
+                flags = _bl_flags(bl)
+                wgt = _noise_wgts(bl, flags)
+                if np.any(wgt > 0):
+                    group_wgts[bl], group_flags[bl] = wgt, flags
+        group_bls = list(group_wgts)
+        if len(group_bls) == 0:
+            continue
+
+        # calibrate this group's raw data (a full-size calibrated copy is never materialized)
+        group_data = datacontainer.DataContainer({bl: data[bl].copy() for bl in group_bls})
+        with np.errstate(divide='ignore', invalid='ignore'):
+            calibrate_in_place(group_data, finite_gains)
+        if snap_decoherence is not None:
+            # exact class-aware correction: inter-SNAP crosses divided by (1 - p_i)(1 - p_j)
+            correct_SNAP_decoherence_in_place(group_data, snap_decoherence.decoherence, ant_to_SNAP,
+                                              data_flags=datacontainer.DataContainer(group_flags),
+                                              nchans_per_block=nchans_per_block)
+
+        # inverse-variance weighted average of this group
+        wgt_sum = np.sum([group_wgts[bl] for bl in group_bls], axis=0)
+        with np.errstate(all='ignore'):
+            avg = np.sum([group_wgts[bl] * group_data[bl] for bl in group_bls], axis=0) \
+                  / np.where(wgt_sum > 0, wgt_sum, 1)
+        avg = np.where(wgt_sum > 0, avg, 0)
+        key = group_bls[0]
+        red_avg_data[key] = avg
+        red_avg_flags[key] = wgt_sum == 0
+        if effective_nsamples:
+            antpol_i, antpol_j = utils.split_pol(key[2])
+            with np.errstate(all='ignore'):
+                red_avg_nsamples[key] = avg_autos[antpol_i] * avg_autos[antpol_j] * wgt_sum / (dt * df)
+        else:
+            red_avg_nsamples[key] = np.sum([group_wgts[bl] > 0 for bl in group_bls], axis=0).astype(float)
+
+        # accumulate redundant-baseline chi^2 over co-polarized cross-correlations.
+        # NOTE: utils.chisq / redcal.normalized_chisq are deliberately not used here: their DoF
+        # normalization (redcal.predict_chisq_per_ant) assumes omnical, where gains are fit from
+        # redundancy. Here only each group's mean is fit, so the expected chi^2 is accumulated
+        # directly: 1 - w / sum(w) per participating baseline (and 1 + w / sum(w) for excluded
+        # antennas below, whose baselines did not participate in the mean).
+        if compute_chisq and utils.split_pol(red[0][2])[0] == utils.split_pol(red[0][2])[1]:
+            antpol = utils.split_bl(key)[0][1]
+            for bl in group_bls:
+                with np.errstate(all='ignore'):
+                    z2 = np.where(group_wgts[bl] > 0, group_wgts[bl] * np.abs(group_data[bl] - avg)**2, 0)
+                    dof = np.where(group_wgts[bl] > 0, 1 - group_wgts[bl] / np.where(wgt_sum > 0, wgt_sum, 1), 0)
+                for ant in utils.split_bl(bl):
+                    chisq_num[ant] = chisq_num.get(ant, 0) + z2
+                    chisq_dof[ant] = chisq_dof.get(ant, 0) + dof
+                total_num[antpol] = total_num.get(antpol, 0) + z2
+                total_dof[antpol] = total_dof.get(antpol, 0) + dof
+
+            # excluded antennas with usable data: chi^2 against the good-antenna group mean,
+            # attributed only to the excluded antenna (never to its partners or the totals)
+            if len(ex_ants) > 0 and np.any(wgt_sum > 0):
+                excl_wgts = {}
+                for bl in red:
+                    if bl in data and bl not in group_wgts and _usable_bl(bl, exclusion_chisq=True):
+                        wgt = _noise_wgts(bl, _bl_flags(bl))
+                        if np.any(wgt > 0):
+                            excl_wgts[bl] = wgt
+                if len(excl_wgts) > 0:
+                    excl_data = datacontainer.DataContainer({bl: data[bl].copy() for bl in excl_wgts})
+                    with np.errstate(divide='ignore', invalid='ignore'):
+                        calibrate_in_place(excl_data, finite_gains)
+                    for bl in excl_wgts:
+                        ant_i, ant_j = utils.split_bl(bl)
+                        if snap_decoherence is not None and _is_inter_SNAP(bl):
+                            # the exact correction, applied inline since an excluded antenna's
+                            # SNAP may lack stored results (.get defaults to no correction)
+                            excl_data[bl] *= np.exp(log_supp.get(ant_to_SNAP.get(bl[0]), 0)
+                                                    + log_supp.get(ant_to_SNAP.get(bl[1]), 0))
+                        usable = (excl_wgts[bl] > 0) & (wgt_sum > 0)
+                        with np.errstate(all='ignore'):
+                            z2 = np.where(usable, excl_wgts[bl] * np.abs(excl_data[bl] - avg)**2, 0)
+                            expectation = np.where(usable, 1 + excl_wgts[bl] / np.where(wgt_sum > 0, wgt_sum, 1), 0)
+                        excluded_ant = (ant_i if ant_i in ex_ants else ant_j)
+                        chisq_num[excluded_ant] = chisq_num.get(excluded_ant, 0) + z2
+                        chisq_dof[excluded_ant] = chisq_dof.get(excluded_ant, 0) + expectation
+
+    meta = {}
+    if compute_chisq:
+        with np.errstate(all='ignore'):
+            meta['chisq_per_ant'] = {ant: np.where(chisq_dof[ant] > 0,
+                                                   chisq_num[ant] / np.where(chisq_dof[ant] > 0, chisq_dof[ant], 1),
+                                                   np.nan) for ant in chisq_num}
+            meta['total_chisq'] = {antpol: np.where(total_dof[antpol] > 0,
+                                                    total_num[antpol] / np.where(total_dof[antpol] > 0, total_dof[antpol], 1),
+                                                    np.nan) for antpol in total_num}
+    return (datacontainer.RedDataContainer(red_avg_data, reds=reds),
+            datacontainer.RedDataContainer(red_avg_flags, reds=reds),
+            datacontainer.RedDataContainer(red_avg_nsamples, reds=reds),
+            meta)
 
 
 def build_gains_by_cadences(data, gains, cal_flags=None, flags_are_wgts=False):

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -229,8 +229,9 @@ def correct_SNAP_decoherence_in_place(data, decoherence, ant_to_SNAP_dict,
                      * coherence_factor[ant_to_SNAP_dict[j]])
 
 
-def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, snap_decoherence=None,
-                          dt=None, df=None, compute_chisq=True, effective_nsamples=True):
+def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_flags=None,
+                          snap_decoherence=None, dt=None, df=None, compute_chisq=True,
+                          effective_nsamples=True):
     '''Calibrate visibilities and redundantly average them with inverse-variance noise
     weights, one group at a time (a full-size calibrated copy of the data is never
     materialized). data must include co-polarized autocorrelations: they set each
@@ -278,6 +279,13 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, snap_
             or excluded antennas' -- resolves to its group's average.
         ant_flags: optional dict mapping (ant, antpol) to boolean flag waterfalls.
         ex_ants: optional iterable of (ant, antpol) tuples excluded from all averages.
+        data_flags: optional DataContainer of boolean flag waterfalls with the same keys
+            as data. Flagged cells get zero weight in averages, chi^2, and effective
+            nsamples. Flags on an autocorrelation affect only its average, never the
+            noise weights of cross-correlations using that antenna -- flagging an
+            antenna everywhere is ant_flags' job. Unnecessary in most current HERA
+            analyses, where flags are carried per-antenna (or array-wide) and belong
+            in ant_flags.
         snap_decoherence: optional io.SNAPDecoherence, e.g. from
             SNAPDecoherence.from_estimate. Default None: no decoherence handling.
         dt: integration time in seconds. Default None infers from data's times.
@@ -339,9 +347,12 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, snap_
     cal_autos = datacontainer.DataContainer(cal_autos)
 
     def _bl_flags(bl):
-        '''Both antennas' gain_flags, plus unmeasured decoherence blocks for inter-SNAP baselines.'''
+        '''Both antennas' gain_flags, plus data_flags and unmeasured decoherence blocks
+        for inter-SNAP baselines.'''
         ant_i, ant_j = utils.split_bl(bl)
         flags = gain_flags[ant_i] | gain_flags[ant_j]
+        if data_flags is not None:
+            flags = flags | data_flags[bl]
         if snap_decoherence is not None and _is_inter_SNAP(bl):
             # .get defaults: SNAPs without stored results (possible for excluded antennas) add no flags
             flags = flags | unmeasured.get(ant_to_SNAP.get(bl[0]), False) | unmeasured.get(ant_to_SNAP.get(bl[1]), False)

--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -248,8 +248,9 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
     Abar_i * Abar_j * sum(w) / (dt * df) for cross groups (above the count, since the
     average leans on quieter-than-typical pairs) and n^2 * Abar_i * Abar_j / (the sum
     over antennas of their co-polarized auto products) for the autocorrelations.
-    Effective nsamples is spectrally smooth (auto structure common to all antennas
-    cancels), so it can be sensibly inpainted across flagging gaps.
+    Flagging gaps will have nsamples = 0, but as long as antenna-to-antenna variation
+    in the autos is spectrally smooth, effective nsamples will be too, and can therefore
+    later be inpainted if needed.
 
     If snap_decoherence is given, gains are first cleaned of the fitted suppression
     staircase (SNAPDecoherence.correct_gains; autocorrelations and intra-SNAP baselines

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -3156,6 +3156,44 @@ class SNAPDecoherence:
         correct_SNAP_decoherence_in_place(data, self.decoherence, self.ant_to_SNAP_dict,
                                           data_flags=data_flags, nchans_per_block=self.block_freqs.shape[1])
 
+    def correct_gains(self, gains):
+        '''Remove the fitted per-SNAP suppression staircase from gain amplitudes by
+        multiplying each gain by e^{-ln(1 - p)} = 1 / (1 - p) per channel, using the
+        stored block map and antenna -> SNAP mapping. Because autocorrelations and
+        intra-SNAP baselines are exempt from decoherence, calibrating them requires
+        these corrected gains (inter-SNAP cross-correlations then get the exact
+        correction from apply_cal.correct_SNAP_decoherence_in_place). Every antenna
+        in gains must appear in the stored mapping (ValueError otherwise); unmeasured
+        (np.nan) blocks and SNAPs without stored results are left unchanged.
+
+        Arguments:
+            gains: dict mapping (ant, antpol) e.g. (0, 'Jee') to (Ntimes, Nfreqs)
+                complex gain waterfalls matching this object's times and freqs
+
+        Returns:
+            corrected_gains: new dict with the same keys, gains x 1 / (1 - p) where measured
+        '''
+        missing = sorted({ant[0] for ant in gains if ant[0] not in self.ant_to_SNAP_dict})
+        if len(missing) > 0:
+            raise ValueError('The stored ant_to_SNAP_dict is missing antennas that appear '
+                             f'in gains: {missing}. All antennas must be mapped to SNAPs.')
+        nchans_per_block = self.block_freqs.shape[1]
+        expected_shape = (len(self.times), len(self.freqs))
+        suppression = {SNAP: np.repeat(np.nan_to_num(ls), nchans_per_block, axis=1)
+                       for SNAP, ls in self._log_suppression.items()}
+        corrected_gains = {}
+        for ant, gain in gains.items():
+            gain = np.asarray(gain)
+            if gain.shape != expected_shape:
+                raise ValueError(f'gains[{ant}] has shape {gain.shape}, but this SNAPDecoherence '
+                                 f'object implies {expected_shape}.')
+            SNAP = self.ant_to_SNAP_dict[ant[0]]
+            if SNAP in suppression:
+                corrected_gains[ant] = gain * np.exp(suppression[SNAP])
+            else:
+                corrected_gains[ant] = gain.copy()
+        return corrected_gains
+
     def write(self, filename, clobber=False):
         """Write to an HDF5 file (suggested suffix: .snap_decoherence.h5).
 

--- a/hera_cal/skycal.py
+++ b/hera_cal/skycal.py
@@ -1112,6 +1112,99 @@ def sky_calibrate(data, model, autos=None, data_flags=None, model_flags=None,
     return gains, meta
 
 
+def expand_sky_gains(data, model, gains, autos=None, data_flags=None, model_flags=None,
+                     ant_flags=None, bls=None, ant_to_SNAP_dict=None, dt=None, df=None,
+                     chisq_per_ant=None):
+    '''Solve for the gains of antennas excluded from sky calibration ("spectators")
+    against the frozen solved gains and the sky model, updating gains in place.
+
+    With the solved gains g_j held fixed, each spectator's per-channel gain is a
+    closed-form weighted least-squares over its baselines to solved antennas:
+    the data/model ratio obeys Z_aj ~ g_a * conj(g_j), so
+    g_a = sum_j(w Z g_j) / sum_j(w |g_j|^2) -- no iteration, no divergence, and by
+    construction no effect on any solved antenna. This gives every antenna in every
+    file comparable statistics for downstream full-day flagging: broken antennas get
+    garbage gains with huge chi^2, which is the point -- they stay flagged upstream,
+    and the statistic records how badly they disagree with the sky. Cells where no
+    baseline is usable get np.nan gains.
+
+    NOTE: unlike its namesake redcal.expand_omni_gains, this deliberately does NOT
+    iterate to solve spectators against other spectators: only baselines to
+    originally-solved antennas are used, so spectator solutions never influence
+    anything else.
+
+    Arguments:
+        data: DataContainer of visibilities, including the autocorrelations for
+            noise weights unless autos is given
+        model: DataContainer or RedDataContainer of model visibilities,
+            time-aligned to data, as in build_data_model_ratio
+        gains: dict mapping (ant, antpol) e.g. (0, 'Jee') to (Ntimes, Nfreqs)
+            complex gain waterfalls of the SOLVED antennas, e.g. from
+            sky_calibrate (after any relative-phase calibration, so spectators
+            inherit that convention). UPDATED IN PLACE with spectator solutions.
+        autos, data_flags, model_flags, ant_flags, dt, df: as in
+            build_data_model_ratio
+        bls: optional list of candidate baselines. Default None considers every
+            modeled cross-correlation in data. Only baselines with exactly one
+            solved antenna are used either way.
+        ant_to_SNAP_dict: optional dict mapping antenna numbers to SNAP IDs. If
+            given, only inter-SNAP baselines are used (mirroring refine_gains, so
+            per-SNAP decoherence lands in spectator gain amplitudes the same way
+            as in solved ones) and baselines with unmapped antennas are skipped.
+        chisq_per_ant: optional dict of per-antenna chi^2 waterfalls, updated in
+            place: each spectator gets the mean over its baselines of
+            w |Z - g_a conj(g_j)|^2, whose expectation is ~1 for noise-like
+            residuals, attributed only to the spectator (solved antennas'
+            entries are never touched).
+    '''
+    # candidate baselines with exactly one solved antenna, oriented spectator-first
+    # (the containers handle the conjugation implied by reversal)
+    if bls is None:
+        bls = [bl for bl in data if bl[0] != bl[1] and bl in model]
+    spec_bls = []
+    for bl in bls:
+        if ant_to_SNAP_dict is not None:
+            if (bl[0] not in ant_to_SNAP_dict or bl[1] not in ant_to_SNAP_dict
+                    or ant_to_SNAP_dict[bl[0]] == ant_to_SNAP_dict[bl[1]]):
+                continue
+        ant_i, ant_j = utils.split_bl(bl)
+        if (ant_i in gains) and (ant_j not in gains):
+            spec_bls.append(utils.reverse_bl(bl))
+        elif (ant_j in gains) and (ant_i not in gains):
+            spec_bls.append(bl)
+    if len(spec_bls) == 0:
+        return
+
+    ratio, wgts = build_data_model_ratio(data, model, autos=autos, data_flags=data_flags,
+                                         model_flags=model_flags, ant_flags=ant_flags,
+                                         bls=spec_bls, dt=dt, df=df)
+
+    # closed-form per-channel solve, then chi^2 against the same frozen reference
+    num, den = {}, {}
+    for bl in spec_bls:
+        spec_ant, solved_ant = utils.split_bl(bl)
+        num[spec_ant] = num.get(spec_ant, 0) + wgts[bl] * np.nan_to_num(ratio[bl]) * gains[solved_ant]
+        den[spec_ant] = den.get(spec_ant, 0) + wgts[bl] * np.abs(gains[solved_ant])**2
+    with np.errstate(all='ignore'):
+        for ant in num:
+            gains[ant] = np.where(den[ant] > 0, num[ant] / np.where(den[ant] > 0, den[ant], 1), np.nan)
+
+    if chisq_per_ant is not None:
+        chisq_num, nobs = {}, {}
+        for bl in spec_bls:
+            spec_ant, solved_ant = utils.split_bl(bl)
+            with np.errstate(all='ignore'):
+                z2 = wgts[bl] * np.abs(ratio[bl] - gains[spec_ant] * np.conj(gains[solved_ant]))**2
+            usable = (wgts[bl] > 0) & np.isfinite(z2)
+            chisq_num[spec_ant] = chisq_num.get(spec_ant, 0) + np.where(usable, z2, 0)
+            nobs[spec_ant] = nobs.get(spec_ant, 0) + usable
+        with np.errstate(all='ignore'):
+            for ant in chisq_num:
+                chisq_per_ant[ant] = np.where(nobs[ant] > 0,
+                                              chisq_num[ant] / np.where(nobs[ant] > 0, nobs[ant], 1),
+                                              np.nan)
+
+
 ########################################################################
 # Per-SNAP, per-X-engine-block decoherence estimation
 ########################################################################

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -1024,8 +1024,11 @@ class TestCalibrateAndRedAvg:
         gains = {ant: g for ant, g in sim['gains'].items() if ant[0] != 0}
         # antenna 4 is entirely flagged; antenna 5 is excluded
         all_flagged = np.ones((sim['ntimes'], sim['nfreqs']), dtype=bool)
+        # listed auto groups with no usable members (no 'nn' autos in data; no antenna has
+        # both antpols' gains for 'en') are skipped without producing averages
+        reds_plus = sim['reds'] + [[(i, i, 'nn') for i in range(7)], [(i, i, 'en') for i in range(7)]]
         avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
-            sim['data'], gains, sim['reds'], ant_flags={(4, 'Jee'): all_flagged}, ex_ants=[(5, 'Jee')],
+            sim['data'], gains, reds_plus, ant_flags={(4, 'Jee'): all_flagged}, ex_ants=[(5, 'Jee')],
             dt=sim['dt'], df=sim['df'])
         # antennas 0 (no gains), 1 (no autos), and 4 (fully flagged) all drop out of the
         # averages, and none of the excluded-antenna chi^2 machinery crashes on their

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -876,6 +876,35 @@ class TestCalibrateAndRedAvg:
         np.testing.assert_array_equal(nsamples[red[0]][0, :10], len(red) - 1)
         np.testing.assert_array_equal(nsamples[red[0]][0, 10:], len(red))
 
+    def test_data_flags(self):
+        sim = build_red_avg_sim()
+        # flag (and corrupt) some cells of one baseline, and flag some cells of one auto
+        data_flags = DataContainer({bl: np.zeros((sim['ntimes'], sim['nfreqs']), dtype=bool)
+                                    for bl in sim['data']})
+        data_flags[(0, 1, 'ee')][0, :10] = True
+        data_flags[(2, 2, 'ee')][1, -5:] = True
+        sim['data'][(0, 1, 'ee')][0, :10] = 100.0
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], data_flags=data_flags,
+            dt=sim['dt'], df=sim['df'], effective_nsamples=False)
+        # the corrupted flagged cells get zero weight: the group average stays exact, loses
+        # exactly one sample there, and the corruption never reaches chi^2
+        red = [r for r in sim['reds'] if (0, 1, 'ee') in r][0]
+        np.testing.assert_allclose(avg[red[0]], sim['true_vis'][red[0]], atol=1e-10)
+        np.testing.assert_array_equal(nsamples[red[0]][0, :10], len(red) - 1)
+        np.testing.assert_array_equal(nsamples[red[0]][0, 10:], len(red))
+        assert np.all(meta['chisq_per_ant'][(0, 'Jee')] < 1e-16)
+        # the flagged auto cells drop out of the auto average, but do NOT affect the noise
+        # weights of cross-correlations involving that antenna (that's ant_flags' job)
+        auto_key = next(bl for bl in avg if bl[0] == bl[1])
+        expected = np.mean([sim['true_autos'][(i, 'Jee')] for i in range(6) if i != 2], axis=0)
+        np.testing.assert_allclose(avg[auto_key][1, -5:], expected[1, -5:], atol=1e-10)
+        np.testing.assert_array_equal(nsamples[auto_key][1, -5:], 5)
+        np.testing.assert_array_equal(nsamples[auto_key][0, :], 6)
+        red2 = [r for r in sim['reds'] if (0, 2, 'ee') in r][0]
+        np.testing.assert_allclose(avg[red2[0]], sim['true_vis'][red2[0]], atol=1e-10)
+        np.testing.assert_array_equal(nsamples[red2[0]], len(red2))
+
     def test_decoherence_round_trip(self):
         sim = build_red_avg_sim()
         ant_to_SNAP = {i: ('S0' if i < 3 else 'S1') for i in range(6)}

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -777,3 +777,312 @@ class TestCorrectSNAPDecoherence:
         with pytest.raises(ValueError, match='shape'):
             ac.correct_SNAP_decoherence_in_place(
                 data, bad_shape, self.SNAP_map, nchans_per_block=self.ncpb)
+
+
+def build_red_avg_sim(nfreqs=64, ntimes=2, nants=6, pols=['ee'], noise_amp=0.0, seed=0):
+    '''Linear redundant array with known gains, per-group true visibilities, and autos.
+    Returns a dict with the DataContainer (antpos attached), gains, truths, and dt/df.
+    With noise_amp=1, injected noise has exactly the variance predicted from the autos.'''
+    rng = np.random.default_rng(seed)
+    antpos = {i: np.array([14.6 * i, 0.0, 0.0]) for i in range(nants)}
+    freqs = 100e6 + np.arange(nfreqs) * 122070.3125
+    dt, df = 9.66, 122070.3125
+    reds = redcal.get_reds(antpos, pols=pols, include_autos=True)
+    gains, true_autos = {}, {}
+    for i in range(nants):
+        for antpol in {utils.split_pol(pol)[sub] for pol in pols for sub in (0, 1)}:
+            gains[(i, antpol)] = (1 + 0.1 * rng.standard_normal((ntimes, nfreqs))
+                                  + 0.1j * rng.standard_normal((ntimes, nfreqs)))
+            true_autos[(i, antpol)] = 10.0 + i + np.zeros((ntimes, nfreqs))
+    true_vis, data = {}, {}
+    for red in reds:
+        if red[0][0] != red[0][1]:
+            true_vis[red[0]] = (rng.standard_normal((ntimes, nfreqs))
+                                + 1j * rng.standard_normal((ntimes, nfreqs)))
+        for bl in red:
+            ant_i, ant_j = utils.split_bl(bl)
+            gi, gj = gains[ant_i], gains[ant_j]
+            if bl[0] == bl[1]:
+                if ant_i == ant_j:  # co-polarized autos only
+                    data[bl] = (np.abs(gi)**2 * true_autos[ant_i]).astype(complex)
+            else:
+                vis = true_vis[red[0]].copy()
+                if noise_amp > 0:
+                    sigma = np.sqrt(true_autos[ant_i] * true_autos[ant_j] / (dt * df)) * noise_amp
+                    vis += ((rng.standard_normal((ntimes, nfreqs))
+                             + 1j * rng.standard_normal((ntimes, nfreqs))) * sigma / np.sqrt(2))
+                data[bl] = gi * np.conj(gj) * vis
+    dc = DataContainer(data)
+    dc.antpos = antpos
+    return dict(data=dc, gains=gains, true_vis=true_vis, true_autos=true_autos,
+                reds=reds, antpos=antpos, freqs=freqs, dt=dt, df=df,
+                ntimes=ntimes, nfreqs=nfreqs)
+
+
+def build_test_SNAP_decoherence(sim, p_by_SNAP, ant_to_SNAP_dict, nchans_per_block=32):
+    '''Wrap hand-built per-SNAP loss fractions (Ntimes, Nblocks) in a SNAPDecoherence.'''
+    nblocks = sim['nfreqs'] // nchans_per_block
+    times = 2459935.5 + np.arange(sim['ntimes']) * 9.66 / (24 * 3600)
+    nan_like = {SNAP: np.full_like(p, np.nan) for SNAP, p in p_by_SNAP.items()}
+    counts = {SNAP: np.full(sim['ntimes'], 4, dtype=int) for SNAP in p_by_SNAP}
+    return io.SNAPDecoherence(
+        decoherence=p_by_SNAP, decoherence_refit={S: p.copy() for S, p in p_by_SNAP.items()},
+        log_suppression_sigma=nan_like, n_spectra_per_SNAP=counts,
+        times=times, block_freqs=sim['freqs'].reshape(nblocks, nchans_per_block),
+        ant_to_SNAP_dict=ant_to_SNAP_dict,
+        covered_blocks=np.ones(nblocks, dtype=bool), edge_blocks=[],
+        band_edges=np.array([[sim['freqs'][0], sim['freqs'][-1]]]))
+
+
+class TestCalibrateAndRedAvg:
+    def test_noiseless_recovery(self):
+        sim = build_red_avg_sim()
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+        for key, truth in sim['true_vis'].items():
+            np.testing.assert_allclose(avg[key], truth, atol=1e-10)
+            assert not np.any(flags[key])
+        # the zero-length group averages the calibrated autos uniformly over antennas
+        auto_key = next(bl for bl in avg if bl[0] == bl[1])
+        expected = np.mean([sim['true_autos'][(i, 'Jee')] for i in range(6)], axis=0)
+        np.testing.assert_allclose(avg[auto_key], expected, atol=1e-10)
+        # noiseless residuals mean zero chi^2
+        assert np.all(meta['chisq_per_ant'][(0, 'Jee')] < 1e-16)
+
+    def test_noise_weights_and_nsamples(self):
+        sim = build_red_avg_sim()
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'], effective_nsamples=False)
+        # weights go as 1 / (A_i * A_j): check a group against the hand-computed average
+        red = [r for r in sim['reds'] if r[0][0] != r[0][1] and len(r) > 2][0]
+        wgts = [1.0 / (sim['true_autos'][utils.split_bl(bl)[0]]
+                       * sim['true_autos'][utils.split_bl(bl)[1]]) for bl in red]
+        cal_vis = [sim['data'][bl] / (sim['gains'][utils.split_bl(bl)[0]]
+                                      * np.conj(sim['gains'][utils.split_bl(bl)[1]])) for bl in red]
+        expected = np.sum([w * v for w, v in zip(wgts, cal_vis)], axis=0) / np.sum(wgts, axis=0)
+        np.testing.assert_allclose(avg[red[0]], expected, atol=1e-10)
+        np.testing.assert_array_equal(nsamples[red[0]], len(red))
+
+    def test_ant_flags(self):
+        sim = build_red_avg_sim()
+        wf = np.zeros((sim['ntimes'], sim['nfreqs']), dtype=bool)
+        wf[0, :10] = True
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], ant_flags={(0, 'Jee'): wf}, dt=sim['dt'], df=sim['df'],
+            effective_nsamples=False)
+        # groups containing antenna 0 lose one sample where it is flagged, but stay correct
+        red = [r for r in sim['reds'] if (0, 1, 'ee') in r][0]
+        np.testing.assert_allclose(avg[red[0]], sim['true_vis'][red[0]], atol=1e-10)
+        np.testing.assert_array_equal(nsamples[red[0]][0, :10], len(red) - 1)
+        np.testing.assert_array_equal(nsamples[red[0]][0, 10:], len(red))
+
+    def test_decoherence_round_trip(self):
+        sim = build_red_avg_sim()
+        ant_to_SNAP = {i: ('S0' if i < 3 else 'S1') for i in range(6)}
+        p_S1 = np.zeros((sim['ntimes'], 2))
+        p_S1[:, 1] = [0.04, 0.02]
+        sd = build_test_SNAP_decoherence(sim, {'S0': np.zeros((sim['ntimes'], 2)), 'S1': p_S1},
+                                         ant_to_SNAP)
+        # suppress inter-SNAP visibilities and put the staircase into the gains
+        suppression = {SNAP: np.repeat(-np.log(1 - sd.decoherence[SNAP]), 32, axis=1)
+                       for SNAP in sd.SNAPs}
+        data = DataContainer({bl: sim['data'][bl].copy() for bl in sim['data']})
+        data.antpos = sim['antpos']
+        for bl in data:
+            if bl[0] != bl[1] and ant_to_SNAP[bl[0]] != ant_to_SNAP[bl[1]]:
+                data[bl] *= np.exp(-suppression[ant_to_SNAP[bl[0]]] - suppression[ant_to_SNAP[bl[1]]])
+        # measured gains carry the staircase; autocorrelations are exempt and stay as built
+        gains = {ant: g * np.exp(-suppression[ant_to_SNAP[ant[0]]]) for ant, g in sim['gains'].items()}
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            data, gains, sim['reds'], snap_decoherence=sd, dt=sim['dt'], df=sim['df'])
+        for key, truth in sim['true_vis'].items():
+            np.testing.assert_allclose(avg[key], truth, atol=1e-8)
+        # without the decoherence handling, the staircase corrupts intra-SNAP members
+        avg_wrong, _, _, _ = ac.calibrate_and_red_avg(data, gains, sim['reds'], dt=sim['dt'], df=sim['df'])
+        assert any(not np.allclose(avg_wrong[key], truth, atol=1e-3)
+                   for key, truth in sim['true_vis'].items())
+
+    def test_unmeasured_blocks_flagged(self):
+        sim = build_red_avg_sim()
+        ant_to_SNAP = {i: ('S0' if i < 3 else 'S1') for i in range(6)}
+        p_S1 = np.zeros((sim['ntimes'], 2))
+        p_S1[0, 0] = np.nan  # unmeasured block for S1 at t = 0
+        sd = build_test_SNAP_decoherence(sim, {'S0': np.zeros((sim['ntimes'], 2)), 'S1': p_S1},
+                                         ant_to_SNAP)
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], snap_decoherence=sd, dt=sim['dt'], df=sim['df'],
+            effective_nsamples=False)
+        # the length-1 group has intra-SNAP members (0-1, 1-2, 3-4, 4-5) and one inter-SNAP
+        # member (2-3): the inter-SNAP baseline is excluded where p is unmeasured
+        red = [r for r in sim['reds'] if (0, 1, 'ee') in r][0]
+        np.testing.assert_array_equal(nsamples[red[0]][0, :32], len(red) - 1)
+        np.testing.assert_array_equal(nsamples[red[0]][0, 32:], len(red))
+        np.testing.assert_array_equal(nsamples[red[0]][1], len(red))
+        np.testing.assert_allclose(avg[red[0]], sim['true_vis'][red[0]], atol=1e-10)
+
+    def test_chisq_noise_expectation(self):
+        sim = build_red_avg_sim(nfreqs=128, noise_amp=1.0, seed=1)
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+        for ant, cspa in meta['chisq_per_ant'].items():
+            assert np.nanmean(cspa) == pytest.approx(1.0, abs=0.25)
+        assert np.nanmean(meta['total_chisq']['Jee']) == pytest.approx(1.0, abs=0.1)
+
+    def test_excluded_antennas(self):
+        sim = build_red_avg_sim(nfreqs=128, noise_amp=1.0, seed=2)
+        # corrupt antenna 5, as if miscalibrated
+        corrupted = DataContainer({bl: (sim['data'][bl] * (3.0 if 5 in bl[:2] and bl[0] != bl[1] else 1.0))
+                                   for bl in sim['data']})
+        corrupted.antpos = sim['antpos']
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            corrupted, sim['gains'], sim['reds'], ex_ants=[(5, 'Jee')], dt=sim['dt'], df=sim['df'])
+        # excluding antenna 5 makes the averages identical to simply not having it
+        no5 = DataContainer({bl: corrupted[bl] for bl in corrupted if 5 not in bl[:2]})
+        no5.antpos = sim['antpos']
+        avg2, flags2, nsamples2, meta2 = ac.calibrate_and_red_avg(
+            no5, sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+        for key in avg2:
+            if 5 not in key[:2]:
+                np.testing.assert_array_equal(avg[key], avg2[key])
+        # excluded antennas' keys still resolve through the containers: their auto key
+        # maps to the array-averaged auto, and their cross keys to the group averages
+        np.testing.assert_array_equal(avg[(5, 5, 'ee')], avg[(0, 0, 'ee')])
+        np.testing.assert_array_equal(avg[(4, 5, 'ee')], avg[(0, 1, 'ee')])
+        # the corrupted antenna's chi^2 is large; its partners' chi^2 and the
+        # per-polarization totals are exactly what they would be without it
+        assert np.nanmean(meta['chisq_per_ant'][(5, 'Jee')]) > 10
+        for ant in meta2['chisq_per_ant']:
+            np.testing.assert_array_equal(meta['chisq_per_ant'][ant], meta2['chisq_per_ant'][ant])
+        np.testing.assert_array_equal(meta['total_chisq']['Jee'], meta2['total_chisq']['Jee'])
+
+    def test_cross_pols(self):
+        sim = build_red_avg_sim(pols=['ee', 'nn', 'en'])
+        # a cross-polarized "auto" is averaged too, though never used for noise weights
+        sim['data'][(0, 0, 'en')] = np.ones((sim['ntimes'], sim['nfreqs']), dtype=complex)
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+        en_keys = [key for key in sim['true_vis'] if key[2] == 'en']
+        assert len(en_keys) > 0
+        for key in en_keys:
+            np.testing.assert_allclose(avg[key], sim['true_vis'][key], atol=1e-10)
+        # the injected cross-polarized auto is calibrated and averaged (a group of one),
+        # with finite effective nsamples anchored by both polarizations' averaged autos
+        expected = 1.0 / (sim['gains'][(0, 'Jee')] * np.conj(sim['gains'][(0, 'Jnn')]))
+        np.testing.assert_allclose(avg[(0, 0, 'en')], expected, atol=1e-10)
+        assert np.all(nsamples[(0, 0, 'en')] > 0)
+        # chi^2 stays co-polarized: totals keyed by Jee/Jnn only
+        assert set(meta['total_chisq'].keys()) == {'Jee', 'Jnn'}
+        # reds govern everything: co-polarized-only reds drop 'en' crosses and autos alike
+        co_reds = [red for red in sim['reds']
+                   if utils.split_pol(red[0][2])[0] == utils.split_pol(red[0][2])[1]]
+        avg_co, _, _, _ = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], co_reds, dt=sim['dt'], df=sim['df'])
+        assert not any(key[2] == 'en' for key in avg_co)
+
+    def test_compute_chisq_false(self):
+        sim = build_red_avg_sim()
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], compute_chisq=False, dt=sim['dt'], df=sim['df'])
+        assert meta == {}
+
+    def test_missing_gains_and_autos_omitted(self):
+        sim = build_red_avg_sim()
+        gains = {ant: g for ant, g in sim['gains'].items() if ant[0] != 0}
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], gains, sim['reds'], dt=sim['dt'], df=sim['df'], effective_nsamples=False)
+        assert not any(0 in key[:2] for key in avg)
+        red = [r for r in sim['reds'] if (0, 1, 'ee') in r][0]
+        np.testing.assert_array_equal(nsamples[red[1]], len(red) - 1)
+
+    def test_excluded_antenna_with_decoherence(self):
+        sim = build_red_avg_sim()
+        ant_to_SNAP = {i: ('S0' if i < 3 else 'S1') for i in range(6)}
+        p_S1 = np.zeros((sim['ntimes'], 2))
+        p_S1[:, 1] = [0.04, 0.02]
+        sd = build_test_SNAP_decoherence(sim, {'S0': np.zeros((sim['ntimes'], 2)), 'S1': p_S1},
+                                         ant_to_SNAP)
+        suppression = {SNAP: np.repeat(-np.log(1 - sd.decoherence[SNAP]), 32, axis=1)
+                       for SNAP in sd.SNAPs}
+        data = DataContainer({bl: sim['data'][bl].copy() for bl in sim['data']})
+        data.antpos = sim['antpos']
+        for bl in data:
+            if bl[0] != bl[1] and ant_to_SNAP[bl[0]] != ant_to_SNAP[bl[1]]:
+                data[bl] *= np.exp(-suppression[ant_to_SNAP[bl[0]]] - suppression[ant_to_SNAP[bl[1]]])
+        gains = {ant: g * np.exp(-suppression[ant_to_SNAP[ant[0]]]) for ant, g in sim['gains'].items()}
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            data, gains, sim['reds'], ex_ants=[(5, 'Jee')], snap_decoherence=sd, dt=sim['dt'], df=sim['df'])
+        # the excluded antenna's data are noiseless and consistent with the good-antenna
+        # averages once the inline decoherence correction is applied, so its chi^2 ~ 0
+        assert np.all(meta['chisq_per_ant'][(5, 'Jee')] < 1e-16)
+
+    def test_excluded_and_omitted_edge_cases(self):
+        sim = build_red_avg_sim(nants=7)
+        # inject a cross-polarized "auto", which is never averaged
+        sim['data'][(0, 0, 'en')] = np.ones((sim['ntimes'], sim['nfreqs']), dtype=complex)
+        # antenna 1 loses its autocorrelation; antenna 0 loses its gains
+        del sim['data'][(1, 1, 'ee')]
+        gains = {ant: g for ant, g in sim['gains'].items() if ant[0] != 0}
+        # antenna 4 is entirely flagged; antenna 5 is excluded
+        all_flagged = np.ones((sim['ntimes'], sim['nfreqs']), dtype=bool)
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], gains, sim['reds'], ant_flags={(4, 'Jee'): all_flagged}, ex_ants=[(5, 'Jee')],
+            dt=sim['dt'], df=sim['df'])
+        # antennas 0 (no gains), 1 (no autos), and 4 (fully flagged) all drop out of the
+        # averages, and none of the excluded-antenna chi^2 machinery crashes on their
+        # baselines to antenna 5 (missing gains/autos, both-unexcluded, or fully flagged)
+        assert not any(0 in key[:2] or 1 in key[:2] for key in avg)
+        assert not any(key[2] == 'en' for key in avg)
+        assert (0, 'Jee') not in meta['chisq_per_ant']
+        assert (4, 'Jee') not in meta['chisq_per_ant']
+
+    def test_dt_df_inference(self):
+        sim = build_red_avg_sim()
+        times = 2459935.5 + np.arange(sim['ntimes']) * sim['dt'] / (24 * 3600)
+        sim['data'].times = times
+        sim['data'].times_by_bl = {bl[:2]: times for bl in sim['data']}
+        sim['data'].freqs = sim['freqs']
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(sim['data'], sim['gains'], sim['reds'])
+        for key, truth in sim['true_vis'].items():
+            np.testing.assert_allclose(avg[key], truth, atol=1e-10)
+
+    def test_effective_nsamples_exact(self):
+        sim = build_red_avg_sim(nfreqs=64, ntimes=400, noise_amp=1.0, seed=3)
+        avg, flags, n_eff, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'], compute_chisq=False)
+        _, _, n_count, _ = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'], compute_chisq=False,
+            effective_nsamples=False)
+        auto_key = next(bl for bl in avg if bl[0] == bl[1])
+        avg_auto = np.abs(avg[auto_key])
+        key = sorted((bl for bl in avg if bl[0] != bl[1]), key=lambda bl: -np.max(n_count[bl]))[0]
+        # effective nsamples exceeds the count for cross groups and makes the standard
+        # predictor Abar^2 / (dt df nsamples) exact; the count over-predicts the noise
+        assert np.all(n_eff[key] > n_count[key])
+        # the sim's true visibilities vary with time, so subtract them to isolate the noise
+        empirical_var = np.var(avg[key] - sim['true_vis'][key], axis=0)
+        pred_eff = avg_auto[0]**2 / (sim['dt'] * sim['df'] * n_eff[key][0])
+        pred_count = avg_auto[0]**2 / (sim['dt'] * sim['df'] * n_count[key][0])
+        assert np.mean(empirical_var / pred_eff) == pytest.approx(1.0, abs=0.05)
+        assert np.mean(empirical_var / pred_count) < 0.98  # ~3.5% over-prediction for this sim's auto spread
+        # the averaged autos' own effective nsamples accounts for uniform weighting of
+        # heteroscedastic autos, and so is at or below the antenna count
+        assert np.all(n_eff[auto_key] <= n_count[auto_key] + 1e-10)
+
+    def test_autos_required(self):
+        sim = build_red_avg_sim()
+        no_autos = DataContainer({bl: sim['data'][bl] for bl in sim['data'] if bl[0] != bl[1]})
+        no_autos.antpos = sim['antpos']
+        with pytest.raises(ValueError, match='autocorrelations'):
+            ac.calibrate_and_red_avg(no_autos, sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+
+    def test_reds_must_include_auto_groups(self):
+        sim = build_red_avg_sim()
+        cross_reds = [red for red in sim['reds'] if red[0][0] != red[0][1]]
+        with pytest.raises(ValueError, match='autocorrelation group'):
+            ac.calibrate_and_red_avg(sim['data'], sim['gains'], cross_reds,
+                                     dt=sim['dt'], df=sim['df'])
+        # with auto groups listed, every antenna's auto key resolves to the average
+        avg, flags, nsamples, meta = ac.calibrate_and_red_avg(
+            sim['data'], sim['gains'], sim['reds'], dt=sim['dt'], df=sim['df'])
+        expected = np.mean([sim['true_autos'][(i, 'Jee')] for i in range(6)], axis=0)
+        np.testing.assert_allclose(avg[(3, 3, 'ee')], expected, atol=1e-10)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -2083,6 +2083,37 @@ class TestSNAPDecoherence:
         assert np.flatnonzero(np.isfinite(
             sd._log_suppression_sigma['A'][0])).tolist() == [2, 6]
 
+    def test_correct_gains(self):
+        sd = make_SNAP_decoherence()
+        nchans_per_block = sd.block_freqs.shape[1]
+        rng = np.random.default_rng(0)
+        ant_on_A = next(a for a, SNAP in sd.ant_to_SNAP_dict.items() if SNAP == 'A')
+        ant_on_B = next(a for a, SNAP in sd.ant_to_SNAP_dict.items() if SNAP == 'B')
+        smooth = np.exp(0.01 * rng.standard_normal((1, len(sd.freqs)))
+                        + 0.1j * rng.standard_normal((1, len(sd.freqs))))
+        suppression = np.repeat(np.nan_to_num(sd._log_suppression['A']), nchans_per_block, axis=1)
+        sd.ant_to_SNAP_dict[999] = 'C'  # mapped, but SNAP C has no stored results
+        gains = {(ant_on_A, 'Jee'): smooth * np.exp(-suppression),
+                 (ant_on_B, 'Jee'): smooth.copy(),
+                 (999, 'Jee'): np.ones((1, len(sd.freqs)), dtype=complex)}
+        corrected = sd.correct_gains(gains)
+        # the staircase is removed from the SNAP-A antenna, recovering the smooth gain
+        np.testing.assert_allclose(corrected[(ant_on_A, 'Jee')], smooth)
+        assert np.any(np.abs(gains[(ant_on_A, 'Jee')]) != np.abs(corrected[(ant_on_A, 'Jee')]))
+        # SNAP B has no detections, so its gain is unchanged
+        np.testing.assert_array_equal(corrected[(ant_on_B, 'Jee')], smooth)
+        # a SNAP without stored results is returned unchanged, as a copy
+        np.testing.assert_array_equal(corrected[(999, 'Jee')], 1.0)
+        corrected[(999, 'Jee')][:] = 0
+        np.testing.assert_array_equal(gains[(999, 'Jee')], 1.0)
+
+    def test_correct_gains_errors(self):
+        sd = make_SNAP_decoherence()
+        with pytest.raises(ValueError, match='missing antennas'):
+            sd.correct_gains({(999, 'Jee'): np.ones((1, len(sd.freqs)), dtype=complex)})
+        with pytest.raises(ValueError, match='shape'):
+            sd.correct_gains({(1, 'Jee'): np.ones((1, 10), dtype=complex)})
+
     def test_multifile_read(self, tmp_path):
         sd1 = make_SNAP_decoherence(times=np.array([2459935.38]))
         # second file: SNAP B absent entirely (e.g. all its antennas dead)

--- a/hera_cal/tests/test_skycal.py
+++ b/hera_cal/tests/test_skycal.py
@@ -1250,3 +1250,82 @@ class TestDivergentChannelTolerance:
         assert 'divergent_chans' in meta
         for key, chans in meta['divergent_chans'].items():
             assert len(chans) == 0  # clean sim: nothing should fail
+
+
+class TestExpandSkyGains:
+    def test_recovery_and_containment(self):
+        sim = build_sim()
+        gains = dict(sim['true_gains'])
+        spectator = (3, 'Jee')
+        del gains[spectator]
+        solved_before = {ant: g.copy() for ant, g in gains.items()}
+        chisq_per_ant = {}
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'],
+                                chisq_per_ant=chisq_per_ant)
+        # the spectator's true gain is recovered exactly and its chi^2 is ~0 (noiseless),
+        # while every solved antenna's gain is bit-identical to before
+        np.testing.assert_allclose(gains[spectator], sim['true_gains'][spectator], rtol=1e-8)
+        assert np.all(chisq_per_ant[spectator] < 1e-16)
+        assert set(chisq_per_ant) == {spectator}
+        for ant, g in solved_before.items():
+            np.testing.assert_array_equal(gains[ant], g)
+
+    def test_two_spectators_never_chain(self):
+        sim = build_sim()
+        gains = dict(sim['true_gains'])
+        # corrupt the baseline between the two spectators: it must never be used
+        sim['data'][(2, 5, sim['pol'])] *= 100
+        for spectator in [(2, 'Jee'), (5, 'Jee')]:
+            del gains[spectator]
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'])
+        for spectator in [(2, 'Jee'), (5, 'Jee')]:
+            np.testing.assert_allclose(gains[spectator], sim['true_gains'][spectator], rtol=1e-8)
+
+    def test_inter_SNAP_restriction(self):
+        sim = build_sim()
+        ant_to_SNAP_dict = {antnum: ('S0' if antnum < 4 else 'S1') for antnum in sim['antnums']}
+        gains = dict(sim['true_gains'])
+        del gains[(2, 'Jee')]
+        # corrupt the spectator's intra-SNAP baselines: with the restriction they are
+        # never used, so recovery stays exact; without it, they bias the solution
+        for j in [0, 1, 3]:
+            sim['data'][(min(2, j), max(2, j), sim['pol'])] *= 3
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'],
+                                ant_to_SNAP_dict=ant_to_SNAP_dict)
+        np.testing.assert_allclose(gains[(2, 'Jee')], sim['true_gains'][(2, 'Jee')], rtol=1e-8)
+        gains_unrestricted = {ant: g for ant, g in sim['true_gains'].items() if ant != (2, 'Jee')}
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains_unrestricted,
+                                dt=sim['dt'], df=sim['df'])
+        assert not np.allclose(gains_unrestricted[(2, 'Jee')], sim['true_gains'][(2, 'Jee')],
+                               rtol=1e-3)
+
+    def test_corrupted_spectator_gets_large_chisq(self):
+        sim = build_sim(noise=1.0, seed=5)
+        gains = dict(sim['true_gains'])
+        del gains[(3, 'Jee')]
+        # a common rescaling would be absorbed by g_a, so corrupt the spectator's
+        # baselines with baseline-DEPENDENT factors no per-antenna gain can explain
+        for k, bl in enumerate(bl for bl in list(sim['data']) if 3 in bl[:2] and bl[0] != bl[1]):
+            sim['data'][bl] *= (1 + 0.5 * (-1)**k)
+        chisq_per_ant = {}
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'],
+                                chisq_per_ant=chisq_per_ant)
+        assert np.mean(chisq_per_ant[(3, 'Jee')]) > 100
+
+    def test_nan_where_unusable(self):
+        sim = build_sim()
+        gains = dict(sim['true_gains'])
+        del gains[(3, 'Jee')]
+        all_flagged = np.ones((sim['ntimes'], len(sim['freqs'])), dtype=bool)
+        chisq_per_ant = {}
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'],
+                                ant_flags={ant: all_flagged for ant in gains},
+                                chisq_per_ant=chisq_per_ant)
+        assert np.all(np.isnan(gains[(3, 'Jee')]))
+        assert np.all(np.isnan(chisq_per_ant[(3, 'Jee')]))
+
+    def test_no_spectators_is_a_no_op(self):
+        sim = build_sim()
+        gains = dict(sim['true_gains'])
+        skycal.expand_sky_gains(sim['data'], sim['model'], gains, dt=sim['dt'], df=sim['df'])
+        assert set(gains) == set(sim['true_gains'])


### PR DESCRIPTION
This PR graduates three functions from the Phase II `file_sky_calibration` notebook into `hera_cal`:

- **`apply_cal.calibrate_and_red_avg`**: calibrates and redundantly averages visibilities one group at a
  time (never materializing a full-size calibrated copy of the data), with inverse-variance noise weights
  from calibrated autocorrelations, optional per-SNAP/per-X-engine-block decoherence handling consistent
  across baseline classes, and redundant-baseline χ² with exact DoF accounting (including a separate tier
  for excluded antennas). By default the returned nsamples are "effective nsamples," which make the
  standard noise predictor $\sigma^2 = \bar{A}^2/(\Delta t\, \Delta\nu\, n)$ exact for inverse-variance
  averages; the required `reds` (which must include co-polarized auto groups) is passed verbatim to the
  returned `RedDataContainer`s, and averaged autos are always included.
- **`io.SNAPDecoherence.correct_gains`**: removes the fitted per-SNAP suppression staircase from a gain
  dictionary using the stored antenna→SNAP mapping.
- **`skycal.expand_sky_gains`**: closed-form solve for the gains of antennas excluded from sky calibration
  against the frozen solved gains and the sky model, updating gains and per-antenna χ² in place so every
  antenna gets comparable statistics for downstream full-day flagging. Unlike its namesake
  `redcal.expand_omni_gains`, it is deliberately single-pass, so excluded-antenna solutions never
  influence anything else.

**We already have ways of doing redundant averaging, so why not `utils.red_average` or `RedSol.update_vis_from_data`?**
- The decoherence correction only applies to inter-SNAP cross-correlations, so it cannot be folded into
  per-antenna gains; it has to be applied to each group's calibrated data before averaging. The
  redundant-baseline χ² and effective nsamples also require per-baseline calibrated data. Doing all of
  this one group at a time avoids ever holding a full-size calibrated copy of the data in memory.
- `utils.red_average` averages already-calibrated data, so using it would require calibrating (and
  decoherence-correcting) the full data set up front.
- `RedSol.update_vis_from_data` does calibrate group-by-group, but it requires gains packaged as a
  `RedSol` (ours come from sky calibration with an external model), returns no flags or nsamples, and
  falls back to uniform averaging over partially-flagged baselines where a group's weights sum to zero,
  whereas we want those cells zeroed and flagged.

Adds 24 tests; all new code fully covered.