### PR TITLE
Correct noise prediction for decoherence

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -255,9 +255,12 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
     If snap_decoherence is given, gains are first cleaned of the fitted suppression
     staircase (SNAPDecoherence.correct_gains; autocorrelations and intra-SNAP baselines
     are exempt) and inter-SNAP cross-correlations instead get the exact correction
-    (correct_SNAP_decoherence_in_place), with unmeasured (np.nan) blocks flagged. The
-    stored antenna -> SNAP mapping is used throughout and must cover every antenna in
-    gains.
+    (correct_SNAP_decoherence_in_place), with unmeasured (np.nan) blocks flagged. Because
+    the correction inflates a baseline's noise by 1 / ((1 - p_i)(1 - p_j)) while the exempt
+    autos do not know it, the noise weights (and therefore the returned effective nsamples)
+    include the squared correction factor, keeping the standard noise prediction exact for
+    corrected data. The stored antenna -> SNAP mapping is used throughout and must cover
+    every antenna in gains.
 
     Chi^2 (co-polarized only): each group's mean is the only fit parameter, so a
     participating baseline's weighted scatter about it has expectation 1 - w / sum(w)
@@ -360,9 +363,17 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
         return flags
 
     def _noise_wgts(bl, flags):
-        '''Inverse noise variance from the calibrated autos, zeroed where flagged.'''
+        '''Inverse noise variance from the calibrated autos, zeroed where flagged. Inter-SNAP
+        baselines' post-correction noise is inflated by e^(ls_i + ls_j) = 1 / ((1 - p_i)(1 - p_j))
+        (decoherence suppresses the correlated signal but not the radiometer noise the autos
+        predict), so their variance carries the matching factor: corrected members are optimally
+        down-weighted, and the returned effective nsamples keep the standard noise prediction
+        (and therefore noise-normalized statistics like z-scores) exact for corrected data.'''
         with np.errstate(all='ignore'):
             sigma2 = noise.predict_noise_variance_from_autos(bl, cal_autos, dt=dt, df=df)
+            if snap_decoherence is not None and _is_inter_SNAP(bl):
+                sigma2 = sigma2 * np.exp(2 * (log_supp.get(ant_to_SNAP.get(bl[0]), 0)
+                                              + log_supp.get(ant_to_SNAP.get(bl[1]), 0)))
             return np.where(flags | ~(sigma2 > 0), 0, 1 / np.where(sigma2 > 0, sigma2, 1))
 
     def _usable_bl(bl, exclusion_chisq=False):

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -1100,6 +1100,46 @@ class TestCalibrateAndRedAvg:
         # heteroscedastic autos, and so is at or below the antenna count
         assert np.all(n_eff[auto_key] <= n_count[auto_key] + 1e-10)
 
+    def test_decoherence_noise_consistent(self):
+        # decoherence suppresses the correlated signal on inter-SNAP baselines but not the
+        # radiometer noise (the autos are exempt), so corrected data has noise inflated by the
+        # correction factor -- which the weights and effective nsamples must track
+        sim = build_red_avg_sim(nfreqs=64, ntimes=400, seed=4)
+        rng = np.random.default_rng(5)
+        ant_to_SNAP = {i: ('S0' if i < 3 else 'S1') for i in range(6)}
+        p_by_SNAP = {'S0': np.zeros((sim['ntimes'], 2)), 'S1': np.zeros((sim['ntimes'], 2))}
+        p_by_SNAP['S0'][:, 1] = 0.4
+        p_by_SNAP['S1'][:, 1] = 0.2
+        sd = build_test_SNAP_decoherence(sim, p_by_SNAP, ant_to_SNAP)
+        suppression = {SNAP: np.repeat(-np.log(1 - p), 32, axis=1) for SNAP, p in p_by_SNAP.items()}
+        data = DataContainer({bl: sim['data'][bl].copy() for bl in sim['data']})
+        data.antpos = sim['antpos']
+        for bl in data:
+            if bl[0] != bl[1]:
+                ant_i, ant_j = utils.split_bl(bl)
+                if ant_to_SNAP[bl[0]] != ant_to_SNAP[bl[1]]:
+                    data[bl] *= np.exp(-suppression[ant_to_SNAP[bl[0]]] - suppression[ant_to_SNAP[bl[1]]])
+                sigma = np.sqrt(sim['true_autos'][ant_i] * sim['true_autos'][ant_j] / (sim['dt'] * sim['df']))
+                data[bl] += (sim['gains'][ant_i] * np.conj(sim['gains'][ant_j]) * sigma / np.sqrt(2)
+                             * (rng.standard_normal(data[bl].shape) + 1j * rng.standard_normal(data[bl].shape)))
+        gains = {ant: g * np.exp(-suppression[ant_to_SNAP[ant[0]]]) for ant, g in sim['gains'].items()}
+        avg, flags, n_eff, _ = ac.calibrate_and_red_avg(data, gains, sim['reds'], snap_decoherence=sd,
+                                                        dt=sim['dt'], df=sim['df'], compute_chisq=False)
+        # in the corrected block, the standard prediction from the returned effective nsamples
+        # matches the empirical noise for every group, including groups mixing corrected
+        # inter-SNAP members with exempt intra-SNAP ones (without the correction-aware weights,
+        # the prediction would be low by the weighted mean squared correction, up to ~4.3x here)
+        auto_key = next(bl for bl in avg if bl[0] == bl[1])
+        avg_auto = np.abs(avg[auto_key])
+        for key, truth in sim['true_vis'].items():
+            empirical_var = np.var((avg[key] - truth)[:, 32:], axis=0)
+            pred = (avg_auto**2 / (sim['dt'] * sim['df'] * n_eff[key]))[0, 32:]
+            assert np.mean(empirical_var / pred) == pytest.approx(1.0, abs=0.1)
+        # a purely inter-SNAP group's effective nsamples drop by ((1 - p_i)(1 - p_j))^2 in the
+        # corrected block, honestly recording that its corrected data is noisier
+        ratio = n_eff[(0, 3, 'ee')][0, 32:] / n_eff[(0, 3, 'ee')][0, :32]
+        np.testing.assert_allclose(ratio, (0.6 * 0.8)**2, rtol=1e-6)
+
     def test_autos_required(self):
         sim = build_red_avg_sim()
         no_autos = DataContainer({bl: sim['data'][bl] for bl in sim['data'] if bl[0] != bl[1]})


### PR DESCRIPTION
This PR adjusts the weights in redundant averaging with decoherence to more properly account for that decoherence, which adjusts effective nsamples, which then fixes the apparent x-engine based structure in z-scores. It's a small effect, but also a relatively easy fix.

Old:

<img width="2000" height="849" alt="image" src="https://github.com/user-attachments/assets/9bb7682b-5a1f-4584-ae2e-a0e23c1fa0bd" />

New:
<img width="2777" height="1179" alt="image" src="https://github.com/user-attachments/assets/7166ba40-579c-436f-a495-cf42efbc90ea" />
