### PR TITLE
Add inverse option to SNAPDecoherence.correct_gains()

### DIFF
--- a/hera_cal/apply_cal.py
+++ b/hera_cal/apply_cal.py
@@ -303,8 +303,10 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
         red_avg_flags: RedDataContainer, True where a group has no unflagged members
         red_avg_nsamples: RedDataContainer of effective nsamples (or counts)
         meta: {'chisq_per_ant': (ant, antpol) -> chi^2 waterfalls (np.nan where nothing
-            was accumulated), 'total_chisq': antpol -> per-polarization totals} if
-            compute_chisq, else {}
+            was accumulated), 'total_chisq': antpol -> per-polarization totals,
+            'chisq_per_bl': bl -> (Ntimes,) chi^2 / DoF summed over frequency for every
+            baseline that participated in an average (its non-redundancy with its group)}
+            if compute_chisq, else {}
     '''
     ant_flags = ({} if ant_flags is None else ant_flags)
     ex_ants = set([] if ex_ants is None else ex_ants)
@@ -428,7 +430,7 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
         else:
             red_avg_nsamples[key] = wgt_sum
 
-    chisq_num, chisq_dof, total_num, total_dof = {}, {}, {}, {}
+    chisq_num, chisq_dof, total_num, total_dof, bl_chisq_num, bl_chisq_dof = {}, {}, {}, {}, {}, {}
     for red in reds:
         if red[0][0] == red[0][1]:
             continue  # autocorrelations are always averaged separately, above
@@ -487,6 +489,7 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
                     chisq_dof[ant] = chisq_dof.get(ant, 0) + dof
                 total_num[antpol] = total_num.get(antpol, 0) + z2
                 total_dof[antpol] = total_dof.get(antpol, 0) + dof
+                bl_chisq_num[bl], bl_chisq_dof[bl] = np.sum(z2, axis=1), np.sum(dof, axis=1)
 
             # excluded antennas with usable data: chi^2 against the good-antenna group mean,
             # attributed only to the excluded antenna (never to its partners or the totals)
@@ -525,6 +528,8 @@ def calibrate_and_red_avg(data, gains, reds, ant_flags=None, ex_ants=None, data_
             meta['total_chisq'] = {antpol: np.where(total_dof[antpol] > 0,
                                                     total_num[antpol] / np.where(total_dof[antpol] > 0, total_dof[antpol], 1),
                                                     np.nan) for antpol in total_num}
+            meta['chisq_per_bl'] = {bl: np.where(bl_chisq_dof[bl] > 0, bl_chisq_num[bl] / np.where(bl_chisq_dof[bl] > 0, bl_chisq_dof[bl], 1), np.nan)
+                                    for bl in bl_chisq_num}
     return (datacontainer.RedDataContainer(red_avg_data, reds=reds),
             datacontainer.RedDataContainer(red_avg_flags, reds=reds),
             datacontainer.RedDataContainer(red_avg_nsamples, reds=reds),

--- a/hera_cal/io.py
+++ b/hera_cal/io.py
@@ -3156,22 +3156,25 @@ class SNAPDecoherence:
         correct_SNAP_decoherence_in_place(data, self.decoherence, self.ant_to_SNAP_dict,
                                           data_flags=data_flags, nchans_per_block=self.block_freqs.shape[1])
 
-    def correct_gains(self, gains):
+    def correct_gains(self, gains, inverse=False):
         '''Remove the fitted per-SNAP suppression staircase from gain amplitudes by
         multiplying each gain by e^{-ln(1 - p)} = 1 / (1 - p) per channel, using the
         stored block map and antenna -> SNAP mapping. Because autocorrelations and
         intra-SNAP baselines are exempt from decoherence, calibrating them requires
         these corrected gains (inter-SNAP cross-correlations then get the exact
-        correction from apply_cal.correct_SNAP_decoherence_in_place). Every antenna
-        in gains must appear in the stored mapping (ValueError otherwise); unmeasured
+        correction from apply_cal.correct_SNAP_decoherence_in_place). With inverse=True
+        the staircase is instead re-imposed (gains x (1 - p)). Every antenna in
+        gains must appear in the stored mapping (ValueError otherwise); unmeasured
         (np.nan) blocks and SNAPs without stored results are left unchanged.
 
         Arguments:
             gains: dict mapping (ant, antpol) e.g. (0, 'Jee') to (Ntimes, Nfreqs)
                 complex gain waterfalls matching this object's times and freqs
+            inverse: if True, apply the staircase rather than removing it
 
         Returns:
-            corrected_gains: new dict with the same keys, gains x 1 / (1 - p) where measured
+            corrected_gains: new dict with the same keys, gains x 1 / (1 - p) (or x (1 - p)
+                if inverse) where measured
         '''
         missing = sorted({ant[0] for ant in gains if ant[0] not in self.ant_to_SNAP_dict})
         if len(missing) > 0:
@@ -3189,7 +3192,7 @@ class SNAPDecoherence:
                                  f'object implies {expected_shape}.')
             SNAP = self.ant_to_SNAP_dict[ant[0]]
             if SNAP in suppression:
-                corrected_gains[ant] = gain * np.exp(suppression[SNAP])
+                corrected_gains[ant] = gain * np.exp((-1 if inverse else 1) * suppression[SNAP])
             else:
                 corrected_gains[ant] = gain.copy()
         return corrected_gains

--- a/hera_cal/tests/test_apply_cal.py
+++ b/hera_cal/tests/test_apply_cal.py
@@ -956,6 +956,11 @@ class TestCalibrateAndRedAvg:
         for ant, cspa in meta['chisq_per_ant'].items():
             assert np.nanmean(cspa) == pytest.approx(1.0, abs=0.25)
         assert np.nanmean(meta['total_chisq']['Jee']) == pytest.approx(1.0, abs=0.1)
+        # per-baseline chi^2 covers exactly the cross-correlations that were averaged, ~1 for noise
+        participating = {bl for red in sim['reds'] if red[0][0] != red[0][1] for bl in red if bl in sim['data']}
+        assert set(meta['chisq_per_bl']) == participating
+        assert all(c.shape == (sim['ntimes'],) for c in meta['chisq_per_bl'].values())
+        assert np.nanmean(np.concatenate(list(meta['chisq_per_bl'].values()))) == pytest.approx(1.0, abs=0.1)
 
     def test_excluded_antennas(self):
         sim = build_red_avg_sim(nfreqs=128, noise_amp=1.0, seed=2)

--- a/hera_cal/tests/test_io.py
+++ b/hera_cal/tests/test_io.py
@@ -2102,6 +2102,10 @@ class TestSNAPDecoherence:
         assert np.any(np.abs(gains[(ant_on_A, 'Jee')]) != np.abs(corrected[(ant_on_A, 'Jee')]))
         # SNAP B has no detections, so its gain is unchanged
         np.testing.assert_array_equal(corrected[(ant_on_B, 'Jee')], smooth)
+        # inverse=True re-imposes the staircase, round-tripping back to the input gains
+        restored = sd.correct_gains(corrected, inverse=True)
+        for ant in gains:
+            np.testing.assert_allclose(restored[ant], gains[ant])
         # a SNAP without stored results is returned unchanged, as a copy
         np.testing.assert_array_equal(corrected[(999, 'Jee')], 1.0)
         corrected[(999, 'Jee')][:] = 0


### PR DESCRIPTION
Also adds a bit more metadata to freq-averaged chi^2 per baseline.